### PR TITLE
changed styling of categories

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -70,14 +70,14 @@
 			</span>
 
 			<span class="text-end font-bold">Categories:</span>
-			<span>
+			<span class="flex flex-wrap gap-1">
 				{#await data.taxo.categories}
 					Loading...
 				{:then categories}
 					{#each product.categories_tags as tag, i}
-						{#if i > 0},
-						{/if}
-						<a class="link" href={'/taxo/categories/' + tag}
+						<a
+							class="link bg-secondary mr-0.5 inline-block break-inside-avoid rounded-xl px-2 font-semibold text-black no-underline"
+							href="/taxo/categories/{tag}"
 							>{categories[tag] != null ? getOrDefault(categories[tag].name, lang) : tag}</a
 						>
 					{/each}


### PR DESCRIPTION
The styling of the categories on the product page was just underline and it was feeling a bit clustered and doesn't provide a good user experience

Before
![image](https://github.com/user-attachments/assets/bde5170d-cd31-4821-9a4b-446613c37fb5)

I have changed to the make it more attractive and user friendly
After
![image](https://github.com/user-attachments/assets/e2bc52de-2bba-431f-9cb8-b42bcd929280)


Fixes #236 