### PR TITLE
enhancement: show loading on edit button

### DIFF
--- a/src/lib/ui/SmallProductCard.svelte
+++ b/src/lib/ui/SmallProductCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { ProductReduced } from '$lib/api';
-	import { navigating } from '$app/stores';
+	import { navigating } from '$app/state';
 
 	interface Props {
 		product: ProductReduced;
@@ -12,11 +12,11 @@
 <a
 	href={`/products/${product.code}`}
 	class="btn btn-ghost text-primary dark:bg-base-300 pointer-events-none h-auto justify-normal rounded-2xl bg-white p-4 text-start shadow-md"
-	class:pointer-events-none={$navigating}
+	class:pointer-events-none={navigating.to}
 >
 	<div class="flex flex-row items-center">
 		<div class="mr-4 flex w-16 shrink-0 items-center justify-center">
-			{#if $navigating?.to?.params?.barcode === product.code}
+			{#if navigating.to?.params?.barcode === product.code}
 				<span class="loading loading-ring loading-lg mx-auto my-auto"></span>
 			{:else if product.image_front_small_url}
 				<img

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -3,6 +3,7 @@
 	import { isConfigured as isPriceConfigured } from '$lib/api/prices';
 	import { isConfigured as isFolksonomyConfigured } from '$lib/api/folksonomy';
 	import { preferences } from '$lib/settings';
+	import { navigating } from '$app/state';
 
 	import EcoScore from '$lib/greenscore/GreenScore.svelte';
 	import KnowledgePanels from '$lib/knowledgepanels/Panels.svelte';
@@ -46,8 +47,16 @@
 			See on OpenFoodFacts
 		</a>
 
-		<a href={`/products/${product.code}/edit`} class="btn btn-secondary max-sm:btn-sm ml-auto">
-			Edit
+		<a
+			href={`/products/${product.code}/edit`}
+			class="btn btn-secondary max-sm:btn-sm ml-auto"
+			class:pointer-events-none={navigating.to}
+		>
+			{#if navigating.to?.params?.barcode === product.code}
+				<span class="loading loading-ring loading-lg mx-auto my-auto"></span>
+			{:else}
+				Edit
+			{/if}
 		</a>
 	</div>
 


### PR DESCRIPTION
### What
- Clicking the edit button on the product page takes quite a bit of time (over 10s sometimes) and the website feels unresponsive to the user without any loading/progress indication.
- This PR adds loading indication similar to the one presert in `SmallProductCard.svelte`.
- `SmallProductCard.svelte` was using the deprecated version of navigation from `$app/stores`, changed to `$app/state`.

### Screenshot
![image](https://github.com/user-attachments/assets/d48d88fc-7033-4baa-89a8-137c478038e9)
