### PR TITLE
fix: Broken pagination

### DIFF
--- a/src/routes/products/search/+page.svelte
+++ b/src/routes/products/search/+page.svelte
@@ -41,15 +41,15 @@
 
 			<button class="btn join-item btn-active">{result.page}</button>
 
-			{#if result.page_count > result.page + 1}
+			{#if result.total_pages > result.page + 1}
 				<a href={getPageUrl($page.url, result.page + 1)} class="btn join-item">{result.page + 1}</a>
 			{/if}
-			{#if result.page_count > result.page + 2}
+			{#if result.total_pages > result.page + 2}
 				<button class="btn btn-disabled join-item">...</button>
 			{/if}
-			{#if result.page_count > result.page}
-				<a href={getPageUrl($page.url, result.page_count)} class="btn join-item">
-					{result.page_count}
+			{#if result.total_pages > result.page}
+				<a href={getPageUrl($page.url, result.total_pages)} class="btn join-item">
+					{result.total_pages}
 				</a>
 			{/if}
 		</div>

--- a/src/routes/products/search/+page.ts
+++ b/src/routes/products/search/+page.ts
@@ -39,7 +39,13 @@ export const load: PageLoad = async ({ fetch, url }) => {
 					page_count: number;
 					products: Product[];
 				}>
-		);
+		)
+		.then((data) => {
+			return {
+				...data,
+				total_pages: Math.ceil(data.count / data.page_size)
+			};
+		});
 
 	return {
 		result: result


### PR DESCRIPTION
### What
Fix the broken pagination.
There are only 7 pages for "abc" query, but the pagination section show 50 pages.
Actually, the previous code assumes `page_count` is the total number of pages, but it is actually `Number of products in this page` as obvious from the [API docs](https://openfoodfacts.github.io/openfoodfacts-server/api/ref-v2/#get-/api/v2/search):
![image](https://github.com/user-attachments/assets/484d79c5-4fef-4ab4-b307-8e97c533b90a)
The Api return no feild indicting total amount of pages, So this PR calculates the feild `total_pages` and uses it instead of `page_count` :)

### Screenshot
Before:
![image](https://github.com/user-attachments/assets/ba3ee43e-e49d-48f6-8e99-f60a18bb2df1)
After:
![image](https://github.com/user-attachments/assets/f0bf835d-8d46-44fe-9e18-374f95a271dd)
