### PR TITLE
fix: text-wrapping in folksonomy engine

### DIFF
--- a/src/routes/products/[barcode]/Folksonomy.svelte
+++ b/src/routes/products/[barcode]/Folksonomy.svelte
@@ -112,13 +112,21 @@
 					</div>
 				</td>
 				<td class="flex gap-2" aria-label="Value">
-					<input
-						type="text"
-						class="input grow max-sm:w-20"
-						value={tag.v}
-						readonly={!loggedIn}
-						onchange={(e) => updateTag(e.currentTarget.value, i)}
-					/>
+					{#if loggedIn}
+						<input
+							type="text"
+							class="input grow max-sm:w-20"
+							value={tag.v}
+							readonly={!loggedIn}
+							onchange={(e) => updateTag(e.currentTarget.value, i)}
+						/>
+					{:else}
+						<textarea
+							class="textarea grow max-sm:w-20"
+							readonly
+							style="white-space: pre-wrap; overflow-wrap: break-word;">{tag.v}</textarea
+						>
+					{/if}
 				</td>
 				{#if loggedIn}
 					<td>

--- a/src/routes/products/[barcode]/Folksonomy.svelte
+++ b/src/routes/products/[barcode]/Folksonomy.svelte
@@ -112,18 +112,12 @@
 					</div>
 				</td>
 				<td class="flex gap-2" aria-label="Value">
-					{#if loggedIn}
-						<input
-							type="text"
-							class="input grow max-sm:w-20"
-							value={tag.v}
-							onchange={(e) => updateTag(e.currentTarget.value, i)}
-						/>
-					{:else}
-						<textarea class="textarea grow break-words whitespace-pre-wrap max-sm:w-20" readonly
-							>{tag.v}</textarea
-						>
-					{/if}
+					<textarea
+						class="textarea grow break-words whitespace-pre-wrap max-sm:w-20"
+						readonly={!loggedIn}
+						value={tag.v}
+						onchange={(e) => updateTag(e.currentTarget.value, i)}
+					></textarea>
 				</td>
 				{#if loggedIn}
 					<td>

--- a/src/routes/products/[barcode]/Folksonomy.svelte
+++ b/src/routes/products/[barcode]/Folksonomy.svelte
@@ -117,14 +117,11 @@
 							type="text"
 							class="input grow max-sm:w-20"
 							value={tag.v}
-							readonly={!loggedIn}
 							onchange={(e) => updateTag(e.currentTarget.value, i)}
 						/>
 					{:else}
-						<textarea
-							class="textarea grow max-sm:w-20"
-							readonly
-							style="white-space: pre-wrap; overflow-wrap: break-word;">{tag.v}</textarea
+						<textarea class="textarea grow break-words whitespace-pre-wrap max-sm:w-20" readonly
+							>{tag.v}</textarea
 						>
 					{/if}
 				</td>


### PR DESCRIPTION
### What
text wrapping issue in folksonomy engine

![image](https://github.com/user-attachments/assets/ea13ce68-8974-44bd-a2ad-f7427a639242)

As the input field does not support text wrapping, so we are gonna toggle between input and textarea fields based on if the user is logged in or not, as the user gets write access if the user is logged in

Fixes #447
