### PR TITLE
fix: type errors fixed in a product which fails to fetch

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -181,7 +181,7 @@
 		<Nova grade={product.nova_group} />
 	</a>
 	<a href="#environment_card" class="md:w-1/3">
-		<EcoScore grade={product.ecoscore_grade || 'unknown'} />
+		<EcoScore grade={product.ecoscore_grade ?? 'unknown'} />
 	</a>
 </div>
 

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -181,7 +181,7 @@
 		<Nova grade={product.nova_group} />
 	</a>
 	<a href="#environment_card" class="md:w-1/3">
-		<EcoScore grade={product.ecoscore_grade} />
+		<EcoScore grade={product.ecoscore_grade || 'unknown'} />
 	</a>
 </div>
 

--- a/src/routes/products/[barcode]/GreenScore.svelte
+++ b/src/routes/products/[barcode]/GreenScore.svelte
@@ -40,7 +40,7 @@
 	let { grade }: { grade: string } = $props();
 	let normalizedGrade = $derived(grade.toLowerCase());
 	let { name, src, textColor, bgColor } = $derived(
-		GRADE_MAP[normalizedGrade] || GRADE_MAP['unknown']
+		GRADE_MAP[normalizedGrade] ?? GRADE_MAP['unknown']
 	);
 </script>
 

--- a/src/routes/products/[barcode]/GreenScore.svelte
+++ b/src/routes/products/[barcode]/GreenScore.svelte
@@ -39,7 +39,9 @@
 
 	let { grade = 'unknown' }: { grade?: string } = $props();
 	let normalizedGrade = $derived((grade || '').toLowerCase());
-	let { name, src, textColor, bgColor } = $derived(GRADE_MAP[normalizedGrade] || GRADE_MAP['unknown']);
+	let { name, src, textColor, bgColor } = $derived(
+		GRADE_MAP[normalizedGrade] || GRADE_MAP['unknown']
+	);
 </script>
 
 <div

--- a/src/routes/products/[barcode]/GreenScore.svelte
+++ b/src/routes/products/[barcode]/GreenScore.svelte
@@ -37,7 +37,7 @@
 		}
 	};
 
-	let { grade = 'unknown' }: { grade?: string } = $props();
+	let { grade }: { grade: string } = $props();
 	let normalizedGrade = $derived((grade || '').toLowerCase());
 	let { name, src, textColor, bgColor } = $derived(
 		GRADE_MAP[normalizedGrade] || GRADE_MAP['unknown']

--- a/src/routes/products/[barcode]/GreenScore.svelte
+++ b/src/routes/products/[barcode]/GreenScore.svelte
@@ -38,7 +38,7 @@
 	};
 
 	let { grade }: { grade: string } = $props();
-	let normalizedGrade = $derived((grade || '').toLowerCase());
+	let normalizedGrade = $derived(grade.toLowerCase());
 	let { name, src, textColor, bgColor } = $derived(
 		GRADE_MAP[normalizedGrade] || GRADE_MAP['unknown']
 	);

--- a/src/routes/products/[barcode]/GreenScore.svelte
+++ b/src/routes/products/[barcode]/GreenScore.svelte
@@ -37,9 +37,9 @@
 		}
 	};
 
-	let { grade }: { grade: string } = $props();
-	let normalizedGrade = $derived(grade.toLowerCase());
-	let { name, src, textColor, bgColor } = $derived(GRADE_MAP[normalizedGrade]);
+	let { grade = 'unknown' }: { grade?: string } = $props();
+	let normalizedGrade = $derived((grade || '').toLowerCase());
+	let { name, src, textColor, bgColor } = $derived(GRADE_MAP[normalizedGrade] || GRADE_MAP['unknown']);
 </script>
 
 <div


### PR DESCRIPTION
### What
- We currently use a grading system which furthers used to map, this console error of `bgColor` arises due to grade being undefined while destructring.
So using a fallback of `( || 'unknown')` for grade whenever it is undefined/null fixes the issue

- Used Crowdin to fix the translations in #406 

### Screenshot
Before: blank Screen, as it could not fetch the data from the BE

After: 
![image](https://github.com/user-attachments/assets/fc806d15-8163-4ffd-846d-f60cd0b1ab28)


### Fixes bug(s)
#361 


