### PR TITLE
refactor: optimize data fetching with Promise.all for product edit page

### DIFF
--- a/src/routes/products/[barcode]/edit/+page.ts
+++ b/src/routes/products/[barcode]/edit/+page.ts
@@ -4,14 +4,15 @@ import { error } from '@sveltejs/kit';
 import type { PageLoad } from '../$types';
 
 export const load = (async ({ fetch, params }) => {
-	const product = await getProduct(params.barcode, fetch);
-
-	const categories = await getTaxo<Category>('categories', fetch);
-	const labels = await getTaxo<Label>('labels', fetch);
-	const brands = await getTaxo<Brand>('brands', fetch);
-	const stores = await getTaxo<Store>('stores', fetch);
-	const origins = await getTaxo<Origin>('origins', fetch);
-	const countries = await getTaxo<Country>('countries', fetch);
+	const [product, categories, labels, brands, stores, origins, countries] = await Promise.all([
+		getProduct(params.barcode, fetch),
+		getTaxo<Category>('categories', fetch),
+		getTaxo<Label>('labels', fetch),
+		getTaxo<Brand>('brands', fetch),
+		getTaxo<Store>('stores', fetch),
+		getTaxo<Origin>('origins', fetch),
+		getTaxo<Country>('countries', fetch)
+	]);
 
 	if (product.status === 'failure') {
 		error(404, {


### PR DESCRIPTION
### What
- Qucik PR to increase speed by `await`ing only once and running all requests in parallel.
- Consistently getting half load times.
- Sepcially noticable on slower internets.

### Screenshot
Before, About 9s:
![image](https://github.com/user-attachments/assets/7b1139fd-d644-4b32-a580-f42cf0fcb1b0)
After, About 4s:
![image](https://github.com/user-attachments/assets/0be1be86-d682-4bc0-8360-610b5c0667f0)