### PR TITLE
added the class to define height

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -176,6 +176,7 @@
 							personalScore={$personalizedSearch.classifyProductsEnabled
 								? scoredProduct.scoreData
 								: undefined}
+							class="h-[11rem] w-full"
 						></product-card>
 					{/each}
 				{/await}


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description
 
Added back the class that defiend the product-card size which was removed due to https://github.com/openfoodfacts/openfoodfacts-explorer/pull/600

Fixes # (issue)

https://github.com/openfoodfacts/openfoodfacts-explorer/issues/722
---
## Screenshots
Before
<img width="1434" height="1234" alt="Screenshot 2025-08-30 at 12 13 39 AM" src="https://github.com/user-attachments/assets/fe2149a8-186b-49c5-bf40-1d6e9fd0e820" />

After
<img width="1310" height="965" alt="Screenshot 2025-08-30 at 12 12 34 AM" src="https://github.com/user-attachments/assets/dcbe7246-18ad-48bc-904c-3ba954d3ff91" />

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
