### PR TITLE
fix: ...Undefined issue was causing blank screen when launched

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+.pnpm-store/

--- a/src/routes/products/[barcode]/Prices.svelte
+++ b/src/routes/products/[barcode]/Prices.svelte
@@ -144,7 +144,7 @@
 <div>
 	<div id="prices">
 		<span class="font-bold">
-			Prices: ({Math.min(prices.results.length ?? 0, prices.count ?? 0)}/{prices.count})
+			Prices: ({Math.min(prices?.results?.length ?? 0, prices?.count ?? 0)}/{prices?.count ?? 0})
 		</span>
 		<table class="table-zebra table">
 			<thead>


### PR DESCRIPTION
### What
When `prices.results` is undefined, it causes `.length` to throw an error. The error seen in the provided screenshot was: `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'length')`, and after looking into the stack trace myself, I saw that the error pointed to this line in the component:
![Screenshot_4](https://github.com/user-attachments/assets/9c0e6e04-1f52-4630-8d35-84748d93daef)

I was then able to reproduce the bug locally:
![Screenshot_2](https://github.com/user-attachments/assets/92d0f2de-9103-4b32-b3ff-35f2f9071576)

I fixed the bug by using optional chaining to safely access nested properties. This prevents the app from crashing when `prices.results` is undefined and avoids calling `.length` on undefined like before.


### Screenshot
With my change, the blank page behaviour wasn't recurring.
![Screenshot_3](https://github.com/user-attachments/assets/5acbd96f-f072-4db4-bb9e-91544f921571)

### Fixes bug(s)
#287
