### PR TITLE
fix: product image overflows from the container

### DIFF
--- a/src/lib/ui/ImageButton.svelte
+++ b/src/lib/ui/ImageButton.svelte
@@ -15,8 +15,8 @@
 </script>
 
 <ImageModal bind:this={modal} />
-<div class="relative">
-	<button class="flex max-w-full justify-center" {onclick}>
+<div class="relative flex h-full w-full items-center justify-center">
+	<button class="flex items-center justify-center" {onclick}>
 		{#if src != null}
 			<div class="flex items-center justify-center">
 				<img

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -198,7 +198,7 @@
 				{/if}
 			</div>
 
-			<div class="flex max-h-56 grow justify-center">
+			<div class="flex h-auto min-h-[40vh] grow justify-center max-md:min-h-[30vh]">
 				<ImageButton src={product.image_front_url} alt={product.product_name} />
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

The container size has been made adaptive for all screens to fit the product image.
Duplicate of #476

Fixes #348 


Before: 
![image](https://github.com/user-attachments/assets/c930330b-dff7-46ab-993a-c1c1984e46f7)

After: 
![image](https://github.com/user-attachments/assets/7811d195-6f1c-4552-b062-5797419345fa)
