### PR TITLE
Fix for undefined error in search results loading skeleton

### DIFF
--- a/src/routes/products/search/+page.svelte
+++ b/src/routes/products/search/+page.svelte
@@ -16,7 +16,7 @@
 </script>
 
 {#await data.result}
-	{#each Array(5) as i (i)}
+	{#each Array(5) as _, i}
 		<div class="skeleton dark:bg-base-300 h-24 bg-white p-4 shadow-md"></div>
 	{/each}
 {:then result}


### PR DESCRIPTION
### What
#### Issue
When searching for a product locally on my machine (`products/search?q=<name>`) I was getting the following error on my console. 
```js
client.js?v=68870e34:329 Uncaught (in promise) Svelte error: each_key_duplicate
Keyed each block has duplicate key `undefined` at indexes 0 and 1
https://svelte.dev/e/each_key_duplicate

	in +page.svelte
	in +layout.svelte
	in root.svelte
```
While reloading the same search result, the results were not getting populated even though the payload was coming in fine. 

This issue was resolved for me by updating the loop that generated the `ProductCard` skeleton from `{#each Array(5) as i (i)}` to `{#each Array(5) as _, i}`. Attaching video as well.

### Screenshot
![image](https://github.com/user-attachments/assets/1aa1beca-22e1-4db1-b26f-7dfd5ccbeff2)
https://github.com/user-attachments/assets/01f088be-8832-4bef-a8c4-3089b054f900


### Fixes bug(s)
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/392
