### PR TITLE
feat: implement ResizableImage component

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
 		"@typescript-eslint/eslint-plugin": "^8.39.0",
 		"@typescript-eslint/parser": "^8.39.0",
 		"@vercel/speed-insights": "^1.2.0",
-		"@zoom-image/core": "^0.41.0",
-		"@zoom-image/svelte": "^0.3.4",
 		"cytoscape": "^3.33.0",
 		"daisyui": "5.0.50",
 		"eslint": "^9.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,12 +75,6 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.2.0(@sveltejs/kit@2.27.3(@sveltejs/vite-plugin-svelte@6.1.1(svelte@5.38.0)(vite@7.1.1(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.38.0)(vite@7.1.1(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.38.0)
-      '@zoom-image/core':
-        specifier: ^0.41.0
-        version: 0.41.0
-      '@zoom-image/svelte':
-        specifier: ^0.3.4
-        version: 0.3.4(svelte@5.38.0)
       cytoscape:
         specifier: ^3.33.0
         version: 3.33.0
@@ -673,9 +667,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@namnode/store@0.1.0':
-    resolution: {integrity: sha512-4NGTldxKcmY0UuZ7OEkvCjs8ZEoeYB6M2UwMu74pdLiFMKxXbj9HdNk1Qn213bxX1O7bY5h+PLh5DZsTURZkYA==}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1074,14 +1065,6 @@ packages:
 
   '@webcomponents/webcomponentsjs@2.8.0':
     resolution: {integrity: sha512-loGD63sacRzOzSJgQnB9ZAhaQGkN7wl2Zuw7tsphI5Isa0irijrRo6EnJii/GgjGefIFO8AIO7UivzRhFaEk9w==}
-
-  '@zoom-image/core@0.41.0':
-    resolution: {integrity: sha512-LAxGru91286gFmyiQB4RjM277YOWxJX+OZcwtIH/N0dyo73y4NfaAE1eGVdnhjxEYv7yVV3xToMyYnm+uQboTw==}
-
-  '@zoom-image/svelte@0.3.4':
-    resolution: {integrity: sha512-8cPkFUjh+t3/eYkoT2krvz8hoFiXoiYZKpcHOnYCHLhEwaHr1yjgXg/ttWehotVH9V3Z51JQgIcGF3uhYWKB/Q==}
-    peerDependencies:
-      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -3129,8 +3112,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@namnode/store@0.1.0': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3537,15 +3518,6 @@ snapshots:
       svelte: 5.38.0
 
   '@webcomponents/webcomponentsjs@2.8.0': {}
-
-  '@zoom-image/core@0.41.0':
-    dependencies:
-      '@namnode/store': 0.1.0
-
-  '@zoom-image/svelte@0.3.4(svelte@5.38.0)':
-    dependencies:
-      '@zoom-image/core': 0.41.0
-      svelte: 5.38.0
 
   abbrev@3.0.1: {}
 

--- a/src/lib/ui/ImageModal.svelte
+++ b/src/lib/ui/ImageModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { useZoomImageWheel } from '@zoom-image/svelte';
+	import ResizableImage from './ResizableImage.svelte';
 
 	type ImageState = { url: string; alt?: string };
 	let image: ImageState | undefined = $state();
@@ -48,29 +47,11 @@
 		rotation = rotation - 90;
 	}
 
-	let container: HTMLDivElement | undefined = $state();
-	const { createZoomImage, setZoomImageState, zoomImageState } = useZoomImageWheel();
-
-	$effect(() => {
-		setZoomImageState?.({ currentZoom: zoomLevel, currentRotation: rotation });
-	});
-
-	onMount(() => {
-		if (container) {
-			createZoomImage(container, {
-				maxZoom: MAX_ZOOM,
-				wheelZoomRatio: 0.5,
-				shouldZoomOnSingleTouch: () => true
-			});
-			zoomImageState.subscribe((state) => {
-				zoomLevel = state.currentZoom;
-			});
-		}
-	});
+	let imageEl: ResizableImage;
 </script>
 
 <dialog
-	class="border-base-300 bg-base-100 fixed inset-0 m-auto h-[90vh] w-[90vw] rounded-xl border p-0 shadow-lg"
+	class="border-base-300 bg-base-100 h-screen max-h-screen w-screen max-w-screen border p-0 shadow-lg md:inset-0 md:m-auto md:h-[90vh] md:w-[90vw] md:rounded-xl"
 	bind:this={dialog}
 	onclose={() => (image = undefined)}
 	onclick={(e) => {
@@ -80,13 +61,15 @@
 	}}
 >
 	<div class="relative flex h-full w-full flex-col">
-		<div
-			bind:this={container}
-			class="flex h-full w-full cursor-move items-center justify-center overflow-hidden p-6"
-		>
-			<img class="max-h-[85vh] max-w-[85vw] object-contain" src={image?.url} alt={image?.alt} />
+		<div class="h-full w-full p-5">
+			<ResizableImage
+				src={image?.url}
+				alt={image?.alt ?? 'Image'}
+				bind:zoom={zoomLevel}
+				bind:rotation
+				bind:this={imageEl}
+			/>
 		</div>
-
 		<div class="absolute right-2 z-10 flex h-full flex-col items-center justify-center gap-2">
 			<button
 				class="btn btn-circle btn-md bg-base-100/80 hover:bg-base-100"
@@ -98,7 +81,7 @@
 				<span class="icon-[mdi--magnify-plus-outline] h-6 w-6"></span>
 			</button>
 			<button
-				class="btn bg-base-100/80 hover:bg-base-100 text-md px-2 py-2 font-medium text-white"
+				class="btn bg-base-100/80 hover:bg-base-100 text-md text-base-content px-2 py-2 font-medium"
 				onclick={resetZoom}
 			>
 				{zoomLevel.toFixed(1)} x
@@ -128,7 +111,7 @@
 			</button>
 		</div>
 
-		<div class="absolute right-2 bottom-2 z-10 flex gap-2">
+		<div class="absolute bottom-2 z-10 flex w-full justify-between gap-2 px-4 md:justify-end">
 			<button
 				class="btn btn-circle btn-md bg-base-100/80 hover:bg-base-100"
 				onclick={rotateLeft}
@@ -152,14 +135,6 @@
 <style>
 	dialog[open] {
 		animation: zoom 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-	}
-	@keyframes zoom {
-		from {
-			transform: scale(0.95);
-		}
-		to {
-			transform: scale(1);
-		}
 	}
 	dialog[open]::backdrop {
 		animation: fade 0.2s ease-out;

--- a/src/lib/ui/ResizableImage.svelte
+++ b/src/lib/ui/ResizableImage.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type Props = {
+		src?: string;
+		alt?: string;
+		zoom?: number;
+		rotation?: number;
+		minzoom?: number;
+		maxzoom?: number;
+	};
+	let {
+		src,
+		alt,
+		zoom = $bindable(1),
+		rotation = $bindable(0),
+		minzoom = 1,
+		maxzoom = 3
+	}: Props = $props();
+
+	let imgEl: HTMLImageElement | undefined;
+
+	onMount(() => {
+		const wheelListener = (e: WheelEvent) => {
+			e.preventDefault();
+			if (e.deltaY < 0) {
+				zoom = Math.min(zoom + 0.1, maxzoom);
+			} else {
+				zoom = Math.max(zoom - 0.1, minzoom);
+			}
+		};
+
+		imgEl?.addEventListener('wheel', wheelListener);
+
+		return () => {
+			imgEl?.removeEventListener('wheel', wheelListener);
+		};
+	});
+</script>
+
+<div class="relative flex h-full w-full max-w-full items-center justify-center overflow-hidden">
+	<img
+		class="image"
+		{src}
+		{alt}
+		style={`transform: scale(${zoom}) rotate(${rotation}deg);`}
+		bind:this={imgEl}
+	/>
+</div>


### PR DESCRIPTION
### Description

- Drop external zoom-image dependency
- Implement ResizableImage and use it in ImageModal
- Improve mobile UX

This drastically simplifies code and uses Svelte native binds and reactivity.