### PR TITLE
fix: added arrows in product page for the content that extends

### DIFF
--- a/src/lib/knowledgepanels/Panel.svelte
+++ b/src/lib/knowledgepanels/Panel.svelte
@@ -59,6 +59,11 @@
 					{/if}
 				</div>
 			{/if}
+
+			<span
+				class="icon-[mdi--chevron-down] h-6 w-6 transition-transform duration-300"
+				style="transform: rotate({expanded ? 180 : 0}deg);"
+			></span>
 		</summary>
 
 		{#if elements != null}

--- a/src/lib/knowledgepanels/Panel.svelte
+++ b/src/lib/knowledgepanels/Panel.svelte
@@ -30,10 +30,15 @@
 {/snippet}
 
 {#snippet detailsElement(title: KnowledgePanelTitle, elements: KnowledgeElement[])}
-	<div class=" border-base-300 rounded-box collapse-arrow collapse border">
-		<input type="checkbox" bind:checked={expanded} />
-		<div
-			class="hover:bg-base-200 dark:hover:bg-base-100 collapse-title my-2 flex w-full cursor-pointer items-center rounded-lg p-2 select-none"
+	<details
+		bind:open={expanded}
+		class:border-l-secondary={expanded}
+		class:border-l-2={expanded}
+		class:pl-4={expanded}
+		class="collapse-arrow collapse"
+	>
+		<summary
+			class="hover:bg-base-200 dark:hover:bg-base-100 collapse-title my-2 !flex w-full cursor-pointer items-center rounded-lg p-2 select-none"
 		>
 			{#if title != null}
 				{#if title.icon_url != null}
@@ -47,7 +52,6 @@
 						/>
 					{/if}
 				{/if}
-
 				<div class="grow sm:text-xl">
 					<div>{title.title}</div>
 					{#if title.subtitle != null}
@@ -55,13 +59,13 @@
 					{/if}
 				</div>
 			{/if}
-		</div>
+		</summary>
 		<div class="collapse-content">
 			{#if elements != null}
 				{@render elementList(panel.elements)}
 			{/if}
 		</div>
-	</div>
+	</details>
 {/snippet}
 
 <div {id}>

--- a/src/lib/knowledgepanels/Panel.svelte
+++ b/src/lib/knowledgepanels/Panel.svelte
@@ -30,14 +30,10 @@
 {/snippet}
 
 {#snippet detailsElement(title: KnowledgePanelTitle, elements: KnowledgeElement[])}
-	<details
-		bind:open={expanded}
-		class:border-l-secondary={expanded}
-		class:border-l-2={expanded}
-		class:pl-4={expanded}
-	>
-		<summary
-			class="hover:bg-base-200 dark:hover:bg-base-100 my-2 flex w-full cursor-pointer items-center rounded-lg p-2 select-none"
+	<div class=" border-base-300 rounded-box collapse-arrow collapse border">
+		<input type="checkbox" bind:checked={expanded} />
+		<div
+			class="hover:bg-base-200 dark:hover:bg-base-100 collapse-title my-2 flex w-full cursor-pointer items-center rounded-lg p-2 select-none"
 		>
 			{#if title != null}
 				{#if title.icon_url != null}
@@ -59,17 +55,13 @@
 					{/if}
 				</div>
 			{/if}
-
-			<span
-				class="icon-[mdi--chevron-down] h-6 w-6 transition-transform duration-300"
-				style="transform: rotate({expanded ? 180 : 0}deg);"
-			></span>
-		</summary>
-
-		{#if elements != null}
-			{@render elementList(panel.elements)}
-		{/if}
-	</details>
+		</div>
+		<div class="collapse-content">
+			{#if elements != null}
+				{@render elementList(panel.elements)}
+			{/if}
+		</div>
+	</div>
 {/snippet}
 
 <div {id}>


### PR DESCRIPTION
### What
The contents that can extend on product page looked like normal text fields, so added arrow that will help user know that this content can be extended

### Screenshot
![image](https://github.com/user-attachments/assets/87e70c77-a2ed-484f-b95a-3176024642ea)

### Fixes bug(s)
Fixes #458 
