### PR TITLE
feat: Add editing support for ingredients and name in all available languages

### DIFF
--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -35,6 +35,20 @@ export class ProductsApi {
 		if (!username || !password) throw new Error('No username or password set');
 
 		const languageCodes = Object.keys(product.languages_codes);
+		const productNames = languageCodes.reduce(
+			(acc, lang) => {
+				acc[`product_name_${lang}`] = product[`product_name_${lang}`];
+				return acc;
+			},
+			{} as Record<string, string>
+		);
+		const ingredientsTexts = languageCodes.reduce(
+			(acc, lang) => {
+				acc[`ingredients_text_${lang}`] = product[`ingredients_text_${lang}`];
+				return acc;
+			},
+			{} as Record<string, string>
+		);
 
 		const body = formData({
 			code: product.code,
@@ -48,22 +62,10 @@ export class ProductsApi {
 			comment: product.comment ?? '',
 
 			product_name: product.product_name,
-			...languageCodes.reduce(
-				(acc, lang) => {
-					acc[`product_name_${lang}`] = product[`product_name_${lang}`];
-					return acc;
-				},
-				{} as Record<string, string>
-			),
+			...productNames,
 
 			ingredients_text: product.ingredients_text,
-			...languageCodes.reduce(
-				(acc, lang) => {
-					acc[`ingredients_text_${lang}`] = product[`ingredients_text_${lang}`];
-					return acc;
-				},
-				{} as Record<string, string>
-			)
+			...ingredientsTexts
 		});
 
 		const res = await this.fetch(url, {

--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -43,7 +43,25 @@ export class ProductsApi {
 			brands: product.brands,
 			quantity: product.quantity,
 			stores: product.stores,
-			comment: product.comment ?? ''
+			comment: product.comment ?? '',
+
+			product_name: product.product_name,
+			product_name_en: product.product_name_en,
+			product_name_ar: product.product_name_ar,
+			product_name_cs: product.product_name_cs,
+			product_name_de: product.product_name_de,
+			product_name_fr: product.product_name_fr,
+			product_name_it: product.product_name_it,
+			product_name_es: product.product_name_es,
+
+			ingredients_text: product.ingredients_text,
+			ingredients_text_en: product.ingredients_text_en,
+			ingredients_text_ar: product.ingredients_text_ar,
+			ingredients_text_cs: product.ingredients_text_cs,
+			ingredients_text_de: product.ingredients_text_de,
+			ingredients_text_fr: product.ingredients_text_fr,
+			ingredients_text_it: product.ingredients_text_it,
+			ingredients_text_es: product.ingredients_text_es
 		});
 
 		const res = await this.fetch(url, {
@@ -130,10 +148,51 @@ export type ProductSearch<T = Product> = {
 
 type LangIngredient = `ingredients_text_${string}`;
 
+type ImageSize = {
+	h: number;
+	w: number;
+};
+
+export type SelectedImage = {
+	angle: number;
+	coordinates_image_size: string;
+	geometry: string;
+	imgid: string;
+	normalize: string | boolean | null;
+	rev: string;
+	sizes: {
+		100: ImageSize;
+		200: ImageSize;
+		400: ImageSize;
+		full: ImageSize;
+	};
+	white_magic: string | boolean | null;
+	x1: string;
+	x2: string;
+	y1: string;
+	y2: string;
+};
+
+type RawImage = {
+	sizes: {
+		full: ImageSize;
+		100: ImageSize;
+		400: ImageSize;
+	};
+	uploaded_t: string;
+	uploader: string;
+};
+
 export type Product = {
 	knowledge_panels: Record<string, KnowledgePanel>;
 	product_name: string;
 	product_name_en: string;
+	product_name_ar: string;
+	product_name_cs: string;
+	product_name_de: string;
+	product_name_fr: string;
+	product_name_it: string;
+	product_name_es: string;
 	_id: string;
 	code: string;
 	_keywords: string[];
@@ -159,6 +218,8 @@ export type Product = {
 	image_ingredients_url: string;
 	image_ingredients_small_url: string;
 	image_ingredients_thumb_url: string;
+
+	images: Record<string, SelectedImage | RawImage>;
 
 	image_nutrition_url: string;
 	image_nutrition_small_url: string;

--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -34,6 +34,8 @@ export class ProductsApi {
 
 		if (!username || !password) throw new Error('No username or password set');
 
+		const languageCodes = Object.keys(product.languages_codes);
+
 		const body = formData({
 			code: product.code,
 			user_id: username,
@@ -46,22 +48,22 @@ export class ProductsApi {
 			comment: product.comment ?? '',
 
 			product_name: product.product_name,
-			product_name_en: product.product_name_en,
-			product_name_ar: product.product_name_ar,
-			product_name_cs: product.product_name_cs,
-			product_name_de: product.product_name_de,
-			product_name_fr: product.product_name_fr,
-			product_name_it: product.product_name_it,
-			product_name_es: product.product_name_es,
+			...languageCodes.reduce(
+				(acc, lang) => {
+					acc[`product_name_${lang}`] = product[`product_name_${lang}`];
+					return acc;
+				},
+				{} as Record<string, string>
+			),
 
 			ingredients_text: product.ingredients_text,
-			ingredients_text_en: product.ingredients_text_en,
-			ingredients_text_ar: product.ingredients_text_ar,
-			ingredients_text_cs: product.ingredients_text_cs,
-			ingredients_text_de: product.ingredients_text_de,
-			ingredients_text_fr: product.ingredients_text_fr,
-			ingredients_text_it: product.ingredients_text_it,
-			ingredients_text_es: product.ingredients_text_es
+			...languageCodes.reduce(
+				(acc, lang) => {
+					acc[`ingredients_text_${lang}`] = product[`ingredients_text_${lang}`];
+					return acc;
+				},
+				{} as Record<string, string>
+			)
 		});
 
 		const res = await this.fetch(url, {
@@ -147,6 +149,7 @@ export type ProductSearch<T = Product> = {
 };
 
 type LangIngredient = `ingredients_text_${string}`;
+type LangProduct = `product_name_${string}`;
 
 type ImageSize = {
 	h: number;
@@ -186,13 +189,7 @@ type RawImage = {
 export type Product = {
 	knowledge_panels: Record<string, KnowledgePanel>;
 	product_name: string;
-	product_name_en: string;
-	product_name_ar: string;
-	product_name_cs: string;
-	product_name_de: string;
-	product_name_fr: string;
-	product_name_it: string;
-	product_name_es: string;
+	[lang: LangProduct]: string;
 	_id: string;
 	code: string;
 	_keywords: string[];

--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -258,6 +258,11 @@ export type Product = {
 	};
 
 	link: string;
+
+	languages_codes: {
+		[lang: string]: number;
+	};
+	lang: string;
 };
 
 const REDUCED_FIELDS = [

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,9 +1,11 @@
 export const STATIC_HOST = 'https://static.openfoodfacts.org';
 export const API_HOST = 'https://world.openfoodfacts.org';
 export const SEARCH_URL = `${API_HOST}/api/v2/search`;
+export const IMAGE_HOST = 'https://images.openfoodfacts.org';
 
 export const USER_AGENT = `Open Food Facts Explorer (${import.meta.env.PACKAGE_VERSION})`;
 
 export const KP_ATTRIBUTE_IMG = (img: string) => `${STATIC_HOST}/images/attributes/dist/${img}`;
 export const TAXONOMY_URL = (taxo: string) => `${STATIC_HOST}/data/taxonomies/${taxo}.json`;
 export const PRODUCT_URL = (barcode: string) => `${API_HOST}/api/v3/product/${barcode}.json`;
+export const PRODUCT_IMAGE_URL = (path: string) => `${IMAGE_HOST}/images/products/${path}`;

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -22,12 +22,16 @@
 			.filter((t): t is string => t !== undefined);
 	}
 
+	function getLanguage(code: string) {
+		const languageNames = new Intl.DisplayNames(['en'], { type: 'language' });
+		return languageNames.of(code);
+	}
+
 	let categoryNames = $derived(getNames(data.categories));
 	let labelNames = $derived(getNames(data.labels));
 	let brandNames = $derived(getNames(data.brands));
 	let storeNames = $derived(getNames(data.stores));
 	let productStore = $derived(writable(data.state.product));
-	let languages = $derived(data.languages);
 	let comment = writable('');
 
 	async function submit() {
@@ -73,35 +77,26 @@
 </script>
 
 <div class="tabs tabs-box">
-	{#each Object.keys(languages) as language}
+	{#each Object.keys($productStore.languages_codes) as code}
 		<input
 			type="radio"
-			name="language_tabs"
+			name="name_tabs"
 			class="tab"
-			aria-label={languages[language as keyof typeof languages]}
-			defaultChecked={language === Object.keys(languages)[0]}
+			aria-label={getLanguage(code)}
+			defaultChecked={code === $productStore.lang}
 		/>
 		<div class="tab-content form-control p-6">
-			<label for="">Name ({languages[language as keyof typeof languages]})</label>
+			<label for="">Name ({getLanguage(code)})</label>
 			<input
 				type="text"
 				class="input input-bordered w-full"
-				bind:value={$productStore[('product_name_' + language) as keyof typeof data.state.product]}
+				bind:value={$productStore[('product_name_' + code) as keyof typeof data.state.product]}
 			/>
 		</div>
 	{/each}
 </div>
 
 <Card>
-	<div class="form-control mb-4">
-		<label for="">Name</label>
-		<input
-			type="text"
-			class="input input-bordered w-full"
-			bind:value={$productStore.product_name}
-		/>
-	</div>
-
 	<div class="form-control mb-4">
 		<label for="">Quantity</label>
 		<input type="text" class="input input-bordered w-full" bind:value={$productStore.quantity} />
@@ -133,26 +128,26 @@
 <Card>
 	<h3 class="mb-4 text-3xl font-bold">Ingredients</h3>
 	<div class="tabs tabs-box">
-		{#each Object.keys(languages) as language}
+		{#each Object.keys($productStore.languages_codes) as code}
 			<input
 				type="radio"
-				name="language_tabs"
+				name="ingredients_tabs"
 				class="tab"
-				aria-label={languages[language as keyof typeof languages]}
-				defaultChecked={language === Object.keys(languages)[0]}
+				aria-label={getLanguage(code)}
+				defaultChecked={code === $productStore.lang}
 			/>
 			<div class="tab-content form-control p-6">
-				{#if getIngredientsImage(language)}
-					<img src={getIngredientsImage(language)} alt="Ingredients" class="mb-4" />
+				{#if getIngredientsImage(code)}
+					<img src={getIngredientsImage(code)} alt="Ingredients" class="mb-4" />
 				{:else}
 					<p class="alert alert-warning mb-4">No ingredients image</p>
 				{/if}
-				<label for="">Ingredients list ({languages[language as keyof typeof languages]})</label>
+				<label for="">Ingredients list ({getLanguage(code)})</label>
 				<div class="form-control mb-4">
 					<textarea
 						class="textarea textarea-bordered h-40 w-full"
 						bind:value={
-							$productStore[('ingredients_text_' + language) as keyof typeof data.state.product]
+							$productStore[('ingredients_text_' + code) as keyof typeof data.state.product]
 						}
 					></textarea>
 				</div>

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -90,7 +90,7 @@
 			<input
 				type="text"
 				class="input input-bordered w-full"
-				bind:value={$productStore[('product_name_' + code) as keyof typeof data.state.product]}
+				bind:value={$productStore[`product_name_${code}`]}
 			/>
 		</div>
 	{/each}
@@ -146,9 +146,7 @@
 				<div class="form-control mb-4">
 					<textarea
 						class="textarea textarea-bordered h-40 w-full"
-						bind:value={
-							$productStore[('ingredients_text_' + code) as keyof typeof data.state.product]
-						}
+						bind:value={$productStore[`ingredients_text_${code}`]}
 					></textarea>
 				</div>
 			</div>

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -151,7 +151,9 @@
 				<div class="form-control mb-4">
 					<textarea
 						class="textarea textarea-bordered h-40 w-full"
-						bind:value={$productStore["ingredients_text_" + language as keyof typeof data.state.product]}
+						bind:value={
+							$productStore[('ingredients_text_' + language) as keyof typeof data.state.product]
+						}
 					></textarea>
 				</div>
 			</div>

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -9,6 +9,7 @@
 
 	import type { PageData } from './$types';
 	import TagsString from './TagsString.svelte';
+	import { PRODUCT_IMAGE_URL } from '$lib/const';
 
 	interface Props {
 		data: PageData;
@@ -52,13 +53,12 @@
 	}
 
 	function getIngredientsImage(language: string) {
-		let baseUrl = 'https://images.openfoodfacts.org/images/products/';
 		const paddedBarcode = get(productStore).code.toString().padStart(13, '0');
 		const match = paddedBarcode.match(/^(.{3})(.{3})(.{3})(.*)$/);
 		if (!match) {
 			throw new Error('Invalid barcode format');
 		}
-		baseUrl += `${match[1]}/${match[2]}/${match[3]}/${match[4]}`;
+		const path = `${match[1]}/${match[2]}/${match[3]}/${match[4]}`;
 		const imageName = 'ingredients_' + language;
 		const image = get(productStore).images[imageName];
 		if (!image) {
@@ -66,7 +66,7 @@
 		}
 		const rev = (image as SelectedImage).rev;
 		const filename = `${imageName}.${rev}.400.jpg`;
-		return `${baseUrl}/${filename}`;
+		return PRODUCT_IMAGE_URL(`${path}/${filename}`);
 	}
 
 	run(() => {

--- a/src/routes/products/[barcode]/edit/+page.ts
+++ b/src/routes/products/[barcode]/edit/+page.ts
@@ -23,15 +23,6 @@ export const load = (async ({ fetch, params }) => {
 		categories,
 		labels,
 		brands,
-		stores,
-		languages: {
-			ar: 'Arabic',
-			cs: 'Czech',
-			de: 'German',
-			en: 'English',
-			es: 'Spanish',
-			fr: 'French',
-			it: 'Italian'
-		}
+		stores
 	};
 }) satisfies PageLoad;

--- a/src/routes/products/[barcode]/edit/+page.ts
+++ b/src/routes/products/[barcode]/edit/+page.ts
@@ -23,6 +23,7 @@ export const load = (async ({ fetch, params }) => {
 		categories,
 		labels,
 		brands,
-		stores
+		stores,
+		languages: { ar: 'Arabic', cs: 'Czech', de: 'German', en: 'English', es: 'Spanish', fr: 'French', it: 'Italian' }
 	};
 }) satisfies PageLoad;

--- a/src/routes/products/[barcode]/edit/+page.ts
+++ b/src/routes/products/[barcode]/edit/+page.ts
@@ -24,6 +24,14 @@ export const load = (async ({ fetch, params }) => {
 		labels,
 		brands,
 		stores,
-		languages: { ar: 'Arabic', cs: 'Czech', de: 'German', en: 'English', es: 'Spanish', fr: 'French', it: 'Italian' }
+		languages: {
+			ar: 'Arabic',
+			cs: 'Czech',
+			de: 'German',
+			en: 'English',
+			es: 'Spanish',
+			fr: 'French',
+			it: 'Italian'
+		}
 	};
 }) satisfies PageLoad;


### PR DESCRIPTION
### What
for each language in the product.languages_codes, show a tab in productnames and indegredients.

### Screenshot
![image](https://github.com/user-attachments/assets/241767ed-e0cf-4bc2-aa80-4fa6465a1bc1)
![image](https://github.com/user-attachments/assets/ff3bd265-863d-4d87-bac5-ab22d2ccc138)
Only tabs for available existing languages are show:
![image](https://github.com/user-attachments/assets/57ec3621-6bba-41ea-ab86-94122f369ccb)


### Fixes bug(s)
- #176 

### Part of 
- #125
