### PR TITLE
feat: added VITE_API_VERSION parameter to test the API in dev mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_FOLKSONOMY_API_URL=https://api.folksonomy.openfoodfacts.net
 VITE_OFF_BASE_URL=https://world.openfoodfacts.org
+VITE_API_VERSION=3

--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -11,7 +11,8 @@ export class ProductsApi {
 	}
 
 	async getProductAttributes(barcode: string): Promise<ProductAttribute[]> {
-		const url = `${API_HOST}/api/v2/product/${barcode}?fields=product_name,code,attribute_groups_en`;
+		const apiVersion = import.meta.env.VITE_API_VERSION || '2';
+		const url = `${API_HOST}/api/v${apiVersion}/product/${barcode}?fields=product_name,code,attribute_groups_en`;
 
 		const res = await this.fetch(url);
 

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -9,5 +9,8 @@ export const USER_AGENT = `Open Food Facts Explorer (${import.meta.env.PACKAGE_V
 
 export const KP_ATTRIBUTE_IMG = (img: string) => `${STATIC_HOST}/images/attributes/dist/${img}`;
 export const TAXONOMY_URL = (taxo: string) => `${STATIC_HOST}/data/taxonomies/${taxo}.json`;
-export const PRODUCT_URL = (barcode: string) => `${API_HOST}/api/v3/product/${barcode}.json`;
+export const PRODUCT_URL = (barcode: string) => {
+	const apiVersion = import.meta.env.VITE_API_VERSION || '3';
+	return `${API_HOST}/api/v${apiVersion}/product/${barcode}.json`;
+};
 export const PRODUCT_IMAGE_URL = (path: string) => `${IMAGE_HOST}/images/products/${path}`;

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -7,7 +7,6 @@
 	import { _ } from '$lib/i18n';
 	import { fade } from 'svelte/transition';
 	import { locale } from '$lib/i18n';
-	import { dev } from '$app/environment';
 
 	interface Props {
 		data: PageData;

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -7,6 +7,7 @@
 	import { _ } from '$lib/i18n';
 	import { fade } from 'svelte/transition';
 	import { locale } from '$lib/i18n';
+	import { dev } from '$app/environment';
 
 	interface Props {
 		data: PageData;


### PR DESCRIPTION



<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context._

Added `VITE_API_VERSION` env variable to `.env.example` with a default value of 3.
Updated the `PRODUCT_URL` function to use the API version from env variables.
Updated the `getProductAttributes` method in `ProductsApi` class to use the API version parameter.

**@VaiTon We must update the README to address the new API version configuration option which would be helpful for the developers to test it.**

![Screenshot 2025-04-20 114443](https://github.com/user-attachments/assets/68f87358-4fde-41f3-9a54-df83f09cf74e)

Fixes #401 

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [ ] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
