### PR TITLE
ci: add permissions block to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
+name: CI
+
 permissions:
   contents: read
-name: CI
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-explorer/security/code-scanning/14](https://github.com/openfoodfacts/openfoodfacts-explorer/security/code-scanning/14)

To fix the problem, add an explicit `permissions` block restricting the `contents` permission to `read` at either the workflow root or at each job level. Since none of the jobs or steps modify repository contents, issues, or pull requests, the minimal required permission is `contents: read`. You should edit the `.github/workflows/ci.yml` file and add the following block at the workflow (top) level, right under the workflow name. No additional imports or dependencies are needed. This provides least-privilege for all jobs within the workflow unless jobs specifically override permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
