### PR TITLE
feat: allow adding a language to a product

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"fuse.js": "^7.1.0",
 		"globals": "^16.0.0",
 		"html5-qrcode": "^2.3.8",
+		"iso-639-1": "^3.1.5",
 		"leaflet": "^1.9.4",
 		"openapi-fetch": "^0.13.4",
 		"openapi-typescript": "^7.6.1",
@@ -57,8 +58,5 @@
 		"vite": "^6.1.1"
 	},
 	"type": "module",
-	"packageManager": "pnpm@8.10.5",
-	"dependencies": {
-		"iso-639-1": "^3.1.5"
-	}
+	"packageManager": "pnpm@8.10.5"
 }

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
 		"vite": "^6.1.1"
 	},
 	"type": "module",
-	"packageManager": "pnpm@8.10.5"
+	"packageManager": "pnpm@8.10.5",
+	"dependencies": {
+		"iso-639-1": "^3.1.5"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  iso-639-1:
-    specifier: ^3.1.5
-    version: 3.1.5
-
 devDependencies:
   '@eslint/eslintrc':
     specifier: ^3.3.0
@@ -79,6 +74,9 @@ devDependencies:
   html5-qrcode:
     specifier: ^2.3.8
     version: 2.3.8
+  iso-639-1:
+    specifier: ^3.1.5
+    version: 3.1.5
   leaflet:
     specifier: ^1.9.4
     version: 1.9.4
@@ -1978,7 +1976,7 @@ packages:
   /iso-639-1@3.1.5:
     resolution: {integrity: sha512-gXkz5+KN7HrG0Q5UGqSMO2qB9AsbEeyLP54kF1YrMsIxmu+g4BdB7rflReZTSTZGpfj8wywu6pfPBCylPIzGQA==}
     engines: {node: '>=6.0'}
-    dev: false
+    dev: true
 
   /jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+dependencies:
+  iso-639-1:
+    specifier: ^3.1.5
+    version: 3.1.5
+
 devDependencies:
   '@eslint/eslintrc':
     specifier: ^3.3.0
@@ -1969,6 +1974,11 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
+
+  /iso-639-1@3.1.5:
+    resolution: {integrity: sha512-gXkz5+KN7HrG0Q5UGqSMO2qB9AsbEeyLP54kF1YrMsIxmu+g4BdB7rflReZTSTZGpfj8wywu6pfPBCylPIzGQA==}
+    engines: {node: '>=6.0'}
+    dev: false
 
   /jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}

--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -37,9 +37,9 @@ export class ProductsApi {
 		const languageCodes = Object.keys(product.languages_codes);
 		const productNames = languageCodes.reduce(
 			(acc, lang) => {
-				const key = `product_name_${lang}`;
-				if (product[key as LangProduct] != null) {
-					acc[key] = product[key as LangProduct];
+				const productName = product[`product_name_${lang}`];
+				if (productName != null) {
+					acc[`product_name_${lang}`] = productName;
 				}
 				return acc;
 			},
@@ -47,9 +47,9 @@ export class ProductsApi {
 		);
 		const ingredientsTexts = languageCodes.reduce(
 			(acc, lang) => {
-				const key = `ingredients_text_${lang}`;
-				if (product[key as LangIngredient] != null) {
-					acc[key] = product[key as LangIngredient];
+				const ingredientsText = product[`ingredients_text_${lang}`];
+				if (ingredientsText != null) {
+					acc[`ingredients_text_${lang}`] = ingredientsText;
 				}
 				return acc;
 			},

--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -37,14 +37,20 @@ export class ProductsApi {
 		const languageCodes = Object.keys(product.languages_codes);
 		const productNames = languageCodes.reduce(
 			(acc, lang) => {
-				acc[`product_name_${lang}`] = product[`product_name_${lang}`];
+				const key = `product_name_${lang}`;
+				if (product[key as LangProduct] != null) {
+					acc[key] = product[key as LangProduct];
+				}
 				return acc;
 			},
 			{} as Record<string, string>
 		);
 		const ingredientsTexts = languageCodes.reduce(
 			(acc, lang) => {
-				acc[`ingredients_text_${lang}`] = product[`ingredients_text_${lang}`];
+				const key = `ingredients_text_${lang}`;
+				if (product[key as LangIngredient] != null) {
+					acc[key] = product[key as LangIngredient];
+				}
 				return acc;
 			},
 			{} as Record<string, string>

--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -37,7 +37,7 @@ export class ProductsApi {
 		const languageCodes = Object.keys(product.languages_codes);
 		const productNames = languageCodes.reduce(
 			(acc, lang) => {
-				const productName = product[`product_name_${lang}`];
+				const productName = getProductNameInLang(product, lang);
 				if (productName != null) {
 					acc[`product_name_${lang}`] = productName;
 				}
@@ -47,7 +47,7 @@ export class ProductsApi {
 		);
 		const ingredientsTexts = languageCodes.reduce(
 			(acc, lang) => {
-				const ingredientsText = product[`ingredients_text_${lang}`];
+				const ingredientsText = getProductIngredientsInLang(product, lang);
 				if (ingredientsText != null) {
 					acc[`ingredients_text_${lang}`] = ingredientsText;
 				}
@@ -306,6 +306,14 @@ export async function getProductName(
 /** @deprecated */
 export async function addOrEditProductV2(product: Product, fetch: typeof window.fetch) {
 	return new ProductsApi(fetch).addOrEditProductV2(product);
+}
+
+function getProductNameInLang(product: Product, lang: string) {
+	return product[`product_name_${lang}`] ?? product.product_name;
+}
+
+function getProductIngredientsInLang(product: Product, lang: string) {
+	return product[`ingredients_text_${lang}`] ?? product.ingredients_text;
 }
 
 function formData(data: Record<string, string | Blob>) {

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -89,7 +89,7 @@
 	});
 </script>
 
-<div class="collapse-arrow dark:bg-base-200 collapse p-2 bg-white shadow-md">
+<div class="collapse-arrow dark:bg-base-200 collapse bg-white p-2 shadow-md">
 	<input type="checkbox" />
 	<div class="collapse-title font-semibold">Add a language</div>
 	<div class="collapse-content text-sm">

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -38,7 +38,15 @@
 	let comment = writable('');
 	const languageCodes = ISO6391.getAllCodes();
 	let languageSearch = $state('');
-	let filteredLanguages = $state(languageCodes);
+	let filteredLanguages = $derived(
+		languageCodes.filter((code) => {
+			if ($productStore.languages_codes[code] !== undefined) {
+				return false;
+			}
+			const language = getLanguage(code);
+			return language.toLowerCase().includes(languageSearch.toLowerCase());
+		})
+	);
 
 	async function submit() {
 		const product = get(productStore);
@@ -77,16 +85,6 @@
 	run(() => {
 		productStore.subscribe((it) => {
 			console.debug('Product store changed', it);
-		});
-	});
-
-	$effect(() => {
-		filteredLanguages = languageCodes.filter((code) => {
-			if ($productStore.languages_codes[code] !== undefined) {
-				return false;
-			}
-			const language = getLanguage(code);
-			return language.toLowerCase().includes(languageSearch.toLowerCase());
 		});
 	});
 </script>

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -89,31 +89,34 @@
 	});
 </script>
 
-<Card>
-	<h3 class="mb-4 text-3xl font-bold">Add a language</h3>
-	<label class="input w-full">
-		<span class="icon-[mdi--search] h-5 w-5"></span>
-		<input type="search" placeholder="Search languages to add" bind:value={languageSearch} />
-	</label>
-	{#if filteredLanguages.length === 0}
-		<p class="mt-4 text-center opacity-70">No languages found</p>
-	{:else}
-		<div
-			class="mt-2 grid max-h-96 grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-2 overflow-auto"
-		>
-			{#each filteredLanguages as code}
-				<button
-					class="btn btn-ghost"
-					onclick={() => {
-						$productStore.languages_codes[code] = 0;
-					}}
-				>
-					{getLanguage(code)}
-				</button>
-			{/each}
-		</div>
-	{/if}
-</Card>
+<div class="collapse-arrow dark:bg-base-200 collapse p-2 bg-white shadow-md">
+	<input type="checkbox" />
+	<div class="collapse-title font-semibold">Add a language</div>
+	<div class="collapse-content text-sm">
+		<label class="input w-full">
+			<span class="icon-[mdi--search] h-5 w-5"></span>
+			<input type="search" placeholder="Search languages to add" bind:value={languageSearch} />
+		</label>
+		{#if filteredLanguages.length === 0}
+			<p class="mt-4 text-center opacity-70">No languages found</p>
+		{:else}
+			<div
+				class="mt-2 grid max-h-96 grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-2 overflow-auto"
+			>
+				{#each filteredLanguages as code}
+					<button
+						class="btn btn-ghost"
+						onclick={() => {
+							$productStore.languages_codes[code] = 0;
+						}}
+					>
+						{getLanguage(code)}
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>
 
 <div class="tabs tabs-box">
 	{#each Object.keys($productStore.languages_codes) as code}

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -65,6 +65,13 @@
 		}
 	}
 
+	function addLanguage(code: string) {
+		productStore.update((store) => {
+			store.languages_codes = { ...store.languages_codes, [code]: 0 };
+			return store;
+		});
+	}
+
 	function getIngredientsImage(language: string) {
 		const paddedBarcode = get(productStore).code.toString().padStart(13, '0');
 		const match = paddedBarcode.match(/^(.{3})(.{3})(.{3})(.*)$/);
@@ -104,12 +111,7 @@
 				class="mt-2 grid max-h-96 grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-2 overflow-auto"
 			>
 				{#each filteredLanguages as code}
-					<button
-						class="btn btn-ghost"
-						onclick={() => {
-							$productStore.languages_codes[code] = 0;
-						}}
-					>
+					<button class="btn btn-ghost" onclick={() => addLanguage(code)}>
 						{getLanguage(code)}
 					</button>
 				{/each}


### PR DESCRIPTION
### What  
Add the ability to add a language to a product.   :)

**Notes:**  
- On the main website, adding a language in the editing page does not take effect unless at least one field related to that language is filled. I have modified `src/lib/api/product.ts` to implement the same behavior.  
- On the main website, each language-specific field has an **"Add Language"** button, but adding a language globally (i.e., all language-specific fields receive a new tab for that language). In my implementation, I introduced an **"Add a Language"** button as its own separate card. 
- Either **ISO 639-1** is needed to get a list of all language codes, or we need to hard-code them based on my research.  


### Screenshot  
![image](https://github.com/user-attachments/assets/978cd43f-da60-4bb2-b75c-a05cc9934d19)  

### Fixes bug(s)  
- #177  
