### PR TITLE
chore: created `.env.example` for environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_FOLKSONOMY_API_URL=https://api.folksonomy.openfoodfacts.org

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-VITE_FOLKSONOMY_API_URL=https://api.folksonomy.openfoodfacts.org
+VITE_FOLKSONOMY_API_URL=https://api.folksonomy.openfoodfacts.net

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ First, install dependencies:
 pnpm install
 ```
 
+### Environment Variables Setup
+
+Before running the project, set up the environment variables:
+
+```bash
+cp .env.example .env
+```
+
+Edit the `.env` file as needed to configure your development environment.
+
 Then start the development server:
 
 ```bash


### PR DESCRIPTION
### What
Updates the `README.md` to include instructions for setting up the `.env` file. Developers can now easily configure their environment by copying `.env.example` and renaming it to ` .env`

1. Added a "Environment Setup" section to README.md
2. Provided a command for copying `.env.example` to `.env
`

### Fixes bug(s)
#306 


