### PR TITLE
fix: Close button visibility bug in preferences form on settings page

### DIFF
--- a/src/lib/ui/PreferencesForm.svelte
+++ b/src/lib/ui/PreferencesForm.svelte
@@ -26,7 +26,7 @@
 		showClassifyToggle = true,
 		classifyProducts = $personalizedSearch.classifyProductsEnabled,
 		onClassifyToggle = () => {},
-		onClose = () => {},
+		onClose,
 		attributeGroups = []
 	}: PreferencesFormProps = $props();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

Close button was visible on settings page, which is not intended.

## Screenshot
<img width="1728" height="682" alt="Screenshot 2025-09-01 at 9 41 33 PM" src="https://github.com/user-attachments/assets/1d429af4-72f9-4218-a983-a63eef6b3525" />


## Checklist:
**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
