### PR TITLE
ci: use correct token for  release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,4 +18,3 @@ jobs:
         with:
           release-type: node
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          


### PR DESCRIPTION
I added the token own by openfoodfacts-bot.