### PR TITLE
fix(ui): auto-close mobile menu and align folksonomy search

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -144,6 +144,13 @@
 	let searchActive = $state(false);
 	let accordionOpen = $state(false);
 
+	// Automatically close mobile menu on navigation
+	$effect(() => {
+		// track dependency
+		const _ = page.url.pathname;
+		accordionOpen = false;
+	});
+
 	let config: HTMLElement;
 
 	onMount(() => {

--- a/src/routes/folksonomy/+page.svelte
+++ b/src/routes/folksonomy/+page.svelte
@@ -121,15 +121,15 @@
 
 			<div class="search-section mb-6">
 				<div class="form-control">
-					<div class="input-group">
+					<div class="join w-full max-w-md">
 						<input
 							type="text"
 							placeholder={$_('folksonomy.search_placeholder')}
-							class="input input-bordered w-full max-w-md"
+							class="input input-bordered join-item w-full"
 							bind:value={searchQuery}
 							transition:fade={{ duration: 200 }}
 						/>
-						<button class="btn btn-square" aria-label={$_('search.button')}>
+						<button class="btn btn-square join-item" aria-label={$_('search.button')}>
 							<IconMdiMagnify class="h-6 w-6" />
 						</button>
 					</div>


### PR DESCRIPTION
## Description

Fixed two distinct mobile UX/UI issues to improve navigation and layout consistency.

**1. Mobile Menu UX Fix:**
- **Issue:** The hamburger menu remained open after clicking a navigation link, obstructing the view of the new page.
- **Fix:** Added a reactive listener in `+layout.svelte` to automatically close the menu (`accordionOpen = false`) whenever the page URL changes.

**2. Folksonomy Search Layout Fix:**
- **Issue:** On mobile screens, the search icon button wrapped to the next line below the input field.
- **Fix:** Replaced the deprecated `input-group` class with the modern DaisyUI `join` component in `folksonomy/+page.svelte` to ensure the input and button stay inline on all screen sizes.

**Screenshots:**
<img width="5354" height="7534" alt="image" src="https://github.com/user-attachments/assets/ca2887e8-2866-476d-b43d-0f6ff87fbacc" />


---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.