### PR TITLE
feat: added padding to header for symmetrical UI

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -49,9 +49,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 </svelte:head>
 
-<div
-	class="bg-base-100 navbar top-0 right-0 left-0 z-50 hidden px-10 md:flex md:px-20 lg:px-40"
->
+<div class="bg-base-100 navbar hidden px-10 md:flex md:px-20 lg:px-40">
 	<div class="navbar-start">
 		<a href="/"> <Logo /> </a>
 	</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -50,7 +50,7 @@
 </svelte:head>
 
 <div
-	class="bg-base-100 navbar top-0 right-0 left-0 z-50 hidden px-10 shadow-md md:flex md:px-20 lg:px-40"
+	class="bg-base-100 navbar top-0 right-0 left-0 z-50 hidden px-10 md:flex md:px-20 lg:px-40"
 >
 	<div class="navbar-start">
 		<a href="/"> <Logo /> </a>
@@ -105,7 +105,7 @@
 	</div>
 </div>
 
-<div class="bg-base-100 top-0 right-0 left-0 z-50 mx-4 shadow-md md:hidden">
+<div class="bg-base-100 top-0 right-0 left-0 z-50 mx-4 md:hidden">
 	<div class="navbar bg-base-100 mx-auto mt-2 mb-2 max-w-7xl">
 		<div class="navbar-start">
 			<a href="/">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -49,7 +49,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 </svelte:head>
 
-<div class="navbar hidden md:flex">
+<div
+	class="bg-base-100 navbar fixed top-0 right-0 left-0 z-50 hidden px-10 shadow-md md:flex md:px-20 lg:px-40"
+>
 	<div class="navbar-start">
 		<a href="/"> <Logo /> </a>
 	</div>
@@ -103,8 +105,8 @@
 	</div>
 </div>
 
-<div class="mx-4 md:hidden">
-	<div class="navbar bg-base-100 mx-auto mt-2 mb-8 max-w-7xl">
+<div class="bg-base-100 fixed top-0 right-0 left-0 z-50 mx-4 shadow-md md:hidden">
+	<div class="navbar bg-base-100 mx-auto mt-2 mb-2 max-w-7xl">
 		<div class="navbar-start">
 			<a href="/">
 				<Logo />
@@ -181,6 +183,8 @@
 		</a>
 	</div>
 </div>
+
+<div class="pt-24 md:pt-20"></div>
 
 <div class="container mx-auto my-2 flex flex-col gap-4 px-4 xl:max-w-6xl">
 	{@render children?.()}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -50,7 +50,7 @@
 </svelte:head>
 
 <div
-	class="bg-base-100 navbar fixed top-0 right-0 left-0 z-50 hidden px-10 shadow-md md:flex md:px-20 lg:px-40"
+	class="bg-base-100 navbar top-0 right-0 left-0 z-50 hidden px-10 shadow-md md:flex md:px-20 lg:px-40"
 >
 	<div class="navbar-start">
 		<a href="/"> <Logo /> </a>
@@ -105,7 +105,7 @@
 	</div>
 </div>
 
-<div class="bg-base-100 fixed top-0 right-0 left-0 z-50 mx-4 shadow-md md:hidden">
+<div class="bg-base-100 top-0 right-0 left-0 z-50 mx-4 shadow-md md:hidden">
 	<div class="navbar bg-base-100 mx-auto mt-2 mb-2 max-w-7xl">
 		<div class="navbar-start">
 			<a href="/">
@@ -183,8 +183,6 @@
 		</a>
 	</div>
 </div>
-
-<div class="pt-24 md:pt-20"></div>
 
 <div class="container mx-auto my-2 flex flex-col gap-4 px-4 xl:max-w-6xl">
 	{@render children?.()}


### PR DESCRIPTION
### What
Added left and right padding to header, making it symmetrical to the footer.
Desktop Header (md+): stays above content with shadow.
Mobile Header (<md): adjusted alignment.


### Screenshot
![Screenshot 2025-03-13 093302](https://github.com/user-attachments/assets/c3420d0d-2966-43b3-a67a-dbc469111735)


### Fixes bug(s)
#268 

### Part of 
None
