### PR TITLE
Added the GitHub icon in mobile view

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -152,9 +152,21 @@
 			</button>
 		</div>
 	{/if}
-	<div class:hidden={!accordionOpen} class="mt-3 flex justify-center gap-2">
-		<a class="btn btn-outline link flex" href="/folksonomy">{$t('common.folksonomy')}</a>
-		<a class="btn btn-outline link flex" href="/settings">{$t('common.settings')}</a>
+	<div class:hidden={!accordionOpen} class="mt-3 flex flex-wrap justify-center gap-2">
+		<a class="btn btn-outline link flex items-center justify-center" href="/folksonomy">
+			{$t('common.folksonomy')}
+		</a>
+		<a class="btn btn-outline link flex items-center justify-center" href="/settings">
+			{$t('common.settings')}
+		</a>
+		<a
+			class="btn btn-outline link flex items-center justify-center"
+			href="https://github.com/openfoodfacts/openfoodfacts-explorer"
+			target="_blank"
+			aria-label={$t('common.github')}
+		>
+			<span class="icon-[mdi--github] h-6 w-6"></span>
+		</a>
 	</div>
 </div>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,6 +12,9 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
+
+	const GITHUB_REPO_URL = 'https://github.com/openfoodfacts/openfoodfacts-explorer';
+
 	interface Props {
 		children?: import('svelte').Snippet;
 	}
@@ -90,7 +93,7 @@
 		<a class="btn btn-outline link" href="/settings">{$t('common.settings')}</a>
 		<a
 			class="btn btn-outline link"
-			href="https://github.com/openfoodfacts/openfoodfacts-explorer"
+			href={GITHUB_REPO_URL}
 			target="_blank"
 			aria-label={$t('common.github')}
 		>
@@ -161,7 +164,7 @@
 		</a>
 		<a
 			class="btn btn-outline link flex items-center justify-center"
-			href="https://github.com/openfoodfacts/openfoodfacts-explorer"
+			href={GITHUB_REPO_URL}
 			target="_blank"
 			aria-label={$t('common.github')}
 		>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -156,14 +156,14 @@
 		</div>
 	{/if}
 	<div class:hidden={!accordionOpen} class="mt-3 flex flex-wrap justify-center gap-2">
-		<a class="btn btn-outline link flex items-center justify-center" href="/folksonomy">
+		<a class="btn btn-outline link" href="/folksonomy">
 			{$t('common.folksonomy')}
 		</a>
-		<a class="btn btn-outline link flex items-center justify-center" href="/settings">
+		<a class="btn btn-outline link" href="/settings">
 			{$t('common.settings')}
 		</a>
 		<a
-			class="btn btn-outline link flex items-center justify-center"
+			class="btn btn-outline link"
 			href={GITHUB_REPO_URL}
 			target="_blank"
 			aria-label={$t('common.github')}


### PR DESCRIPTION
### What
Added the GitHub Logo for mobile view in drop down menu

### Screenshot
![Screenshot 2025-03-10 070749](https://github.com/user-attachments/assets/e91b6eb8-8dfc-4004-86a7-7ff057676176)


### Fixes bug(s)
#249 

### Part of 
None