### PR TITLE
fix: country dropdown menu overflowing horizontally

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -58,7 +58,7 @@
 			{@const country = data.countries[countryKey]}
 			{@const code2 = country.country_code_2.en}
 			<option value={code2} selected={$preferences.country === code2}>
-				{country.name['en']} ({country.name[$preferences.lang]})
+				{country.name['en']}
 			</option>
 		{/each}
 	</select>


### PR DESCRIPTION
### What
Fixed the drop down menu for Country options overflowing horizontally in Settings page.

### Screenshot
![Screenshot 2025-03-17 162921](https://github.com/user-attachments/assets/18693782-2701-428e-acf7-c857952546f9)


### Fixes bug(s)
#216 

### Part of 
None
