### PR TITLE
docs: add first-time setup notes for dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ First, install dependencies:
 pnpm install
 ```
 
+### First-time Setup Notes
+
+- The first `pnpm run dev` may take 1–2 minutes. This is normal.
+- The dev server keeps running after startup — this does not mean it is stuck.
+- You may see a warning about `.svelte-kit/tsconfig.json` on first run.
+  This file is generated automatically and the warning can be safely ignored.
+- Once ready, Vite will print a local URL such as `http://localhost:5173`.
+
 ### Environment Variables Setup
 
 Before running the project, set up the environment variables:


### PR DESCRIPTION
Adds helpful notes for first-time contributors to understand
what to expect during the first `pnpm run dev` and tsconfig warnings.