### PR TITLE
fix: data sources overflow from the container on mobile browsers

### DIFF
--- a/src/routes/products/[barcode]/DataSources.svelte
+++ b/src/routes/products/[barcode]/DataSources.svelte
@@ -57,7 +57,7 @@
 				values: { date: formatUnixToDateString(product.created_t) }
 			})}
 		</span>
-		<span class="underline">{product.creator ?? $_('product.datasources.unknown')}</span>
+		<span class="break-all underline">{product.creator ?? $_('product.datasources.unknown')}</span>
 	</p>
 
 	<p class="mt-2 text-sm">
@@ -66,10 +66,12 @@
 				values: { date: formatUnixToDateString(product.last_modified_t) }
 			})}
 		</span>
-		<span class="underline">{product.last_editor ?? $_('product.datasources.unknown')}</span>
+		<span class="break-all underline"
+			>{product.last_editor ?? $_('product.datasources.unknown')}</span
+		>
 	</p>
 
-	<p class="mt-2 text-sm">
+	<p class="mt-2 overflow-hidden text-sm break-words">
 		<span class="text-gray-600 dark:text-gray-300">
 			{$_('product.datasources.also_edited_by')}
 		</span>
@@ -78,8 +80,9 @@
 			<span class="underline">{$_('product.datasources.unknown')}</span>
 		{:else}
 			{#each product.editors_tags as editor, i (i)}
-				<span class="underline"> {String(editor)}</span>{#if i < product.editors_tags.length - 1},
-					&nbsp;
+				<span class="break-all underline">
+					{String(editor)}</span
+				>{#if i < product.editors_tags.length - 1}, &nbsp;
 				{/if}
 			{/each}
 		{/if}
@@ -91,7 +94,9 @@
 				values: { date: formatUnixToDateString(product.last_checked_t) }
 			})}
 		</span>
-		<span class="underline"> {product.checkers_tags[0] ?? $_('product.datasources.unknown')}</span>
+		<span class="break-all underline">
+			{product.checkers_tags[0] ?? $_('product.datasources.unknown')}</span
+		>
 	</p>
 
 	<div class="divider"></div>


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

Added `break-words` and `overflow-hidden` to the paragraph containing editor tags.
Adding `break-all` to all user IDs including product creator, last editor, editors list and the checker

## Screenshots
![WhatsApp Image 2025-04-19 at 17 00 07_eb02de1f](https://github.com/user-attachments/assets/86b9a524-7864-4131-9f79-ce8e9115d582)


Fixes #492 

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).


