### PR TITLE
fix(dev): allow to view edit page when not logged in

### DIFF
--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -22,6 +22,7 @@
 	import { PRODUCT_IMAGE_URL, PRODUCT_STATUS } from '$lib/const';
 	import { page } from '$app/state';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
+	import { dev } from '$app/environment';
 
 	interface Props {
 		data: PageData;
@@ -534,6 +535,22 @@
 		handleCommentChange
 	});
 </script>
+
+{#if dev}
+	<div class="alert alert-warning my-8 text-lg" role="alert">
+		<span class="icon-[mdi--alert]"></span>
+		<div>
+			<p>
+				<strong> You are not logged in! </strong>
+				This means that the product will not be saved to the database.
+			</p>
+			<p class="text-sm">
+				We allow opening this page because you're in development mode, but the submit button will
+				not work.
+			</p>
+		</div>
+	</div>
+{/if}
 
 <div class="space-y-8">
 	<!-- Super Title -->

--- a/src/routes/products/[barcode]/edit/+page.ts
+++ b/src/routes/products/[barcode]/edit/+page.ts
@@ -15,6 +15,7 @@ import { userInfo } from '$lib/stores/pkceLoginStore';
 import { PRODUCT_STATUS } from '$lib/const';
 
 import type { PageLoad } from './$types';
+import { dev } from '$app/environment';
 
 export const ssr = false;
 
@@ -23,7 +24,9 @@ export const load = (async ({ fetch, params }) => {
 		error(500, 'This page requires a browser environment');
 	}
 
-	if (get(userInfo) == null) {
+	if (get(userInfo) == null && !dev) {
+		// If the user is not logged in, redirect to the login page
+		// We allow an exception for development mode
 		error(401, 'You must be logged in to view this page');
 	}
 


### PR DESCRIPTION
Allow viewing the edit page even when not logged, when in vite dev mode, to allow development work without having to configure oauth.
