### PR TITLE
feat: github action pinning with Ratchet

### DIFF
--- a/.github/.gemini/config.yaml
+++ b/.github/.gemini/config.yaml
@@ -1,9 +1,0 @@
-have_fun: false
-code_review:
-  disable: false
-  comment_severity_threshold: MEDIUM
-  max_review_comments: -1
-  pull_request_opened:
-    help: false
-    summary: false
-    code_review: false

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -17,4 +17,4 @@ jobs:
     name: 'Pull request assignment'
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v2.1.1
+      - uses: toshimaru/auto-author-assign@16f0022cf3d7970c106d8d1105f75a1165edb516 # ratchet:toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # ratchet:pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'

--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -45,97 +45,97 @@ jobs:
     name: Automatically add relevant issues to the relevant GitHub projects
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/11
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🎨 Mockups available, 🎨 Mockup required
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/36 # Add issue to the open pet food facts project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🐾 Open Pet Food Facts
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/43 # Add issue to the open products facts project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 📸 Open Products Facts
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/37 # Add issue to the open beauty facts project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🧴 Open Beauty Facts
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/4 # Add issue to the packaging project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 📦 Packaging
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/25 # Add issue to the documentation project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 📚 Documentation
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/5 # Add issue to the folksonomy project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🏷️ Folksonomy Engine
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/44 # Add issue to the data quality project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🧽 Data quality
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/82 # Add issue to the search project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🔎 Search
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/41 # Add issue to the producer platform project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🏭 Producers Platform
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/19 # Add issue to the infrastructure project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: infrastructure
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/92 # Add issue to the Nutri-Score project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🚦 Nutri-Score
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/132 # Add issue to the Top upvoted issues board
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: ⭐ top issue, 👍 Top 10 Issue!
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/57 # Add issue to the Most impactful issues board
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🎯 P0, 🎯 P1
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/105 # Add issue to the Prices project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 💸 Prices
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/136 # Add issue to the Translations project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/labeler@v5.0.0
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # ratchet:actions/labeler@v5.0.0
         if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -14,7 +14,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Check for merge conflicts
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@fd1f295ee7443d13745804bc49fe158e240f6c6e # ratchet:eps1lon/actions-label-merge-conflict@releases/2.x
         with:
           dirtyLabel: '💥 Merge Conflicts'
           removeOnDirtyLabel: 'PR: ready to ship'

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -16,7 +16,7 @@ jobs:
     name: Validate Pull Request title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # ratchet:amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
**Signed-off-by:** Jagjeevan Kashid <jagjeevandev97@gmail.com>
### What

Most CI/CD systems are one layer of indirection away from `curl | sudo bash`. Unless you are specifically pinning CI workflows, containers, and base images to checksummed versions, _everything_ is mutable: GitHub labels are mutable and Docker tags are mutable. This poses a substantial security and reliability risk.

**Few Week earlier the most popular action was compromised with `curl` command pointing to an python script :** [Link](https://alexwlchan.net/2025/github-actions-audit/)


Documentation related to ratchet is added on openfoodfacts-server repo

### Also 
Fixes the issue #475 