### PR TITLE
ci: auto-generate-changelogs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,28 @@
+name: 🚀 Adding the commit to the next release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - id: release
+        uses: googleapis/release-please-action@v4.1.4
+        with:
+          # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
+          # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          # So this is a personal access token
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          release-type: simple
+          pull-request-title-pattern: "chore${scope}: 🚀 Open Food Facts Explorer - Experimental frontend - Release${component} ${version}."
+          changelog-types: |
+            [
+              {"type":"feat","section":"Features","hidden":false},
+              {"type":"fix","section":"Bug Fixes","hidden":false},
+              {"type":"taxonomy","section":"Taxonomy","hidden":false},
+              {"type":"l10n","section":"Translations","hidden":false},
+              {"type":"style","section":"Technical","hidden":false},
+              {"type":"docs","section":"Technical","hidden":false},
+              {"type":"test","section":"Technical","hidden":false}
+            ]


### PR DESCRIPTION


### What
- I propose we do time based releases, just for the sake of it, since we already deploy at every commit