### PR TITLE
fix: Fixed value of set_cookie in Open Prices Auth

### DIFF
--- a/src/lib/api/prices.ts
+++ b/src/lib/api/prices.ts
@@ -49,7 +49,7 @@ export class PricesApi {
 	login(body: { username: string; password: string }) {
 		return this.client.POST('/api/v1/auth', {
 			// @ts-expect-error - The type definition doesn't include set_cookie parameter but the API requires it
-			params: { query: { set_cookie: true } },
+			params: { query: { set_cookie: 1 } },
 			body,
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 			bodySerializer: (body) => new URLSearchParams(body as Record<string, string>)


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context._

In this PR, I am fixing issue with open prices auth API. In Open Prices login API, we should be passing value of set_cookie parameter in the query as 1, but currently we are passing value "true", which is incorrect. 
Due to this, Open Prices server is **not returning any cookie** in the headers of the response.

For reference check below code line and the screenshot:

https://github.com/openfoodfacts/open-prices/blob/ada05e3216ea6bca5b92780a2793c170cfd71a58/open_prices/api/auth/views.py#L39

![Screenshot 2025-04-20 at 1 53 22 AM](https://github.com/user-attachments/assets/19fc4ad9-bda9-4287-abd3-80666e459e4d)

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
