### PR TITLE
Allow Unselecting Images from a Product

### DIFF
--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -91,7 +91,17 @@
 	<h3 class="mb-4 text-3xl font-bold">Ingredients</h3>
 
 	{#if $productStore.image_ingredients_url}
-		<img src={$productStore.image_ingredients_url} alt="Ingredients" class="mb-4" />
+		<div class="relative mb-4">
+			<img src={$productStore.image_ingredients_url} alt="Ingredients" class="mb-4" />
+
+			<!-- Unselect Image Button -->
+			<button
+				class="mt-2 rounded bg-orange-500 px-3 py-1 text-sm text-white transition hover:bg-red-600"
+				onclick={() => productStore.update((p) => ({ ...p, image_ingredients_url: '' }))}
+			>
+				Unselect Image
+			</button>
+		</div>
 	{:else}
 		<p class="alert alert-warning mb-4">No ingredients image</p>
 	{/if}


### PR DESCRIPTION
## 📌 Description  
This PR adds functionality to **unselect images** from a product without deleting them from the API.  

## 🔧 Changes Made  
- Added an **"Unselect Image"** button below the product image.  
- Updated the UI to remove the image from the frontend when unselected.  
- Ensured proper event handling (`onclick` instead of `on:click`).  
- Improved UX by instantly reflecting changes in the UI.  

## 🔗 Related Issue  
- Closes : #175 

## 📸 Preview  
1. 
![image](https://github.com/user-attachments/assets/2c74552c-63c6-41df-a7c2-af1870adf939)

2. 
![image](https://github.com/user-attachments/assets/d5a42fb9-d2d6-469a-a484-30b87942e3e8)

Let me know if any improvements are needed! 
