### PR TITLE
style: fixed btn's on product page

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -66,17 +66,17 @@
 				{product.product_name ?? product.code}
 			</h1>
 
-			<div class="flex items-center justify-center gap-2">
+			<div class="flex flex-wrap items-center justify-center gap-2">
 				<a
 					href={'https://world.openfoodfacts.org/product/' + product.code}
 					target="_blank"
 					rel="noopener noreferrer"
-					class="link me-4"
+					class="link"
 				>
 					See on OpenFoodFacts
 				</a>
 
-				<button class="btn btn-secondary max-sm:btn-sm mr-2" onclick={addToCalculator}>
+				<button class="btn btn-secondary max-sm:btn-sm" onclick={addToCalculator}>
 					Add to Calculator
 				</button>
 				<a


### PR DESCRIPTION
## Description

The btn's in the product page are overflowing

## Solution
I tested it by using `join`, but they were still overflowing and also `join` was overwriting the border radius properties
![image](https://github.com/user-attachments/assets/21bdf249-ae0d-4237-881b-3f73984aa6dd)
![image](https://github.com/user-attachments/assets/8a0a6a81-734b-4554-8508-2a501c312393)


So solved this issue using `flex-wrap`
![image](https://github.com/user-attachments/assets/dcf41068-76ec-43c8-912a-f7c1902c07fe)

![image](https://github.com/user-attachments/assets/b9dc2808-14bc-46dc-8b26-53f88d73bbbc)


Fixes #498 

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).
