### PR TITLE
feat: add robotoff-contribution-message webcomponent to product page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ PUBLIC_AUTH_BASE_URL=https://auth.openfoodfacts.net
 PUBLIC_AUTH_PKCE_ID=test_public_client
 PUBLIC_KEYCLOAK_REALM=test_tealm
 VITE_PRICES_API_URL=https://prices.openfoodfacts.org
+
+PUBLIC_ROBOTOFF_URL=https://robotoff.openfoodfacts.net/
+PUBLIC_IMAGES_URL=https://images.openfoodfacts.net/

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -41,3 +41,6 @@ export const SORT_OPTIONS = [
 ];
 
 export const NO_MARGIN_ROUTES = ['/static/discover', '/static/contribute', '/static/producers'];
+
+export const MATOMO_SITE_ID = 17;
+export const MATOMO_HOST = 'https://analytics.openfoodfacts.org';

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,13 +1,16 @@
 import {
 	PUBLIC_AUTH_BASE_URL,
 	PUBLIC_AUTH_PKCE_ID,
-	PUBLIC_KEYCLOAK_REALM
+	PUBLIC_IMAGES_URL,
+	PUBLIC_KEYCLOAK_REALM,
+	PUBLIC_ROBOTOFF_URL
 } from '$env/static/public';
+
+export { PUBLIC_ROBOTOFF_URL as ROBOTOFF_URL, PUBLIC_IMAGES_URL as IMAGE_HOST };
 
 export const STATIC_HOST = 'https://static.openfoodfacts.org';
 export const API_HOST = import.meta.env.VITE_OFF_BASE_URL || 'https://world.openfoodfacts.org';
 export const SEARCH_URL = `${API_HOST}/api/v2/search`;
-export const IMAGE_HOST = 'https://images.openfoodfacts.org';
 export const PRODUCT_EDIT_URL = `${API_HOST}/product/`;
 export const PRODUCT_REPORT_URL = `${API_HOST}/product/`;
 
@@ -19,7 +22,7 @@ export const USER_AGENT = `Open Food Facts Explorer (${import.meta.env.PACKAGE_V
 export const KP_ATTRIBUTE_IMG = (img: string) => `${STATIC_HOST}/images/attributes/dist/${img}`;
 export const TAXONOMY_URL = (taxo: string) => `${STATIC_HOST}/data/taxonomies/${taxo}.json`;
 export const PRODUCT_URL = (barcode: string) => `${API_HOST}/api/v3/product/${barcode}.json`;
-export const PRODUCT_IMAGE_URL = (path: string) => `${IMAGE_HOST}/images/products/${path}`;
+export const PRODUCT_IMAGE_URL = (path: string) => `${PUBLIC_IMAGES_URL}/images/products/${path}`;
 export const PRODUCT_STATUS = {
 	EMPTY: 'empty'
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 	import SearchBar from '$lib/ui/SearchBar.svelte';
 
 	import { initI18n, _, isLoading } from '$lib/i18n';
-	import { KEYCLOAK_ACCOUNT_URL, NO_MARGIN_ROUTES } from '$lib/const';
+	import { KEYCLOAK_ACCOUNT_URL, MATOMO_HOST, MATOMO_SITE_ID, NO_MARGIN_ROUTES } from '$lib/const';
 	import { userInfo } from '$lib/stores/pkceLoginStore';
 	import { extractQuery } from '$lib/facets';
 	import { dev } from '$app/environment';
@@ -69,7 +69,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 </svelte:head>
 
-<Matomo url="https://analytics.openfoodfacts.org" siteId={17} />
+<Matomo url={MATOMO_HOST} siteId={MATOMO_SITE_ID} />
 
 {#if !$isLoading}
 	<!-- Global OpenFoodFacts Web Components Configuration -->

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,6 +20,7 @@
 	import { KEYCLOAK_ACCOUNT_URL, NO_MARGIN_ROUTES } from '$lib/const';
 	import { userInfo } from '$lib/stores/pkceLoginStore';
 	import { extractQuery } from '$lib/facets';
+	import { dev } from '$app/environment';
 
 	onMount(async () => {
 		await import('@openfoodfacts/openfoodfacts-webcomponents');
@@ -72,7 +73,15 @@
 
 {#if !$isLoading}
 	<!-- Global OpenFoodFacts Web Components Configuration -->
-	<off-webcomponents-configuration language-code="en" assets-images-path="assets/webcomponents">
+	<off-webcomponents-configuration
+		language-code="en"
+		assets-images-path="/assets/webcomponents"
+		robotoff-configuration={{
+			dryRun: !dev,
+			apiUrl: 'https://robotoff.openfoodfacts.net/api/v1',
+			imgUrl: 'https://images.openfoodfacts.net/images/products'
+		}}
+	>
 	</off-webcomponents-configuration>
 
 	<div class="flex justify-center">

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -5,7 +5,6 @@
 
 	import KnowledgePanels from '$lib/knowledgepanels/Panels.svelte';
 	import Card from '$lib/ui/Card.svelte';
-	import Debug from '$lib/ui/Debug.svelte';
 	import Metadata from '$lib/Metadata.svelte';
 
 	import ProductAttributes from './ProductAttributes.svelte';
@@ -17,6 +16,7 @@
 
 	import type { PageData } from './$types';
 	import Prices from './Prices.svelte';
+	import { userInfo } from '$lib/stores/pkceLoginStore';
 
 	type Props = { data: PageData };
 
@@ -33,6 +33,9 @@
 
 <div class="flex flex-col gap-4">
 	<ProductHeader {product} taxonomies={data.taxo} />
+
+	<robotoff-contribution-message product-code={product.code} is-logged-in={$userInfo != null}
+	></robotoff-contribution-message>
 
 	<ProductAttributes {productAttributes} />
 
@@ -59,14 +62,4 @@
 			/>
 		</Card>
 	{/if}
-
-	<Card>
-		{#await data?.questions}
-			Loading...
-		{:then questions}
-			<h1 class="my-4 text-2xl font-bold sm:text-4xl">Questions</h1>
-
-			<Debug data={questions} />
-		{/await}
-	</Card>
 </div>

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
-import { OpenFoodFacts, PricesApi } from '@openfoodfacts/openfoodfacts-nodejs';
+import { PricesApi } from '@openfoodfacts/openfoodfacts-nodejs';
 
 import {
 	type Brand,
@@ -41,7 +41,6 @@ async function getPricesCoords(api: PricesApi, code: string) {
 
 export const load: PageLoad = async ({ params, fetch }) => {
 	const productsApi = new ProductsApi(fetch);
-	const off = new OpenFoodFacts(fetch);
 	const folkApi = createFolksonomyApi(fetch);
 
 	const state = await productsApi.getProduct(params.barcode);
@@ -66,21 +65,6 @@ export const load: PageLoad = async ({ params, fetch }) => {
 
 	const productAttributes = await productsApi.getProductAttributes(params.barcode);
 
-	// TODO: parseInt should be removed. Barcodes are strings
-	const questions = off.robotoff.questionsByProductCode(parseInt(params.barcode)).then(
-		(res) => {
-			if (res?.status === 'found') {
-				return res.questions ?? [];
-			} else {
-				return [];
-			}
-		},
-		(e) => {
-			console.error(e);
-			return [];
-		}
-	);
-
 	return {
 		state,
 		productAttributes: productAttributes,
@@ -94,7 +78,6 @@ export const load: PageLoad = async ({ params, fetch }) => {
 			countries,
 			origins
 		},
-		prices: await pricesResponse,
-		questions
+		prices: await pricesResponse
 	};
 };


### PR DESCRIPTION
## Description

- Replace broken robotoff integration with the robotoff-contribution-message webcomponent. 
- Add field to off-webcomponents-configuration to enable robotoff component usage.
- Move Matomo fields to constants file

## Example

- https://openfoodfacts-explorer-git-robotoff-webcomponent-openfoodfacts.vercel.app/products/5056737900163
