### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     name: 'Dependency Review'
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
 
     steps:
       - name: 'Checkout Repository'


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-explorer/security/code-scanning/16](https://github.com/openfoodfacts/openfoodfacts-explorer/security/code-scanning/16)

To fix this issue, the workflow file should explicitly define the permissions for each job or at the workflow root. In this case, CodeQL highlights the `dependency-review` job as missing a `permissions` block, and recommends at least restricting to `contents: read`. The fix is to add a `permissions:` section under the `dependency-review` job, setting `contents: read`. To maximize clarity and least privilege, we add:

```yaml
permissions:
  contents: read
```

directly below the `runs-on` and `if` lines (as appropriate placement according to YAML and Actions specification). No other changes, imports, or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
