### PR TITLE
feat: Implementation of the Knowledge Panel Facets for facets

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,10 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico" />
 		<meta name="viewport" content="width=device-width" />
+		<script
+			type="module"
+			src="https://cdn.jsdelivr.net/npm/@openfoodfacts/facets-knowledge-panels@latest/dist/facets-knowledge-panels.js"
+		></script>
 		%sveltekit.head%
 	</head>
 

--- a/src/lib/components/FacetsKnowledgePanel.svelte
+++ b/src/lib/components/FacetsKnowledgePanel.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	export let barcode: string;
+	export let lang: string = 'en';
+	export let country: string = 'world';
+	export let knowledgePanels: string[] = [
+		'nutrition',
+		'ingredients',
+		'allergens',
+		'labels',
+		'categories',
+		'brands',
+		'packaging',
+		'origins',
+		'ecoscore',
+		'nova'
+	];
+
+	interface FacetsKnowledgePanelsElement extends HTMLElement {
+		barcode: string;
+		lang: string;
+		country: string;
+		knowledgePanels: string[];
+	}
+
+	let element: FacetsKnowledgePanelsElement;
+
+	onMount(() => {
+		// Initialize the web component with the provided props
+		if (element) {
+			element.barcode = barcode;
+			element.lang = lang;
+			element.country = country;
+			element.knowledgePanels = knowledgePanels;
+		}
+	});
+</script>
+
+<facets-knowledge-panels
+	bind:this={element}
+	class="w-full"
+	style="--off-facets-knowledge-panels-primary-color: hsl(var(--p)); --off-facets-knowledge-panels-secondary-color: hsl(var(--s));"
+></facets-knowledge-panels>
+
+<style>
+	facets-knowledge-panels {
+		width: 100%;
+	}
+</style>

--- a/src/lib/translations/en/common.json
+++ b/src/lib/translations/en/common.json
@@ -5,5 +5,11 @@
 	"settings": "Settings",
 	"folksonomy": "Folksonomy",
 	"world": "World",
-	"github": "GitHub"
+	"github": "GitHub",
+	"product": {
+		"facets": {
+			"title": "Product Knowledge Panels",
+			"no_barcode": "No barcode provided"
+		}
+	}
 }

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -49,6 +49,9 @@
 		<a href={`/products/${product.code}/edit`} class="btn btn-secondary max-sm:btn-sm ml-auto">
 			Edit
 		</a>
+		<a href={`/products/${product.code}/facets`} class="btn btn-secondary max-sm:btn-sm ml-2">
+			Knowledge Panels
+		</a>
 	</div>
 
 	<div class="flex flex-col-reverse gap-4 md:flex-row">

--- a/src/routes/products/[barcode]/facets/+page.svelte
+++ b/src/routes/products/[barcode]/facets/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import FacetsKnowledgePanel from '$lib/components/FacetsKnowledgePanel.svelte';
+	import { page } from '$app/stores';
+	import { t } from '$lib/translations';
+
+	// Get the barcode from the URL parameters
+	$: barcode = $page.params.barcode;
+</script>
+
+<div class="container mx-auto px-4 py-8">
+	<h1 class="mb-8 text-3xl font-bold">{$t('product.facets.title')}</h1>
+	{#if barcode}
+		<FacetsKnowledgePanel {barcode} />
+	{:else}
+		<div class="alert alert-error">
+			<span>{$t('product.facets.no_barcode')}</span>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
### What

- Added the web component script to `app.html`
- Created `FacetsKnowledgePanel.svelte` with TypeScript props, CSS styling, and default panels (nutrition, ingredients, allergens, etc.).
- Added translations for the facets page in `common.json`
- The facets panel is now available at `/products/[barcode]/facets`, showing nutrition, ingredients, allergens, labels, categories, brands, packaging, origins, Eco-Score, and Nova group.


### Fixes bug(s)
#260 

### Part of 
#2 
