### PR TITLE
Resolved the missing string in nutrition editing

### DIFF
--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -368,8 +368,6 @@
 				/>
 			</div>
 		</div>
-	{:else}
-		<div class="alert alert-info">{$t('product.nutrition.not_specified')}</div>
 	{/if}
 </Card>
 


### PR DESCRIPTION
### What
missing string in the nutrition editing
![image](https://github.com/user-attachments/assets/5ca63d2c-bad9-483c-93f4-a6c95c484308)

Removed the missing nutrition string because the checkbox is already displaying that the nutrition details are not on the product, so showing that again below the checkbox is not a good idea
But if you want to show the text (nutrition details not specified on the product), then you can let me know, I'll add it

![image](https://github.com/user-attachments/assets/3b941779-2dcb-44be-a5d9-1b4ff12abe21)


### Fixes bug(s)
Fixes #378 

