### PR TITLE
style: fixes the text color of tags in Light mode

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -89,7 +89,7 @@
 				{:then categories}
 					{#each product.categories_tags as tag (tag)}
 						<a
-							class="link bg-secondary mr-0.5 inline-block break-inside-avoid rounded-xl px-2 font-semibold text-black no-underline"
+							class="link bg-secondary text-secondary-content mr-0.5 inline-block break-inside-avoid rounded-xl px-2 font-semibold no-underline"
 							href="/taxo/categories/{tag}"
 						>
 							{categories[tag] != null ? getOrDefault(categories[tag].name, lang) : tag}


### PR DESCRIPTION
### What
Fixed the tags text-color's responsiveness as per the theme under categories. 

### Screenshot
![Screenshot 2025-03-29 164258](https://github.com/user-attachments/assets/b89014ef-2945-4eb3-a499-c106044fc98b)

### Fixes bug(s)
#389 

