### PR TITLE
fix: text inside tags getting clipped on mobile browsers

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -108,12 +108,12 @@
 				<span>{product.quantity}</span>
 
 				<span class="text-end font-bold">Brands:</span>
-				<div>
+				<div class="flex flex-wrap gap-1">
 					{#await data.taxo.brands}
 						Loading...
 					{:then brands}
 						{#each product.brands_tags as tag, i (i)}
-							<span class="badge">
+							<span class="badge flex h-auto items-center break-words">
 								{brands[tag] != null ? getOrDefault(brands[tag].name, lang) : tag}
 							</span>
 						{/each}
@@ -126,7 +126,10 @@
 						Loading...
 					{:then categories}
 						{#each product.categories_tags as tag (tag)}
-							<a class="badge badge-secondary" href="/taxo/categories/{tag}">
+							<a
+								class="badge badge-secondary flex h-auto items-center break-words"
+								href="/taxo/categories/{tag}"
+							>
 								{categories[tag] != null ? getOrDefault(categories[tag].name, lang) : tag}
 							</a>
 						{/each}
@@ -134,12 +137,12 @@
 				</div>
 
 				<span class="text-end font-bold">Stores:</span>
-				<div>
+				<div class="flex flex-wrap gap-1">
 					{#await data.taxo.stores}
 						Loading...
 					{:then stores}
 						{#each product.stores_tags as tag, i (i)}
-							<span class="badge">
+							<span class="badge flex h-auto items-center break-words">
 								{stores[tag] != null ? getOrDefault(stores[tag].name, lang) : tag}
 							</span>
 						{/each}
@@ -147,45 +150,45 @@
 				</div>
 
 				<span class="text-end font-bold">Labels:</span>
-				<span>
+				<div class="flex flex-wrap gap-1">
 					{#await data.taxo.labels}
 						Loading...
 					{:then labels}
 						{#each product.labels_tags as tag, i (i)}
-							<a class="badge" href={'/taxo/labels/' + tag}>
+							<a class="badge flex h-auto items-center break-words" href={'/taxo/labels/' + tag}>
 								{labels[tag] != null ? getOrDefault(labels[tag].name, lang) : tag}
 							</a>
 						{/each}
 					{/await}
-				</span>
+				</div>
 
 				<span class="text-end font-bold">Countries:</span>
-				<span>
+				<div class="flex flex-wrap gap-1">
 					{#await data.taxo.countries}
 						Loading...
 					{:then countries}
 						{#each product.countries_tags as tag, i (i)}
-							<a class="badge" href={'/taxo/countries/' + tag}>
+							<a class="badge flex h-auto items-center break-words" href={'/taxo/countries/' + tag}>
 								{countries[tag] != null ? getOrDefault(countries[tag].name, lang) : tag}
 							</a>
 						{/each}
 					{/await}
-				</span>
+				</div>
 
 				<span class="text-end font-bold">Origins:</span>
-				<span>
+				<div class="flex flex-wrap gap-1">
 					{#await data.taxo.origins}
 						Loading...
 					{:then origins}
 						{#each product.origins_tags as tag, i (i)}
 							{#if i > 0},
 							{/if}
-							<a class="link" href={'/taxo/origin/' + tag}>
+							<a class="link inline-flex items-center break-words" href={'/taxo/origin/' + tag}>
 								{origins[tag] != null ? getOrDefault(origins[tag].name, lang) : tag}
 							</a>
 						{/each}
 					{/await}
-				</span>
+				</div>
 
 				{#if product.emb_codes != null && product.emb_codes.length > 0}
 					<span class="text-end font-bold">Traceability Codes:</span>

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -113,7 +113,7 @@
 						Loading...
 					{:then brands}
 						{#each product.brands_tags as tag, i (i)}
-							<span class="badge flex h-auto items-center break-words">
+							<span class="badge h-auto break-words">
 								{brands[tag] != null ? getOrDefault(brands[tag].name, lang) : tag}
 							</span>
 						{/each}
@@ -126,10 +126,7 @@
 						Loading...
 					{:then categories}
 						{#each product.categories_tags as tag (tag)}
-							<a
-								class="badge badge-secondary flex h-auto items-center break-words"
-								href="/taxo/categories/{tag}"
-							>
+							<a class="badge badge-secondary h-auto break-words" href="/taxo/categories/{tag}">
 								{categories[tag] != null ? getOrDefault(categories[tag].name, lang) : tag}
 							</a>
 						{/each}
@@ -142,7 +139,7 @@
 						Loading...
 					{:then stores}
 						{#each product.stores_tags as tag, i (i)}
-							<span class="badge flex h-auto items-center break-words">
+							<span class="badge h-auto break-words">
 								{stores[tag] != null ? getOrDefault(stores[tag].name, lang) : tag}
 							</span>
 						{/each}
@@ -155,7 +152,7 @@
 						Loading...
 					{:then labels}
 						{#each product.labels_tags as tag, i (i)}
-							<a class="badge flex h-auto items-center break-words" href={'/taxo/labels/' + tag}>
+							<a class="badge h-auto break-words" href={'/taxo/labels/' + tag}>
 								{labels[tag] != null ? getOrDefault(labels[tag].name, lang) : tag}
 							</a>
 						{/each}
@@ -168,7 +165,7 @@
 						Loading...
 					{:then countries}
 						{#each product.countries_tags as tag, i (i)}
-							<a class="badge flex h-auto items-center break-words" href={'/taxo/countries/' + tag}>
+							<a class="badge h-auto break-words" href={'/taxo/countries/' + tag}>
 								{countries[tag] != null ? getOrDefault(countries[tag].name, lang) : tag}
 							</a>
 						{/each}


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description
Added `flex` and `items-center` to ensure proper alignment of content within badges and `break-words` to allow long text to wrap naturally instead of being cut off.

## Screenshots
![WhatsApp Image 2025-04-19 at 16 35 12_48e5219c](https://github.com/user-attachments/assets/be8b1de9-1bf8-4da3-9256-451040c7fd0f)


Fixes #489 

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

