### PR TITLE
fix(ui): align search bar and scan button on mobile

### DIFF
--- a/src/lib/ui/SearchBar.svelte
+++ b/src/lib/ui/SearchBar.svelte
@@ -108,12 +108,12 @@
 </script>
 
 <div class="form-control">
-	<div>
-		<div class="join dropdown dropdown-bottom dropdown-center md:w-98">
+	<div class="flex w-full items-center gap-2">
+		<div class="join dropdown dropdown-bottom dropdown-center min-w-0 flex-1 md:w-98 md:flex-none">
 			<input
 				type="text"
 				bind:value={searchQuery}
-				class="input join-item input-bordered xl:w-full"
+				class="input join-item input-bordered w-full"
 				placeholder={$_('search.placeholder')}
 				disabled={loading}
 				aria-label={$_('search.placeholder')}
@@ -176,7 +176,7 @@
 			href="/qr"
 			title={$_('search.scan')}
 			aria-label={$_('search.scan')}
-			class="btn btn-secondary join-item ms-2 text-lg"
+			class="btn btn-secondary join-item text-lg"
 		>
 			<IconMdiBarcodeScan class="h-6 w-6" />
 		</a>


### PR DESCRIPTION
## Description

Fixed a UI layout issue on mobile screens (specifically smaller viewports like iPhone SE) where the barcode scan button would wrap to the next line below the search bar, breaking the layout.

**Changes:**
- Refactored `SearchBar.svelte` to use a Flexbox container (`flex items-center gap-2`).
- Set the search input to `flex-1` so it dynamically resizes to fill available space without pushing the scan button out of the row.
- Replaced manual margins with `gap-2` for consistent spacing.

**Screenshots:**

<img width="2160" height="2700" alt="image" src="https://github.com/user-attachments/assets/894dc074-9536-4c94-adf6-340b25ee8a87" />


---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.