### PR TITLE
feat: add edit/flag buttons to image viewer for logged-in users

### DIFF
--- a/src/lib/ui/ImageModal.svelte
+++ b/src/lib/ui/ImageModal.svelte
@@ -165,7 +165,7 @@
 						href={resolve('/products/[barcode]/edit', { barcode: image.productCode })}
 					>
 						<IconMdiPencilOutline class="h-5 w-5" />
-						<span>{$_('product.buttons.edit')}</span>
+						<span>{$_('product.buttons.edit', { default: 'Edit' })}</span>
 					</a>
 				{/if}
 
@@ -178,7 +178,7 @@
 						rel="noopener"
 					>
 						<IconMdiFlagOutline class="h-5 w-5" />
-						<span>Report</span>
+						<span>{$_('product.buttons.report_issue', { default: 'Report' })}</span>
 					</a>
 				{/if}
 			{/if}


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

Added **Edit** and **Flag** buttons to the full-screen image viewer ([ImageModal.svelte](file:///d:/webDev/more-projects/open-source/GSOC/openfoodfacts-explorer/src/lib/ui/ImageModal.svelte)). These buttons are conditionally rendered and only appear for logged-in users, allowing contributors to quickly edit product pages or report image issues directly from the viewer.

Fixes #825

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
