### PR TITLE
fix: search ui display 3 cards per row

### DIFF
--- a/src/routes/products/search/+page.svelte
+++ b/src/routes/products/search/+page.svelte
@@ -15,48 +15,51 @@
 	}
 </script>
 
-{#await data.result}
-	{#each Array(5) as _, i (i)}
-		<div class="skeleton dark:bg-base-300 h-24 bg-white p-4 shadow-md"></div>
-	{/each}
-{:then result}
-	{#if result.count > 0}
-		{#each result.products as product (product.code)}
-			<SmallProductCard {product} />
+<div class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-6 xl:grid-cols-3">
+	{#await data.result}
+		{#each Array(6) as _, i (i)}
+			<div class="skeleton dark:bg-base-300 h-28 bg-white p-4 shadow-md"></div>
 		{/each}
+	{:then result}
+		{#if result.count > 0}
+			{#each result.products as product (product.code)}
+				<SmallProductCard {product} />
+			{/each}
+			<div class="col-span-full my-8 flex justify-center">
+				<div class="join">
+					{#if result.page > 1}
+						<a href={getPageUrl(page.url, 1)} class="btn join-item">1</a>
+					{/if}
+					{#if result.page > 3}
+						<button class="btn btn-disabled join-item">...</button>
+					{/if}
 
-		<div class="join my-8 justify-center">
-			{#if result.page > 1}
-				<a href={getPageUrl(page.url, 1)} class="btn join-item"> 1 </a>
-			{/if}
-			{#if result.page > 3}
-				<button class="btn btn-disabled join-item">...</button>
-			{/if}
-
-			{#if result.page > 2}
-				<a href={getPageUrl(page.url, result.page - 1)} class="btn join-item">
-					{result.page - 1}
-				</a>
-			{/if}
-
-			<button class="btn join-item btn-active">{result.page}</button>
-
-			{#if result.total_pages > result.page + 1}
-				<a href={getPageUrl(page.url, result.page + 1)} class="btn join-item">{result.page + 1}</a>
-			{/if}
-			{#if result.total_pages > result.page + 2}
-				<button class="btn btn-disabled join-item">...</button>
-			{/if}
-			{#if result.total_pages > result.page}
-				<a href={getPageUrl(page.url, result.total_pages)} class="btn join-item">
-					{result.total_pages}
-				</a>
-			{/if}
-		</div>
-	{:else}
-		<div class="mt-8 text-center opacity-70">
-			<p>No products found</p>
-			<p>We couldn't find any products matching your search</p>
-		</div>
-	{/if}
-{/await}
+					{#if result.page > 2}
+						<a href={getPageUrl(page.url, result.page - 1)} class="btn join-item">
+							{result.page - 1}
+						</a>
+					{/if}
+					<button class="btn join-item btn-active">{result.page}</button>
+					{#if result.total_pages > result.page + 1}
+						<a href={getPageUrl(page.url, result.page + 1)} class="btn join-item"
+							>{result.page + 1}</a
+						>
+					{/if}
+					{#if result.total_pages > result.page + 2}
+						<button class="btn btn-disabled join-item">...</button>
+					{/if}
+					{#if result.total_pages > result.page}
+						<a href={getPageUrl(page.url, result.total_pages)} class="btn join-item">
+							{result.total_pages}
+						</a>
+					{/if}
+				</div>
+			</div>
+		{:else}
+			<div class="col-span-full mt-8 text-center opacity-70">
+				<p>No products found</p>
+				<p>We couldn't find any products matching your search</p>
+			</div>
+		{/if}
+	{/await}
+</div>

--- a/src/routes/products/search/+page.svelte
+++ b/src/routes/products/search/+page.svelte
@@ -21,7 +21,12 @@
 			<div class="skeleton dark:bg-base-300 h-28 bg-white p-4 shadow-md"></div>
 		{/each}
 	{:then result}
-		{#if result.count > 0}
+		{#if result.count === 0}
+			<div class="col-span-full mt-8 text-center opacity-70">
+				<p>No products found</p>
+				<p>We couldn't find any products matching your search</p>
+			</div>
+		{:else}
 			{#each result.products as product (product.code)}
 				<SmallProductCard {product} />
 			{/each}
@@ -33,7 +38,6 @@
 					{#if result.page > 3}
 						<button class="btn btn-disabled join-item">...</button>
 					{/if}
-
 					{#if result.page > 2}
 						<a href={getPageUrl(page.url, result.page - 1)} class="btn join-item">
 							{result.page - 1}
@@ -54,11 +58,6 @@
 						</a>
 					{/if}
 				</div>
-			</div>
-		{:else}
-			<div class="col-span-full mt-8 text-center opacity-70">
-				<p>No products found</p>
-				<p>We couldn't find any products matching your search</p>
 			</div>
 		{/if}
 	{/await}


### PR DESCRIPTION
### What
- Fixed the product search UI to display 3 cards per row
- Adjusted the skeleton loader to match the 3-card layout

### Screenshot
[screen-capture (2).webm](https://github.com/user-attachments/assets/60a51d2c-00d5-4db4-96ba-dec851c744b0)

### Fixes bug(s)
- #[399](https://github.com/openfoodfacts/openfoodfacts-explorer/issues/399)

### Part of 
