### PR TITLE
fix: Undefined issue was causing blank screen when launched

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"name": "OpenFoodFacts Explorer",
+	"customizations": {
+		"vscode": {
+			"extensions": ["svelte.svelte-vscode"]
+		}
+	},
+	"postCreateCommand": "npm install -g pnpm && cp .env.example .env && npm install",
+	"postStartCommand": "pnpm run dev"
+}

--- a/src/lib/ui/SmallProductCard.svelte
+++ b/src/lib/ui/SmallProductCard.svelte
@@ -27,7 +27,7 @@
 	class="btn btn-ghost text-primary dark:bg-base-300 pointer-events-none flex h-auto flex-col justify-normal rounded-2xl bg-white p-4 text-start shadow-md"
 	class:pointer-events-none={navigating.to}
 >
-	<div class="flex flex-row items-center">
+	<div class="flex flex-row items-center overflow-hidden">
 		<div class="mr-4 flex w-16 shrink-0 items-center justify-center">
 			{#if navigating.to?.params?.barcode === product.code}
 				<span class="loading loading-ring loading-lg mx-auto my-auto"></span>
@@ -49,11 +49,11 @@
 				</div>
 			{/if}
 		</div>
-		<div>
-			<p class="text-lg">
+		<div class="m-auto flex w-full flex-col items-center overflow-hidden text-ellipsis">
+			<p class="line-clamp-1 w-full overflow-hidden text-lg text-ellipsis">
 				{product.product_name ?? product.code}
 			</p>
-			<p class="mt-2 text-sm font-light">
+			<p class="mt-1 line-clamp-1 w-full overflow-hidden text-sm font-light text-ellipsis">
 				{product.brands} - {product.quantity}
 			</p>
 			{#if product.product_type === 'food'}

--- a/src/routes/products/[barcode]/Prices.svelte
+++ b/src/routes/products/[barcode]/Prices.svelte
@@ -12,11 +12,36 @@
 	type ApiResponse<T> = { data?: T; error?: object };
 
 	type PriceResult = {
-		price: number;
-		currency: string;
-		location_osm_id: number;
-		location_osm_type: 'NODE' | 'WAY' | 'RELATION';
-		date: string;
+		readonly id: number;
+		product_id: number;
+		location_id: number;
+		proof_id: number;
+		product: {
+			readonly id: number;
+			code: string;
+		};
+		location: unknown;
+		proof: unknown;
+		type: string;
+		product_code?: string | null;
+		product_name?: string | null;
+		category_tag?: string | null;
+		labels_tags?: unknown;
+		origins_tags?: unknown;
+		price?: number | null;
+		price_is_discounted?: boolean;
+		price_without_discount?: number | null;
+		discount_type?: unknown | null;
+		price_per?: unknown | null;
+		currency?: string | null;
+		location_osm_id?: number | null;
+		location_osm_type?: 'NODE' | 'WAY' | 'RELATION' | '' | null;
+		date?: string | null;
+		receipt_quantity?: number | null;
+		owner?: string | null;
+		source?: string | null;
+		created?: string;
+		readonly updated: string;
 	};
 
 	interface Props {
@@ -130,26 +155,31 @@
 				</tr>
 			</thead>
 			<tbody>
-				<!-- TODO: the key here is not guaranteed to be unique -->
-				{#each prices.results as price (price.date + price.location_osm_id + price.price)}
+				{#each prices.results as price (price.id)}
 					<tr>
-						<td>{price.price + ' ' + price.currency}</td>
+						<td
+							>{price.price != null ? price.price + ' ' + (price.currency ?? 'Unknown') : 'N/A'}</td
+						>
 						<td>
-							{#await idToName(fetch, price.location_osm_id)}
-								Loading...
-							{:then storeName}
-								<a
-									href={`https://www.openstreetmap.org/${price.location_osm_type.toLowerCase()}/${
-										price.location_osm_id
-									}`}
-								>
-									{storeName}
-								</a>
-							{:catch error}
-								<span class="text-red-500">Error: {error.message}</span>
-							{/await}
+							{#if price.location_osm_id != null}
+								{#await idToName(fetch, price.location_osm_id)}
+									Loading...
+								{:then storeName}
+									<a
+										href={`https://www.openstreetmap.org/${(price.location_osm_type ?? 'node').toLowerCase()}/${
+											price.location_osm_id
+										}`}
+									>
+										{storeName}
+									</a>
+								{:catch error}
+									<span class="text-red-500">Error: {error.message}</span>
+								{/await}
+							{:else}
+								Unknown location
+							{/if}
 						</td>
-						<td>{new Date(price.date).toLocaleDateString()}</td>
+						<td>{price.date ? new Date(price.date).toLocaleDateString() : 'Unknown date'}</td>
 					</tr>
 				{/each}
 			</tbody>

--- a/src/routes/products/[barcode]/Prices.svelte
+++ b/src/routes/products/[barcode]/Prices.svelte
@@ -119,7 +119,7 @@
 <div>
 	<div id="prices">
 		<span class="font-bold">
-			Prices: ({Math.min(prices.results.length ?? 0, prices.count ?? 0)}/{prices.count})
+			Prices: ({Math.min(prices?.results?.length ?? 0, prices?.count ?? 0)}/{prices?.count ?? 0})
 		</span>
 		<table class="table-zebra table">
 			<thead>


### PR DESCRIPTION
### What
When `prices.results` is undefined, it causes `.length` to throw an error. The error seen in the provided screenshot was: `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'length')`, and after looking into the stack trace myself, I saw that the error pointed to this line in the component:
![Screenshot_4](https://github.com/user-attachments/assets/9c0e6e04-1f52-4630-8d35-84748d93daef)

I was then able to reproduce the bug locally:
![Screenshot_2](https://github.com/user-attachments/assets/92d0f2de-9103-4b32-b3ff-35f2f9071576)

I fixed the bug by using optional chaining to safely access nested properties. This prevents the app from crashing when `prices.results` is undefined and avoids calling `.length` on undefined like before.


### Screenshot
With my change, the blank page behaviour wasn't recurring.
![Screenshot_3](https://github.com/user-attachments/assets/5acbd96f-f072-4db4-bb9e-91544f921571)

### Fixes bug(s)
#287
