### PR TITLE
fix: Nova card not targeting specific panel ID

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -177,7 +177,7 @@
 	<a href="#health_card" class="md:w-1/3">
 		<NutriScore grade={product.nutriscore_grade} />
 	</a>
-	<a href="#nutrition_card" class="md:w-1/3">
+	<a href="#nova" class="md:w-1/3">
 		<Nova grade={product.nova_group} />
 	</a>
 	<a href="#environment_card" class="md:w-1/3">


### PR DESCRIPTION
### What
Earlier the Nova card used to `href="#nutrition_card"` which did not target the specified panel ID.

I've updated here the link to directly target the `href="#nova"` panel ID. This focuses specifically on the Nova food processing classification section when we click it.

### Fixes bug(s)
#419 


