### PR TITLE
feat: nodejs SDK Integration for Folksonomy APIs

### DIFF
--- a/src/lib/api/folksonomy.ts
+++ b/src/lib/api/folksonomy.ts
@@ -1,9 +1,8 @@
 import { preferences } from '$lib/settings';
 import { get } from 'svelte/store';
 
-import type { paths, components } from './folksonomy.d';
-import createClient from 'openapi-fetch';
-import { formBody as formBodySerializer } from './utils';
+import type { components } from './folksonomy.d';
+import { Folksonomy } from '@openfoodfacts/openfoodfacts-nodejs';
 
 export type FolksonomyTag = components['schemas']['ProductTag'];
 export type FolksonomyKey = {
@@ -18,76 +17,17 @@ export function isConfigured() {
 	return BASE_URL != null;
 }
 
-export class FolksonomyApi {
-	private client: ReturnType<typeof createClient<paths>>;
+export const createFolksonomyApi = (fetch: typeof window.fetch): Folksonomy => {
+	const folksonomyApi = new Folksonomy(fetch, {
+		baseUrl: BASE_URL,
+		authToken: `${get(preferences).folksonomy.authToken}`
+	});
+	return folksonomyApi;
+};
 
-	constructor(fetch: typeof window.fetch) {
-		this.client = createClient({
-			baseUrl: BASE_URL,
-			fetch,
-			headers: {
-				'Content-Type': 'application/json',
-				Authorization: 'Bearer ' + get(preferences).folksonomy.authToken
-			}
-		});
-	}
-
-	async getKeys(): Promise<FolksonomyKey[]> {
-		const res = await this.client.GET('/keys');
-		return res.data as FolksonomyKey[];
-	}
-
-	async getProducts(key: string, value?: string) {
-		const res = await this.client.GET('/products', { params: { query: { k: key, v: value } } });
-		return res.data;
-	}
-
-	async putTag(tag: FolksonomyTag): Promise<boolean> {
-		const res = await this.client.PUT('/product', { body: tag });
-		return res.response.status === 200;
-	}
-
-	async getProduct(barcode: string) {
-		const res = await this.client.GET('/product/{product}', {
-			params: { path: { product: barcode } }
-		});
-
-		return res;
-	}
-
-	async addTag(tag: FolksonomyTag): Promise<boolean> {
-		const res = await this.client.POST('/product', {
-			body: tag
-		});
-
-		return res.response.status === 200;
-	}
-
-	async removeTag(tag: FolksonomyTag & { version: number }) {
-		const res = await this.client.DELETE('/product/{product}/{k}', {
-			params: {
-				path: { product: tag.product, k: tag.k },
-				query: { version: tag.version }
-			}
-		});
-
-		return res;
-	}
-
-	async login(username: string, password: string) {
-		const res = await this.client.POST('/auth', {
-			// @ts-expect-error - I could not find why "scope" is needed here
-			body: { username, password },
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-			bodySerializer: formBodySerializer
-		});
-
-		if (res.response.status !== 200) throw new Error('Could not authenticate to Folksonomy API');
-
-		const token = res.data as { access_token: string; token_type: string };
-		preferences.update((p) => ({
-			...p,
-			folksonomy: { ...p.folksonomy, authToken: token.access_token }
-		}));
-	}
-}
+export const updateFolksonomyAuthToken = (token: string | null) => {
+	preferences.update((p) => ({
+		...p,
+		folksonomy: { ...p.folksonomy, authToken: token }
+	}));
+};

--- a/src/routes/folksonomy/+page.ts
+++ b/src/routes/folksonomy/+page.ts
@@ -1,11 +1,11 @@
-import { FolksonomyApi } from '$lib/api/folksonomy';
+import { createFolksonomyApi } from '$lib/api/folksonomy';
 import type { PageLoad } from '../$types';
 
 export const ssr = false;
 
 export const load: PageLoad = async ({ fetch }) => {
-	const api = new FolksonomyApi(fetch);
-	const keys = await api.getKeys();
+	const folksonomyApi = createFolksonomyApi(fetch);
+	const keys = await folksonomyApi.getKeys();
 
 	return {
 		keys

--- a/src/routes/folksonomy/[key]/+page.ts
+++ b/src/routes/folksonomy/[key]/+page.ts
@@ -1,12 +1,13 @@
 import { ProductsApi } from '$lib/api';
-import { FolksonomyApi } from '$lib/api/folksonomy';
+import { createFolksonomyApi } from '$lib/api/folksonomy';
 import type { PageLoad } from './$types';
 
 export const ssr = false;
 
 export const load: PageLoad = async ({ fetch, params }) => {
 	const { key } = params;
-	const tags = (await new FolksonomyApi(fetch).getProducts(key)) ?? [];
+	const folksonomyApi = createFolksonomyApi(fetch);
+	const tags = (await folksonomyApi.getProducts(key)) ?? [];
 
 	const productsApi = new ProductsApi(fetch);
 	const products = Promise.all(tags.map((tag) => productsApi.getProductName(tag.product)));

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -219,7 +219,7 @@
 			</h1>
 
 			<Folksonomy
-				tags={data.tags?.data ?? []}
+				tags={data.tags ?? []}
 				keys={data.keys.map((it) => it.k)}
 				barcode={product.code}
 			/>

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -10,7 +10,7 @@ import {
 	ProductsApi
 } from '$lib/api';
 import { error } from '@sveltejs/kit';
-import { FolksonomyApi } from '$lib/api/folksonomy';
+import { createFolksonomyApi } from '$lib/api/folksonomy';
 import { createPricesApi, isConfigured as isPriceConfigured } from '$lib/api/prices';
 
 export const ssr = false;
@@ -33,7 +33,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
 
 	const off = new OpenFoodFacts(fetch);
 
-	const folkApi = new FolksonomyApi(fetch);
+	const folkApi = createFolksonomyApi(fetch);
 	const folksonomyTags = folkApi.getProduct(params.barcode);
 	const folksonomyKeys = folkApi.getKeys();
 

--- a/src/routes/products/[barcode]/Folksonomy.svelte
+++ b/src/routes/products/[barcode]/Folksonomy.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { FolksonomyApi, type FolksonomyTag } from '$lib/api/folksonomy';
+	import { createFolksonomyApi, type FolksonomyTag } from '$lib/api/folksonomy';
 	import { preferences } from '$lib/settings';
 
 	interface Props {
@@ -11,11 +11,12 @@
 	let { tags = $bindable(), barcode, keys }: Props = $props();
 
 	async function refreshTags() {
-		const res = await new FolksonomyApi(fetch).getProduct(barcode);
+		const folksonomyApi = createFolksonomyApi(fetch);
+		const res = await folksonomyApi.getProduct(barcode);
 		if (res.error) {
 			console.error(res.error);
 		} else {
-			tags = res.data;
+			tags = res;
 		}
 	}
 
@@ -36,7 +37,9 @@
 			v: newValue
 		};
 
-		const ok = await new FolksonomyApi(fetch).putTag(newTag);
+		const folksonomyApi = createFolksonomyApi(fetch);
+
+		const ok = await folksonomyApi.putTag(newTag);
 		if (!ok) {
 			console.error('Failed to update tag', oldTag, 'to', newTag);
 			return;
@@ -53,7 +56,9 @@
 			throw new Error('Tag value is null');
 		}
 		// otherwise ts complains about version possibly being null
-		new FolksonomyApi(fetch).removeTag({ ...tag, version });
+		const folksonomyApi = createFolksonomyApi(fetch);
+
+		folksonomyApi.removeTag({ ...tag, version });
 	}
 
 	let newKey = $state('');
@@ -77,7 +82,9 @@
 			owner: ''
 		};
 
-		const created = await new FolksonomyApi(fetch).addTag(newTag);
+		const folksonomyApi = createFolksonomyApi(fetch);
+
+		const created = await folksonomyApi.addTag(newTag);
 
 		if (created) {
 			tags = [...tags, newTag];

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -3,7 +3,7 @@
 	import { preferences } from '$lib/settings';
 	import Influence from './Influence.svelte';
 	import Heading from './Heading.svelte';
-	import { FolksonomyApi } from '$lib/api/folksonomy';
+	import { createFolksonomyApi, updateFolksonomyAuthToken } from '$lib/api/folksonomy';
 	import { _ } from '$lib/i18n';
 	import { fade } from 'svelte/transition';
 	import { locale } from '$lib/i18n';
@@ -25,11 +25,14 @@
 		if (username == null || password == null) throw new Error('Username or password is null');
 
 		try {
-			await new FolksonomyApi(fetch).login(username, password);
+			const folksonomyApi = createFolksonomyApi(fetch);
+			const response = await folksonomyApi.login(username, password);
 			loginStatus = true;
 			setTimeout(() => {
 				loginStatus = undefined;
 			}, 3000);
+
+			updateFolksonomyAuthToken(response?.token?.access_token ?? null);
 		} catch (error) {
 			console.error('Error while logging in', error);
 			loginStatus = false;


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context._
- Removed direct API calls to Folksonomy in entire Explorer project.
- Replaced it with respective Nodejs SDK.
- Fixed issue with showing tags for a product. Initially tags list was not showing any data on product page.
- Fixed folksonomy login in settings and properly saved the authToken in local storage as required.

Before these changes: null was getting stored in localstorage as authToken for folksonomy.
<img width="853" alt="Screenshot 2025-04-29 at 10 35 31 PM" src="https://github.com/user-attachments/assets/582cf457-4a39-478d-b946-cafd34e76f8f" />

After fixes:
<img width="1276" alt="Screenshot 2025-04-30 at 12 04 59 AM" src="https://github.com/user-attachments/assets/d6b388da-e16a-4ca8-94c4-279e210cac05" />

<img width="1267" alt="Screenshot 2025-04-30 at 12 05 19 AM" src="https://github.com/user-attachments/assets/79656a25-89ba-42de-9b07-a4b95aa65fe7" />


Fixes # (issue)
- #270 
---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
