### PR TITLE
chore: fix all `pnpm lint` errors

### DIFF
--- a/src/lib/knowledgepanels/Element.svelte
+++ b/src/lib/knowledgepanels/Element.svelte
@@ -13,7 +13,7 @@
 		element: KnowledgeElement;
 		size?: KnowledgePanelSize;
 	};
-	let { allPanels, element, size }: Props = $props();
+	let { allPanels, element }: Props = $props();
 
 	const BUTTON_ACTIONS_TITLES: Record<string, string> = {
 		edit_product: 'Edit Product',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -92,6 +92,7 @@
 			class="btn btn-outline link"
 			href="https://github.com/openfoodfacts/openfoodfacts-explorer"
 			target="_blank"
+			aria-label="GitHub repository"
 		>
 			<span class="icon-[mdi--github] h-8 w-8"></span>
 		</a>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,7 +30,7 @@
 				</div>
 				Explorer!
 			</h3>
-
+			<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 			<p>{@html $t('home.intro_1')}</p>
 			<p>{$t('home.intro_2')}</p>
 		</div>
@@ -39,6 +39,7 @@
 	<div class="mt-8 w-full">
 		<div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
 			{#await data.streamed.products}
+				<!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
 				{#each Array(4) as _}
 					<div class="skeleton dark:bg-base-300 h-28 bg-white p-4 shadow-md"></div>
 				{/each}

--- a/src/routes/products/search/+page.svelte
+++ b/src/routes/products/search/+page.svelte
@@ -16,6 +16,7 @@
 </script>
 
 {#await data.result}
+	<!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
 	{#each Array(5) as _}
 		<div class="skeleton dark:bg-base-300 h-24 bg-white p-4 shadow-md"></div>
 	{/each}

--- a/src/routes/qr/+page.svelte
+++ b/src/routes/qr/+page.svelte
@@ -22,7 +22,7 @@
 			.start(
 				{ facingMode: 'environment' },
 				{ fps: 1, qrbox: { width: 500, height: 300 } },
-				(text, _result) => {
+				(text) => {
 					if (text == null) return;
 					console.log('QR code detected:', text);
 


### PR DESCRIPTION
### What
- Fixed all `pnpm lint` errors causing the build to fail.  
- Removed unused variables.  
- Suppressed `{#each Array(4) as _}` ESLint warning using:  
  ```jsx
  <!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
  ```
- Considered using @list, but it was unnecessary for static skeleton placeholders since it would create an unneeded reactive store.
```jsx
<script>
  import { list } from '@svelte/rune';

  let skeletons = list(new Array(4).fill(null));
</script>

{@list skeletons}
  <div class="skeleton dark:bg-base-300 h-28 bg-white p-4 shadow-md"></div>
{/list}

```

### Screenshot
issue:
![image](https://github.com/user-attachments/assets/05079359-2737-4c8a-bcf2-3141ce0519f3)

### Part of 
- #202 