### PR TITLE
feat: Add link to github repo

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -82,6 +82,13 @@
 	<div class="navbar-end gap-2">
 		<a class="btn btn-outline link" href="/folksonomy">{$t('common.folksonomy')}</a>
 		<a class="btn btn-outline link" href="/settings">{$t('common.settings')}</a>
+		<a
+			class="btn btn-outline link"
+			href="https://github.com/openfoodfacts/openfoodfacts-explorer"
+			target="_blank"
+		>
+			<span class="icon-[mdi--github] w-8 h-8"></span>
+		</a>
 	</div>
 </div>
 


### PR DESCRIPTION
### What
Add a link to this repos in the form of a button next to settings.

### Screenshot
![image](https://github.com/user-attachments/assets/d19a6aee-400b-4593-98fd-70979ded1aaa)

### Part of 
- [x] Add a link to this repository from the openfoodfacts-explorer interface
#2