### PR TITLE
fix: updated prices link in navbar

### DIFF
--- a/src/lib/ui/Navbar.svelte
+++ b/src/lib/ui/Navbar.svelte
@@ -7,7 +7,7 @@
 		{ name: 'discover_link', href: '/static/discover' },
 		{ name: 'contribute_link', href: '/static/contribute' },
 		{ name: 'producers_link', href: '/static/producers' },
-		{ name: 'prices_link', href: '#' },
+		{ name: 'prices_link', href: 'https://prices.openfoodfacts.org' },
 		{ name: 'folksonomy_link', href: '/folksonomy' }
 	];
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -157,7 +157,7 @@
 			<a class="btn btn-outline link" href="/static/producers">
 				{$_('producers_link')}
 			</a>
-			<a class="btn btn-outline link" href="#">
+			<a class="btn btn-outline link" href="https://prices.openfoodfacts.org">
 				{$_('prices_link')}
 			</a>
 			<a class="btn btn-outline link" href="/folksonomy">


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

Added link to the "Prices" item in the navbar. The link navigates to "https://prices.openfoodfacts.org".

Fixes # (issue)

- https://github.com/openfoodfacts/openfoodfacts-explorer/issues/581
- https://github.com/orgs/openfoodfacts/projects/157/views/1?pane=issue&itemId=113986079&issue=openfoodfacts%7Copenfoodfacts-explorer%7C532

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
