### PR TITLE
fix: Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,5 +1,9 @@
 name: '📋 Semantic Pull Requests'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-explorer/security/code-scanning/3](https://github.com/openfoodfacts/openfoodfacts-explorer/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow is validating pull request titles and does not appear to require write access, we will set the permissions to `contents: read` and `pull-requests: read`. This ensures the `GITHUB_TOKEN` has only the minimal permissions necessary for the task.

The `permissions` block will be added at the root level of the workflow, so it applies to all jobs. This is appropriate because the workflow contains only one job (`main`), and there is no indication that additional jobs with different permissions will be added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
