### PR TITLE
fix: increase price tooltip z-index in search page

### DIFF
--- a/src/routes/products/search/+page.svelte
+++ b/src/routes/products/search/+page.svelte
@@ -228,7 +228,7 @@
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<div class="indicator block w-full">
 						{#if showPrices}
-							<span class="indicator-item badge badge-secondary badge-sm right-4">
+							<span class="indicator-item badge badge-secondary badge-sm right-4 z-20">
 								{data.prices[scoredProduct.product.code]} prices
 							</span>
 						{/if}


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

Gave price-tooltip z-index 20 to not be hidden when personalised search enabled

## Screenshots 
Before:
<img width="1572" height="1098" alt="Screenshot 2025-08-22 at 10 53 49 PM" src="https://github.com/user-attachments/assets/fa92db05-53b7-4a79-892b-4315a02be6b0" />

After:
<img width="1701" height="1041" alt="Screenshot 2025-08-22 at 10 52 51 PM" src="https://github.com/user-attachments/assets/6190c625-589b-4b87-aa23-6647b8a27ac8" />

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
