### PR TITLE
fix: include product_type in product API request

### DIFF
--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -39,6 +39,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
 	const folkApi = createFolksonomyApi(fetch);
 
 	const { data: state, error: apiError } = await productsApi.getProductV3(params.barcode, {
+		product_type: 'all',
 		fields: ['all', 'knowledge_panels']
 	});
 


### PR DESCRIPTION
In #691 I replaced the better part of the API layer with the SDK, but forgot to include this parameter.