### PR TITLE
fix: product image overflowing from the container

### DIFF
--- a/src/lib/ui/ImageButton.svelte
+++ b/src/lib/ui/ImageButton.svelte
@@ -16,12 +16,12 @@
 
 <ImageModal bind:this={modal} />
 
-<div class="relative">
-	<button class="flex max-w-full justify-center" {onclick}>
+<div class="relative flex h-full items-center justify-center">
+	<button class="flex max-h-full max-w-full justify-center" {onclick}>
 		<img
 			{src}
 			{alt}
-			class="float-right h-full rounded-lg"
+			class="max-h-full max-w-full rounded-lg object-contain"
 			style="transform: rotate({rotation}deg); transition: transform 0.3s ease;"
 		/>
 	</button>

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -187,7 +187,7 @@
 			{/if}
 		</div>
 
-		<div class="flex max-h-56 grow justify-center">
+		<div class="flex h-56 grow justify-center">
 			<ImageButton src={product.image_front_url} alt={product.product_name} />
 		</div>
 	</div>


### PR DESCRIPTION
### What
Fixes the product image overflowing from the container.

### Screenshot
Before: 
![Screenshot 2025-04-05 233059](https://github.com/user-attachments/assets/946c37bf-0771-4627-8a2c-83400e0758bc)

After:
![Screenshot 2025-04-05 232637](https://github.com/user-attachments/assets/7bfb8b3e-449b-40ae-838a-6a232ae2657c)





