### PR TITLE
fix: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -1,5 +1,9 @@
 name: Automatically add relevant issues to the relevant GitHub projects
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   issues:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-explorer/security/code-scanning/2](https://github.com/openfoodfacts/openfoodfacts-explorer/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with GitHub projects and issues, the permissions should include `contents: read` and `issues: write`. Adding the `permissions` block at the root level of the workflow ensures that all jobs inherit these permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
