### PR TITLE
feat: Product Image Zoom Enhancement

### DIFF
--- a/src/lib/ui/ImageButton.svelte
+++ b/src/lib/ui/ImageButton.svelte
@@ -5,10 +5,13 @@
 	let { src, alt, className = '' }: Props = $props();
 
 	let modal: ImageModal;
+
+	function getFullSizeImageUrl(url: string): string {
+		return url.replace(/\.400\.|\.200\.|\.100\./, '.full.');
+	}
+
 	let onclick = $derived(
-		src != null
-			? () => modal.displayImage(src.replace(/\.400\.|\.200\.|\.100\./, '.full.'), alt)
-			: undefined
+		src != null ? () => modal.displayImage(getFullSizeImageUrl(src), alt) : undefined
 	);
 
 	let rotation = $state(0);

--- a/src/lib/ui/ImageButton.svelte
+++ b/src/lib/ui/ImageButton.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
 	import ImageModal from './ImageModal.svelte';
 
-	type Props = { src?: string; alt?: string };
-	let { src, alt }: Props = $props();
+	type Props = { src?: string; alt?: string; className?: string };
+	let { src, alt, className = '' }: Props = $props();
 
 	let modal: ImageModal;
-	let onclick = $derived(src != null ? () => modal.displayImage(src, alt) : undefined);
+	let onclick = $derived(
+		src != null
+			? () => modal.displayImage(src.replace(/\.400\.|\.200\.|\.100\./, '.full.'), alt)
+			: undefined
+	);
 
 	let rotation = $state(0);
 
@@ -21,7 +25,7 @@
 		<img
 			{src}
 			{alt}
-			class="float-right h-full rounded-lg"
+			class="float-right h-full rounded-lg {className}"
 			style="transform: rotate({rotation}deg); transition: transform 0.3s ease;"
 		/>
 	</button>

--- a/src/lib/ui/ImageModal.svelte
+++ b/src/lib/ui/ImageModal.svelte
@@ -11,27 +11,55 @@
 		| undefined = $state();
 
 	let dialog: HTMLDialogElement | undefined = $state();
-	let rotation = $state(0);
+	let zoomLevel = $state(1);
+	const MAX_ZOOM = 3;
 
 	export function displayImage(url: string, alt?: string) {
 		image = { url, alt };
-		rotation = 0;
+		zoomLevel = 1;
 		dialog?.showModal();
 	}
 
 	function close() {
 		dialog?.close();
 		setZoomImageState({ currentZoom: 1 });
-		rotation = 0;
+		zoomLevel = 1;
 	}
 
-	function rotateImage() {
-		rotation = rotation + 90;
+	function zoomIn(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+		const newZoom = Math.min(zoomLevel + 0.5, MAX_ZOOM);
+		setZoomImageState({ currentZoom: newZoom });
+		zoomLevel = newZoom;
+	}
+
+	function zoomOut(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+		const newZoom = Math.max(zoomLevel - 0.5, 1);
+		setZoomImageState({ currentZoom: newZoom });
+		zoomLevel = newZoom;
+	}
+
+	function resetZoom(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+		setZoomImageState({ currentZoom: 1 });
+		zoomLevel = 1;
 	}
 
 	onMount(() => {
 		if (container) {
-			createZoomImage(container);
+			createZoomImage(container, {
+				maxZoom: MAX_ZOOM,
+				wheel: { step: 0.5 },
+				zoomOnHover: true,
+				zoomOnClick: true,
+				onZoomChange: (zoom: number) => {
+					zoomLevel = zoom;
+				}
+			});
 		}
 	});
 
@@ -40,31 +68,66 @@
 </script>
 
 <dialog
-	class="border-none bg-transparent p-4 backdrop:backdrop-brightness-50 md:max-h-max md:max-w-xl"
+	class="border-base-300 bg-base-100 fixed inset-0 m-auto max-h-[95vh] max-w-[95vw] border p-0 shadow-lg"
 	bind:this={dialog}
 	onclose={() => (image = undefined)}
 	onclick={self(() => close())}
 >
-	<div class="relative">
-		<div bind:this={container}>
-			<img
-				class="max-h-full max-w-full"
-				src={image?.url}
-				alt={image?.alt}
-				style="transform: rotate({rotation}deg); transition: transform 0.3s ease;"
-			/>
+	<div class="relative flex h-full w-full flex-col">
+		<div class="absolute top-2 right-2 z-10">
+			<button
+				class="btn btn-circle btn-sm bg-base-100/80 hover:bg-base-100"
+				onclick={(e) => {
+					e.stopPropagation();
+					close();
+				}}
+				title="Close"
+				aria-label="Close image"
+			>
+				<span class="icon-[mdi--close] h-5 w-5"></span>
+			</button>
 		</div>
-		<button
-			class="btn btn-circle bg-base-100/80 hover:bg-base-100 absolute right-4 bottom-4"
-			onclick={(e) => {
-				e.stopPropagation();
-				rotateImage();
-			}}
-			title="Rotate image"
-			aria-label="Rotate image 90 degrees clockwise"
+
+		<div
+			bind:this={container}
+			class="flex h-full w-full cursor-zoom-in items-center justify-center overflow-hidden p-6"
 		>
-			<span class="icon-[mdi--rotate-right] h-6 w-6"></span>
-		</button>
+			<img class="max-h-[85vh] max-w-[85vw] object-contain" src={image?.url} alt={image?.alt} />
+		</div>
+
+		<div class="absolute right-4 bottom-4 z-10 flex items-center gap-2">
+			{#if zoomLevel > 1}
+				<button
+					class="btn btn-circle btn-sm bg-base-100/80 hover:bg-base-100"
+					onclick={zoomOut}
+					title="Zoom Out"
+					aria-label="Zoom Out"
+				>
+					<span class="icon-[mdi--magnify-minus-outline] h-5 w-5"></span>
+				</button>
+				<span class="bg-base-100/80 rounded-md px-2 text-sm font-medium text-white"
+					>{zoomLevel.toFixed(1)}x</span
+				>
+				<button
+					class="btn btn-circle btn-sm bg-base-100/80 hover:bg-base-100"
+					onclick={resetZoom}
+					title="Reset Zoom"
+					aria-label="Reset Zoom"
+				>
+					<span class="icon-[mdi--magnify-close] h-5 w-5"></span>
+				</button>
+			{/if}
+			{#if zoomLevel < MAX_ZOOM}
+				<button
+					class="btn btn-circle btn-sm bg-base-100/80 hover:bg-base-100"
+					onclick={zoomIn}
+					title="Zoom In"
+					aria-label="Zoom In"
+				>
+					<span class="icon-[mdi--magnify-plus-outline] h-5 w-5"></span>
+				</button>
+			{/if}
+		</div>
 	</div>
 </dialog>
 

--- a/src/lib/ui/ZoomableImage.svelte
+++ b/src/lib/ui/ZoomableImage.svelte
@@ -56,7 +56,7 @@
 
 <div class="relative">
 	<div bind:this={container} class="cursor-zoom-in overflow-hidden">
-		<img {src} {alt} class={`rounded-lg ${className}`} />
+		<img {src} {alt} class="rounded-lg" class:className />
 	</div>
 	<div class="absolute right-2 bottom-2 z-10 flex items-center gap-1">
 		{#if zoomLevel > 1}

--- a/src/lib/ui/ZoomableImage.svelte
+++ b/src/lib/ui/ZoomableImage.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { useZoomImageWheel } from '@zoom-image/svelte';
+
+	type Props = { src?: string; alt?: string; className?: string };
+	let { src, alt, className = '' }: Props = $props();
+
+	let zoomLevel = $state(1);
+	const MAX_ZOOM = 3;
+	let isZooming = $state(false);
+
+	function zoomIn(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+		const newZoom = Math.min(zoomLevel + 0.5, MAX_ZOOM);
+		setZoomImageState({ currentZoom: newZoom });
+		zoomLevel = newZoom;
+		isZooming = true;
+	}
+
+	function zoomOut(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+		const newZoom = Math.max(zoomLevel - 0.5, 1);
+		setZoomImageState({ currentZoom: newZoom });
+		zoomLevel = newZoom;
+		if (newZoom === 1) isZooming = false;
+	}
+
+	function resetZoom(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+		setZoomImageState({ currentZoom: 1 });
+		zoomLevel = 1;
+		isZooming = false;
+	}
+
+	let container: HTMLDivElement | undefined = $state();
+	const { createZoomImage, setZoomImageState } = useZoomImageWheel();
+
+	onMount(() => {
+		if (container) {
+			createZoomImage(container, {
+				maxZoom: MAX_ZOOM,
+				wheel: { step: 0.5 },
+				zoomOnHover: true,
+				zoomOnClick: true,
+				onZoomChange: (zoom: number) => {
+					zoomLevel = zoom;
+					isZooming = zoom > 1;
+				}
+			});
+		}
+	});
+</script>
+
+<div class="relative">
+	<div bind:this={container} class="cursor-zoom-in overflow-hidden">
+		<img {src} {alt} class={`rounded-lg ${className}`} />
+	</div>
+	<div class="absolute right-2 bottom-2 z-10 flex items-center gap-1">
+		{#if zoomLevel > 1}
+			<button
+				class="btn btn-circle btn-xs bg-base-100/80 hover:bg-base-100"
+				onclick={zoomOut}
+				title="Zoom Out"
+				aria-label="Zoom Out"
+			>
+				<span class="icon-[mdi--magnify-minus-outline] h-3 w-3"></span>
+			</button>
+			<span class="bg-base-100/80 rounded-md px-1 text-xs font-medium text-white"
+				>{zoomLevel.toFixed(1)}x</span
+			>
+			<button
+				class="btn btn-circle btn-xs bg-base-100/80 hover:bg-base-100"
+				onclick={resetZoom}
+				title="Reset Zoom"
+				aria-label="Reset Zoom"
+			>
+				<span class="icon-[mdi--magnify-close] h-3 w-3"></span>
+			</button>
+		{/if}
+		{#if zoomLevel < MAX_ZOOM}
+			<button
+				class="btn btn-circle btn-xs bg-base-100/80 hover:bg-base-100"
+				onclick={zoomIn}
+				title="Zoom In"
+				aria-label="Zoom In"
+			>
+				<span class="icon-[mdi--magnify-plus-outline] h-3 w-3"></span>
+			</button>
+		{/if}
+	</div>
+</div>

--- a/src/lib/ui/ZoomableImage.svelte
+++ b/src/lib/ui/ZoomableImage.svelte
@@ -7,7 +7,6 @@
 
 	let zoomLevel = $state(1);
 	const MAX_ZOOM = 3;
-	let isZooming = $state(false);
 
 	function zoomIn(e: MouseEvent) {
 		e.preventDefault();
@@ -15,7 +14,6 @@
 		const newZoom = Math.min(zoomLevel + 0.5, MAX_ZOOM);
 		setZoomImageState({ currentZoom: newZoom });
 		zoomLevel = newZoom;
-		isZooming = true;
 	}
 
 	function zoomOut(e: MouseEvent) {
@@ -24,7 +22,6 @@
 		const newZoom = Math.max(zoomLevel - 0.5, 1);
 		setZoomImageState({ currentZoom: newZoom });
 		zoomLevel = newZoom;
-		if (newZoom === 1) isZooming = false;
 	}
 
 	function resetZoom(e: MouseEvent) {
@@ -32,7 +29,6 @@
 		e.stopPropagation();
 		setZoomImageState({ currentZoom: 1 });
 		zoomLevel = 1;
-		isZooming = false;
 	}
 
 	let container: HTMLDivElement | undefined = $state();
@@ -47,7 +43,6 @@
 				zoomOnClick: true,
 				onZoomChange: (zoom: number) => {
 					zoomLevel = zoom;
-					isZooming = zoom > 1;
 				}
 			});
 		}

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -181,16 +181,12 @@
 
 		<div class="flex max-h-80 grow justify-center">
 			<div class="flex flex-col items-center">
-				<ZoomableImage
+				<ImageButton
 					src={product.image_front_url}
 					alt={product.product_name}
 					className="h-full max-h-72 object-contain"
 				/>
-				<button class="text-secondary mt-2 text-xs hover:underline" onclick={viewFullImage}>
-					View full image
-				</button>
 			</div>
-			<ImageModal bind:this={imageModal} />
 		</div>
 	</div>
 </Card>

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -21,7 +21,6 @@
 	import type { PageData } from './$types';
 	import Prices from './Prices.svelte';
 	import Gs1Country from './GS1Country.svelte';
-	import type { components } from '$lib/api/prices.d';
 
 	interface Props {
 		data: PageData;
@@ -32,13 +31,21 @@
 
 	let lang = $derived($preferences.lang);
 
-	// Import PriceResult type from API types instead of redefining it
+	// Define PriceResult type from Prices.svelte
 	type PriceResult = {
+		id: number;
+		product_id: number;
+		location_id: number;
+		proof_id: number;
 		price: number;
 		currency: string;
 		location_osm_id: number;
 		location_osm_type: 'NODE' | 'WAY' | 'RELATION';
 		date: string;
+		owner?: string | null;
+		source?: string | null;
+		created?: string;
+		updated?: string;
 	};
 
 	function getPricesData() {

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -21,6 +21,7 @@
 	import type { PageData } from './$types';
 	import Prices from './Prices.svelte';
 	import Gs1Country from './GS1Country.svelte';
+	import type { components } from '$lib/api/prices.d';
 
 	interface Props {
 		data: PageData;
@@ -31,21 +32,13 @@
 
 	let lang = $derived($preferences.lang);
 
-	// Define PriceResult type from Prices.svelte
+	// Import PriceResult type from API types instead of redefining it
 	type PriceResult = {
-		id: number;
-		product_id: number;
-		location_id: number;
-		proof_id: number;
 		price: number;
 		currency: string;
 		location_osm_id: number;
 		location_osm_type: 'NODE' | 'WAY' | 'RELATION';
 		date: string;
-		owner?: string | null;
-		source?: string | null;
-		created?: string;
-		updated?: string;
 	};
 
 	function getPricesData() {

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -17,10 +17,6 @@
 	import Card from '$lib/ui/Card.svelte';
 	import Debug from '$lib/ui/Debug.svelte';
 	import ImageButton from '$lib/ui/ImageButton.svelte';
-	// @ts-ignore - Imported for future use
-	import ZoomableImage from '$lib/ui/ZoomableImage.svelte';
-	// @ts-ignore - Imported for future use
-	import ImageModal from '$lib/ui/ImageModal.svelte';
 
 	import type { PageData } from './$types';
 	import Prices from './Prices.svelte';
@@ -34,23 +30,24 @@
 	let product = $derived(data.state.product);
 
 	let lang = $derived($preferences.lang);
-	// @ts-ignore - Using any for component reference is acceptable here
-	let imageModal: any;
 
-	// @ts-ignore - Function reserved for future use
-	function viewFullImage() {
-		if (imageModal) {
-			const imageUrl =
-				product.image_front_url?.replace(/\.400\.|\.200\.|\.100\./, '.full.') ||
-				product.image_front_url;
-			imageModal.displayImage(imageUrl, product.product_name);
-		}
-	}
+	// Define PriceResult type from Prices.svelte
+	type PriceResult = {
+		price: number;
+		currency: string;
+		location_osm_id: number;
+		location_osm_type: 'NODE' | 'WAY' | 'RELATION';
+		date: string;
+	};
 
-	// @ts-ignore - Function to handle type incompatibility with Prices component
 	function getPricesData() {
 		if (data.prices?.data) {
-			return data.prices.data as any;
+			return data.prices.data as {
+				count: number;
+				next?: string | null;
+				previous?: string | null;
+				results: PriceResult[];
+			};
 		}
 		return { count: 0, results: [] };
 	}

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -33,11 +33,19 @@
 
 	// Define PriceResult type from Prices.svelte
 	type PriceResult = {
+		id: number;
+		product_id: number;
+		location_id: number;
+		proof_id: number;
 		price: number;
 		currency: string;
 		location_osm_id: number;
 		location_osm_type: 'NODE' | 'WAY' | 'RELATION';
 		date: string;
+		owner?: string | null;
+		source?: string | null;
+		created?: string;
+		updated?: string;
 	};
 
 	function getPricesData() {

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -21,6 +21,9 @@
 	import type { PageData } from './$types';
 	import Prices from './Prices.svelte';
 	import Gs1Country from './GS1Country.svelte';
+	import type { components } from '$lib/api/prices.d';
+
+	type PriceResult = components['schemas']['PriceFull'];
 
 	interface Props {
 		data: PageData;
@@ -30,23 +33,6 @@
 	let product = $derived(data.state.product);
 
 	let lang = $derived($preferences.lang);
-
-	// Define PriceResult type from Prices.svelte
-	type PriceResult = {
-		id: number;
-		product_id: number;
-		location_id: number;
-		proof_id: number;
-		price: number;
-		currency: string;
-		location_osm_id: number;
-		location_osm_type: 'NODE' | 'WAY' | 'RELATION';
-		date: string;
-		owner?: string | null;
-		source?: string | null;
-		created?: string;
-		updated?: string;
-	};
 
 	function getPricesData() {
 		if (data.prices?.data) {

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -17,6 +17,8 @@
 	import Card from '$lib/ui/Card.svelte';
 	import Debug from '$lib/ui/Debug.svelte';
 	import ImageButton from '$lib/ui/ImageButton.svelte';
+	import ZoomableImage from '$lib/ui/ZoomableImage.svelte';
+	import ImageModal from '$lib/ui/ImageModal.svelte';
 
 	import type { PageData } from './$types';
 	import Prices from './Prices.svelte';
@@ -30,6 +32,16 @@
 	let product = $derived(data.state.product);
 
 	let lang = $derived($preferences.lang);
+	let imageModal: any;
+
+	function viewFullImage() {
+		if (imageModal) {
+			const imageUrl =
+				product.image_front_url?.replace(/\.400\.|\.200\.|\.100\./, '.full.') ||
+				product.image_front_url;
+			imageModal.displayImage(imageUrl, product.product_name);
+		}
+	}
 </script>
 
 <svelte:head>
@@ -167,8 +179,18 @@
 			{/if}
 		</div>
 
-		<div class="flex max-h-56 grow justify-center">
-			<ImageButton src={product.image_front_url} alt={product.product_name} />
+		<div class="flex max-h-80 grow justify-center">
+			<div class="flex flex-col items-center">
+				<ZoomableImage
+					src={product.image_front_url}
+					alt={product.product_name}
+					className="h-full max-h-72 object-contain"
+				/>
+				<button class="text-secondary mt-2 text-xs hover:underline" onclick={viewFullImage}>
+					View full image
+				</button>
+			</div>
+			<ImageModal bind:this={imageModal} />
 		</div>
 	</div>
 </Card>

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -17,7 +17,9 @@
 	import Card from '$lib/ui/Card.svelte';
 	import Debug from '$lib/ui/Debug.svelte';
 	import ImageButton from '$lib/ui/ImageButton.svelte';
+	// @ts-ignore - Imported for future use
 	import ZoomableImage from '$lib/ui/ZoomableImage.svelte';
+	// @ts-ignore - Imported for future use
 	import ImageModal from '$lib/ui/ImageModal.svelte';
 
 	import type { PageData } from './$types';
@@ -32,8 +34,10 @@
 	let product = $derived(data.state.product);
 
 	let lang = $derived($preferences.lang);
+	// @ts-ignore - Using any for component reference is acceptable here
 	let imageModal: any;
 
+	// @ts-ignore - Function reserved for future use
 	function viewFullImage() {
 		if (imageModal) {
 			const imageUrl =
@@ -41,6 +45,14 @@
 				product.image_front_url;
 			imageModal.displayImage(imageUrl, product.product_name);
 		}
+	}
+
+	// @ts-ignore - Function to handle type incompatibility with Prices component
+	function getPricesData() {
+		if (data.prices?.data) {
+			return data.prices.data as any;
+		}
+		return { count: 0, results: [] };
 	}
 </script>
 
@@ -227,7 +239,7 @@
 			Open prices <span class="font-light italic">(alpha)</span>
 		</h1>
 
-		<Prices prices={data.prices.data} barcode={product.code} />
+		<Prices prices={getPricesData()} barcode={product.code} />
 	</Card>
 {/if}
 

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -18,6 +18,7 @@
 	import TagsString from './TagsString.svelte';
 	import { PRODUCT_IMAGE_URL } from '$lib/const';
 	import TraceabilityCodes from './TraceabilityCodes.svelte';
+	import ZoomableImage from '$lib/ui/ZoomableImage.svelte';
 
 	interface Props {
 		data: PageData;
@@ -250,7 +251,13 @@
 			/>
 			<div class="tab-content form-control p-6">
 				{#if getIngredientsImage(code)}
-					<img src={getIngredientsImage(code)} alt="Ingredients" class="mb-4" />
+					<div class="relative mb-4 max-w-full">
+						<ZoomableImage
+							src={getIngredientsImage(code)}
+							alt="Ingredients"
+							className="w-full object-contain"
+						/>
+					</div>
 				{:else}
 					<p class="alert alert-warning mb-4">No ingredients image</p>
 				{/if}


### PR DESCRIPTION
### What
1. Added intuitive zoom functionality for product images:
- Displays current zoom level with consistent styling
- Full-screen modal option with centered image display
- Works on product pages and edit screens

2. Fixes the product image moving out of the container
before: 
![Screenshot 2025-04-03 130444](https://github.com/user-attachments/assets/8dc0a157-50ce-4017-8974-cd05ff2eb503)
 
After: 
![Screenshot 2025-04-03 130433](https://github.com/user-attachments/assets/e59ac336-0aa1-4998-a63c-3f26b60572c5)



### Screen Recordings

https://github.com/user-attachments/assets/4d6ea3de-6c3d-44d4-9781-94a7efa3fd79



### Fixes bug(s)
#329 

### Part of 
None
