### PR TITLE
ci: Add devcontainers group to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,13 +18,13 @@ updates:
         patterns: ['*']
         update-types: ['minor', 'patch']
 
-  - package-ecosystem: "devcontainers"
-    directory: "/"
+  - package-ecosystem: 'devcontainers'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     allow:
-      - dependency-type: "all"
+      - dependency-type: 'all'
     groups:
       devcontainers:
         patterns:
-          - "*"
+          - '*'


### PR DESCRIPTION
- ci: Add devcontainers configuration to dependabot
- stolen from @john-gom 

  - package-ecosystem: "devcontainers"
    directory: "/"
    schedule:
      interval: "monthly"
    allow:
      - dependency-type: "all"
    groups:
      devcontainers:
        patterns:
          - "*"