### PR TITLE
chore: made the base URL configurable via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 VITE_FOLKSONOMY_API_URL=https://api.folksonomy.openfoodfacts.net
-VITE_BASE_URL=https://world.openfoodfacts.org
+VITE_OFF_BASE_URL=https://world.openfoodfacts.org

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_FOLKSONOMY_API_URL=https://api.folksonomy.openfoodfacts.net
+VITE_BASE_URL=https://world.openfoodfacts.org

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,5 +1,5 @@
 export const STATIC_HOST = 'https://static.openfoodfacts.org';
-export const API_HOST = import.meta.env.VITE_BASE_URL || 'https://world.openfoodfacts.org';
+export const API_HOST = import.meta.env.VITE_OFF_BASE_URL || 'https://world.openfoodfacts.org';
 export const SEARCH_URL = `${API_HOST}/api/v2/search`;
 export const IMAGE_HOST = 'https://images.openfoodfacts.org';
 export const PRODUCT_EDIT_URL = `${API_HOST}/product/`;

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -2,6 +2,8 @@ export const STATIC_HOST = 'https://static.openfoodfacts.org';
 export const API_HOST = import.meta.env.VITE_BASE_URL || 'https://world.openfoodfacts.org';
 export const SEARCH_URL = `${API_HOST}/api/v2/search`;
 export const IMAGE_HOST = 'https://images.openfoodfacts.org';
+export const PRODUCT_EDIT_URL = `${API_HOST}/product/`;
+export const PRODUCT_REPORT_URL = `${API_HOST}/product/`;
 
 export const USER_AGENT = `Open Food Facts Explorer (${import.meta.env.PACKAGE_VERSION})`;
 

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,5 +1,5 @@
 export const STATIC_HOST = 'https://static.openfoodfacts.org';
-export const API_HOST = 'https://world.openfoodfacts.org';
+export const API_HOST = import.meta.env.VITE_BASE_URL || 'https://world.openfoodfacts.org';
 export const SEARCH_URL = `${API_HOST}/api/v2/search`;
 export const IMAGE_HOST = 'https://images.openfoodfacts.org';
 

--- a/src/lib/knowledgepanels/Action.svelte
+++ b/src/lib/knowledgepanels/Action.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import type { KnowledgeActionElement, KnowledgePanel } from '$lib/api';
 	import { goto } from '$app/navigation';
+	import { API_HOST } from '$lib/const';
 
 	// URL constants
-	const PRODUCT_EDIT_URL = 'https://world.openfoodfacts.org/product/';
-	const PRODUCT_REPORT_URL = 'https://world.openfoodfacts.org/product/';
+	const PRODUCT_EDIT_URL = `${API_HOST}/product/`;
+	const PRODUCT_REPORT_URL = `${API_HOST}/product/`;
 
 	type Props = {
 		element: KnowledgeActionElement;

--- a/src/lib/knowledgepanels/Action.svelte
+++ b/src/lib/knowledgepanels/Action.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
 	import type { KnowledgeActionElement, KnowledgePanel } from '$lib/api';
 	import { goto } from '$app/navigation';
-	import { API_HOST } from '$lib/const';
-
-	// URL constants
-	const PRODUCT_EDIT_URL = `${API_HOST}/product/`;
-	const PRODUCT_REPORT_URL = `${API_HOST}/product/`;
+	import { API_HOST, PRODUCT_EDIT_URL, PRODUCT_REPORT_URL } from '$lib/const';
 
 	type Props = {
 		element: KnowledgeActionElement;

--- a/src/routes/products/search/+page.ts
+++ b/src/routes/products/search/+page.ts
@@ -1,6 +1,7 @@
 import { error, redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 import type { Product } from '$lib/api';
+import { API_HOST } from '$lib/const';
 
 export const load: PageLoad = async ({ fetch, url }) => {
 	const query = url.searchParams.get('q');
@@ -23,7 +24,7 @@ export const load: PageLoad = async ({ fetch, url }) => {
 		page: page
 	});
 
-	const result = fetch(`https://world.openfoodfacts.org/cgi/search.pl?` + urlSearch.toString())
+	const result = fetch(`${API_HOST}/cgi/search.pl?` + urlSearch.toString())
 		.then((res) => {
 			if (!res.ok) {
 				error(400, 'Failed to fetch data');


### PR DESCRIPTION
### What
- Added `VITE_BASE_URL` to `.env.example` with default value `https://world.openfoodfacts.org`
- Updated `src/lib/const.ts` to use this environment variable with a fallback
- Replaced hardcoded URLs in` src/routes/products/search/+page.ts` and `src/lib/knowledgepanels/Action.svelte` to use the API_HOST constant


### Fixes bug(s)
#331 


