### PR TITLE
style: product page buttons on smaller screen

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ devDependencies:
     version: 7.6.1(typescript@5.8.2)
   openfoodfacts-nodejs:
     specifier: github:openfoodfacts/openfoodfacts-nodejs
-    version: github.com/openfoodfacts/openfoodfacts-nodejs/492e63c72676a28eff93a02bfb2fe46c991bcaa2
+    version: github.com/openfoodfacts/openfoodfacts-nodejs/efb9fe569980b2a325a9b42f07f6e74cee30023b
   postcss:
     specifier: ^8.5.3
     version: 8.5.3
@@ -3340,8 +3340,8 @@ packages:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
     dev: true
 
-  github.com/openfoodfacts/openfoodfacts-nodejs/492e63c72676a28eff93a02bfb2fe46c991bcaa2:
-    resolution: {tarball: https://codeload.github.com/openfoodfacts/openfoodfacts-nodejs/tar.gz/492e63c72676a28eff93a02bfb2fe46c991bcaa2}
+  github.com/openfoodfacts/openfoodfacts-nodejs/efb9fe569980b2a325a9b42f07f6e74cee30023b:
+    resolution: {tarball: https://codeload.github.com/openfoodfacts/openfoodfacts-nodejs/tar.gz/efb9fe569980b2a325a9b42f07f6e74cee30023b}
     name: openfoodfacts-nodejs
     version: 2.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ devDependencies:
     version: 7.6.1(typescript@5.8.2)
   openfoodfacts-nodejs:
     specifier: github:openfoodfacts/openfoodfacts-nodejs
-    version: github.com/openfoodfacts/openfoodfacts-nodejs/598d49a2ac910c839de25568ffd5fc15c7c1a8ef
+    version: github.com/openfoodfacts/openfoodfacts-nodejs/492e63c72676a28eff93a02bfb2fe46c991bcaa2
   postcss:
     specifier: ^8.5.3
     version: 8.5.3
@@ -3340,8 +3340,8 @@ packages:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
     dev: true
 
-  github.com/openfoodfacts/openfoodfacts-nodejs/598d49a2ac910c839de25568ffd5fc15c7c1a8ef:
-    resolution: {tarball: https://codeload.github.com/openfoodfacts/openfoodfacts-nodejs/tar.gz/598d49a2ac910c839de25568ffd5fc15c7c1a8ef}
+  github.com/openfoodfacts/openfoodfacts-nodejs/492e63c72676a28eff93a02bfb2fe46c991bcaa2:
+    resolution: {tarball: https://codeload.github.com/openfoodfacts/openfoodfacts-nodejs/tar.gz/492e63c72676a28eff93a02bfb2fe46c991bcaa2}
     name: openfoodfacts-nodejs
     version: 2.0.0
     dependencies:

--- a/src/lib/knowledgepanels/Panels.svelte
+++ b/src/lib/knowledgepanels/Panels.svelte
@@ -24,7 +24,7 @@
 
 	<div class="border-secondary mt-3 border-b-2 border-dashed"></div>
 
-	<div class="my-4 flex flex-col justify-center gap-4 md:flex-row" id={SUMMARY_ID}>
+	<div class="my-4 flex justify-center gap-2 md:gap-4 flex-row flex-wrap" id={SUMMARY_ID}>
 		{#each panelsArray as [panelKey, panel]}
 			{#if panel.type === 'card'}
 				<a class="btn btn-secondary text-lg" href={'#' + panelKey}>

--- a/src/lib/knowledgepanels/Panels.svelte
+++ b/src/lib/knowledgepanels/Panels.svelte
@@ -24,7 +24,7 @@
 
 	<div class="border-secondary mt-3 border-b-2 border-dashed"></div>
 
-	<div class="my-4 flex justify-center gap-2 md:gap-4 flex-row flex-wrap" id={SUMMARY_ID}>
+	<div class="my-4 flex flex-row flex-wrap justify-center gap-2 md:gap-4" id={SUMMARY_ID}>
 		{#each panelsArray as [panelKey, panel]}
 			{#if panel.type === 'card'}
 				<a class="btn btn-secondary text-lg" href={'#' + panelKey}>

--- a/src/lib/knowledgepanels/Panels.svelte
+++ b/src/lib/knowledgepanels/Panels.svelte
@@ -25,7 +25,6 @@
 	<div class="border-secondary mt-3 border-b-2 border-dashed"></div>
 
 	<div class="my-4 flex flex-row flex-wrap justify-center gap-2 md:gap-4" id={SUMMARY_ID}>
-	<div class="my-4 flex justify-center gap-2 md:gap-4 flex-row flex-wrap" id={SUMMARY_ID}>
 		{#each panelsArray as [panelKey, panel]}
 			{#if panel.type === 'card'}
 				<a class="btn btn-secondary text-lg" href={'#' + panelKey}>


### PR DESCRIPTION
The buttons of environment, health, report a problem in the product page were way too big for the mobile screen 

before
![Image](https://github.com/user-attachments/assets/08598c27-a24d-47e7-88f8-a1be0569a607)

After

![Image](https://github.com/user-attachments/assets/30f4ff82-412c-4fb5-8e03-be618ff4b32c)

Fixes #228 