### PR TITLE
chore: added the missing VITE_PRICES_API_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_FOLKSONOMY_API_URL=https://api.folksonomy.openfoodfacts.net
+VITE_PRICES_API_URL=https://prices.openfoodfacts.org


### PR DESCRIPTION
### What
- Added `VITE_PRICES_API_URL=https://prices.openfoodfacts.org` to `.env.example`
- This ensures the prices API client in `src/lib/api/prices.ts` has its base URL properly configured


### Fixes bug(s)
#333 

