### PR TITLE
feat: dark/light mode toggle in settings

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,21 @@
+import type { Handle } from "@sveltejs/kit";
+
+export const handle = (async ({ event, resolve }) => {
+    let theme: string | null = null;
+    const url = new URL(event.request.url); 
+    const newTheme = url.searchParams.get('theme');
+    const cookieTheme = event.cookies.get('colortheme');
+    if (newTheme) {
+        theme = newTheme;
+    } else if (cookieTheme) {
+        theme = cookieTheme;
+    }
+    if (theme) {
+        return await resolve(event, {
+            transformPageChunk: ({ html }) =>
+                html.replace('data-theme=""', `data-theme="${theme}"`),
+        });
+    }
+    return await resolve(event);
+}) satisfies Handle;
+

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,0 +1,13 @@
+import type { Actions } from "@sveltejs/kit";
+
+export const actions: Actions = {
+	setTheme: async ({ url, cookies }) => {
+		const theme = url.searchParams.get('theme');
+		if(theme){
+			cookies.set('colortheme', theme, {
+				path: '/',
+				maxAge: 60 * 60 * 24 * 365,
+			});
+		}
+	}
+};

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -5,6 +5,8 @@
 	import Heading from './Heading.svelte';
 	import { FolksonomyApi } from '$lib/api/folksonomy';
 	import { t } from '$lib/translations';
+	import type { SubmitFunction } from '@sveltejs/kit';
+	import { enhance } from '$app/forms';
 
 	interface Props {
 		data: PageData;
@@ -19,6 +21,13 @@
 
 		new FolksonomyApi(fetch).login(username, password);
 	}
+
+	const submitUpdateTheme: SubmitFunction = ({action})=>{
+		const theme = action.searchParams.get('theme');
+		if(theme){
+			document.documentElement.setAttribute('data-theme', theme);
+		}
+	} 
 </script>
 
 <div class="mx-auto my-8 grid grid-cols-[1fr,max-content] items-center gap-x-8 gap-y-2">
@@ -52,6 +61,18 @@
 			</option>
 		{/each}
 	</select>
+
+	<Heading>Appearance</Heading>
+	<label for="theme-select" class="justify-self-end">Theme:</label>
+	
+	<form method="POST" use:enhance={submitUpdateTheme}>
+		<li>
+			<button formaction="/?/setTheme&theme=dark" name="theme" value="dark">Dark</button>
+		</li>
+		<li>
+			<button formaction="/?/setTheme&theme=light" name="theme" value="light">Light</button>
+		</li>
+	</form>
 
 	<Heading>Influences</Heading>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ export default {
 	],
 	daisyui: {
 		themes: [
+			"light",
 			{
 				off: {
 					primary: '#201a17',


### PR DESCRIPTION
### Description
This PR introduces a **dark/light mode** toggle feature, allowing users to switch between themes dynamically. The selected theme remains **persistent** even after refreshing the website.

Key Features:
- Implemented dark/light mode toggle using DaisyUI.
- Users can switch between various light mode themes provided by DaisyUI.
- Theme preference is stored persistently using cookie.
- Ensured smooth UI updates on theme change.

### Additional Context
The logo also needs to be changed for the light mode and the theme change option need to be styled as the dropdown like other similar fields.
If you prefer to change the light mode colors, it can be selected from any theme of DaisyUI: [https://daisyui.com/docs/themes](https://daisyui.com/docs/themes). Let me know if you'd like a specific theme to be set as the default.

Looking forward to your feedback!


### Screenshot

[Screencast from 2025-02-28 04-38-36.webm](https://github.com/user-attachments/assets/5492c5f4-1667-4899-858d-d7c310d6c786)


### Fixes bug(s)
Closes the dark/light mode feature on #2 

