### PR TITLE
fix: fixed content overflow on Folksonomy

### DIFF
--- a/src/routes/folksonomy/+page.svelte
+++ b/src/routes/folksonomy/+page.svelte
@@ -205,8 +205,8 @@
 			onclick={() => toggleGroup(group)}
 			onkeydown={(e) => handleGroupKeyDown(e, group)}
 		>
-			<div class="flex items-center gap-2 overflow-hidden">
-				<span class="truncate">{group}</span>
+			<div class="flex items-center gap-2">
+				<span class="break-all">{group}</span>
 				<div class="badge">{keys.length}</div>
 			</div>
 			<button class="btn btn-sm btn-circle" aria-hidden="true">

--- a/src/routes/folksonomy/+page.svelte
+++ b/src/routes/folksonomy/+page.svelte
@@ -104,7 +104,7 @@
 	}
 </script>
 
-<div class="folksonomy-container flex flex-col gap-6 p-4" transition:fade={{ duration: 500 }}>
+<div class="folksonomy-container flex flex-col gap-6 sm:p-4" transition:fade={{ duration: 500 }}>
 	{#snippet headerSection()}
 		<div class="header-section mb-2">
 			<h1 class="text-primary mb-4 text-3xl font-bold">
@@ -198,15 +198,15 @@
 
 	{#snippet groupHeader(group: string, keys: FolksonomyKey[])}
 		<div
-			class="group-header flex cursor-pointer items-center justify-between p-3 text-lg font-semibold"
+			class="group-header flex cursor-pointer items-center justify-between p-3 font-semibold sm:text-lg"
 			role="button"
 			tabindex="0"
 			aria-expanded={expandedGroups[group] ? 'true' : 'false'}
 			onclick={() => toggleGroup(group)}
 			onkeydown={(e) => handleGroupKeyDown(e, group)}
 		>
-			<div class="flex items-center gap-2">
-				<span>{group}</span>
+			<div class="flex items-center gap-2 overflow-hidden">
+				<span class="truncate">{group}</span>
 				<div class="badge">{keys.length}</div>
 			</div>
 			<button class="btn btn-sm btn-circle" aria-hidden="true">


### PR DESCRIPTION

## Description

Fixed the content overflow on Folksonomy 

Before
![image](https://github.com/user-attachments/assets/e5f7cfb7-14da-4448-9b96-ea48a93cb535)

After
![image](https://github.com/user-attachments/assets/c97df6c4-c622-4f26-a76f-b2212d1924b3)


Fixes #501 

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).
