### PR TITLE
feat: Add support for logged in knowledge panels

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -243,6 +243,13 @@
 			"no_prices_found": "No prices found for this product",
 			"loading": "Loading prices…",
 			"view_prices": "View prices on Open Prices"
+		},
+		"knowledge_panels": {
+			"action": {
+				"add_packaging_components": "Add packaging components",
+				"add_origins": "Add origins",
+				"add_ingredients_text": "Add ingredients text"
+			}
 		}
 	},
 	"qr": {

--- a/src/lib/knowledgepanels/Action.svelte
+++ b/src/lib/knowledgepanels/Action.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { _ } from '$lib/i18n';
 	import { NUTRIPATROL_URL } from '$lib/const';
+	import { resolve } from '$app/paths';
 
 	type Props = {
 		element: KnowledgeElementAction;
@@ -10,113 +11,82 @@
 	};
 	let { element, code: code }: Props = $props();
 
-	// Action-related functionality
-	const BUTTON_ACTIONS_TITLES: Record<string, string> = {
-		edit_product: 'Edit Product',
-		report_product_to_nutripatrol: 'Report Product to NutriPatrol'
-	};
-
-	let isLoading = $state(false);
-
-	function getButtonTitle(actions: string[]) {
-		for (const action of actions) {
-			if (BUTTON_ACTIONS_TITLES[action] != null) {
-				return BUTTON_ACTIONS_TITLES[action];
-			}
+	function requireCode() {
+		if (code == null) {
+			throw new Error('This action requires a product code, but none was provided.');
 		}
-
-		return actions.join(', ');
+		return code;
 	}
 
-	/**
-	 * Handles clicks on the action button.
-	 *
-	 * Special case: When an action element contains HTML content with links (<a> tags),
-	 * we need to allow those links to function normally. This happens when knowledge panels
-	 * include rich HTML content with clickable elements. In such cases, if the user clicks
-	 * directly on a link within the button's HTML content, we want the link's default
-	 * navigation behavior to work instead of triggering the button's action.
-	 *
-	 * @param event - The mouse event from the button click
-	 */
-	function handleActionClick(event: MouseEvent) {
-		// If the action has HTML content and the click was on a link, let the link handle it
-		if (element.action_element.html !== '') {
-			const target = event.target as HTMLElement;
-			if (target.tagName === 'A' || target.closest('a')) {
-				// Let the link handle the click
-				return;
+	const HANDLED_ACTIONS = [
+		{
+			type: 'edit_product',
+			action: () => {
+				goto(resolve(`/products/[barcode]/edit`, { barcode: requireCode() }));
+			}
+		},
+		{
+			type: 'add_categories',
+			action: () => {
+				goto(resolve(`/products/[barcode]/edit`, { barcode: requireCode() }) + '#categories');
+			}
+		},
+		{
+			type: 'report_product_to_nutripatrol',
+			action: () => {
+				const params = new URLSearchParams({
+					barcode: requireCode(),
+					source: 'web',
+					flavor: 'off'
+				});
+				window.open(`${NUTRIPATROL_URL}/flag/product/?${params.toString()}`, '_blank');
+			}
+		},
+		{
+			type: 'add_ingredients_text',
+			action: () => {
+				goto(`/products/${requireCode()}/edit#ingredients`);
+			}
+		},
+		{
+			type: 'add_packaging_components',
+			action: () => {
+				goto(`/products/${requireCode()}/edit#packaging`);
 			}
 		}
+	];
 
-		// Check if this is a valid action element with actions
-		if (!element.action_element.actions || element.action_element.actions.length === 0) {
+	const DEFAULT_ACTION = (action: string) => {
+		console.warn(`No specific handler for action: ${action}`);
+	};
+
+	function getActionHandler(action: string) {
+		const handler = HANDLED_ACTIONS.find((a) => a.type === action);
+		return handler ? handler.action : DEFAULT_ACTION.bind(null, action);
+	}
+
+	function handleHtmlActionElementClick(event: MouseEvent) {
+		// If the click was on a link, let it handle the navigation
+		const target = event.target as HTMLElement;
+		if (target.tagName === 'A' || target.closest('a')) {
 			return;
 		}
-
-		// Show loading state
-		isLoading = true;
-
-		// Get the first action from the list (most cases will only have one action)
-		const action = element.action_element.actions[0];
-
-		// Handle known action types if product code is available
-		if (code != null && action === 'edit_product') {
-			// Edit product action
-			goto(`/products/${code}/edit`);
-		} else if (code != null && action === 'add_categories') {
-			goto(`/products/${code}/edit#categories`);
-		}
-		// Report to NutriPatrol action
-		else if (code != null && action === 'report_product_to_nutripatrol') {
-			const params = new URLSearchParams({
-				barcode: code,
-				source: 'web',
-				flavor: 'off'
-			});
-			window.open(`${NUTRIPATROL_URL}/flag/product/?${params.toString()}`);
-		}
-		// Handle URLs directly
-		else if (code != null && (action.startsWith('http://') || action.startsWith('https://'))) {
-			window.open(action, '_blank');
-		}
-		// If no product code but it's a URL, still try to open it
-		else if (action.startsWith('http://') || action.startsWith('https://')) {
-			window.open(action, '_blank');
-		} else {
-			// If no specific action is defined, just log it or handle it as needed
-			console.warn('No valid action found for the button:', action);
-		}
-
-		// Process any additional actions if necessary
-		if (element.action_element.actions.length > 1) {
-			for (let i = 1; i < element.action_element.actions.length; i++) {
-				const additionalAction = element.action_element.actions[i];
-				// Handle direct URLs in additional actions
-				if (additionalAction.startsWith('http://') || additionalAction.startsWith('https://')) {
-					window.open(additionalAction, '_blank');
-				}
-			}
-		}
-
-		// Reset loading state after a short delay
-		setTimeout(() => {
-			isLoading = false;
-		}, 1000);
+		// TODO
+		console.warn('HTML action element clicked, but no handler is defined.', element);
 	}
 </script>
 
-<button
-	class="btn btn-primary {isLoading ? 'loading' : ''}"
-	onclick={handleActionClick}
-	disabled={isLoading}
->
-	{#if element.action_element.html != '' && !isLoading}
+{#if element.action_element.html != ''}
+	<button class="btn btn-primary" onclick={handleHtmlActionElementClick}>
 		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 		{@html element.action_element.html}
-	{:else if !isLoading}
-		{getButtonTitle(element.action_element.actions)}
-	{:else}
-		{$_('general.loading')}
-	{/if}
-</button>
+	</button>
+{:else}
+	{#each element.action_element.actions as action (action)}
+		{@const actionHandler = getActionHandler(action)}
+
+		<button class="btn btn-primary" onclick={actionHandler}>
+			{$_(`product.knowledge_panels.action.${action}`, { default: action })}
+		</button>
+	{/each}
+{/if}

--- a/src/lib/knowledgepanels/Element.svelte
+++ b/src/lib/knowledgepanels/Element.svelte
@@ -30,7 +30,7 @@
 	{/if}
 {/snippet}
 
-<div class="my-1">
+<div class="mt-4">
 	{#if element.element_type === 'panel'}
 		{@render panel(element.panel_element.panel_id)}
 	{:else if element.element_type === 'panel_group'}

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -77,7 +77,9 @@ export const load: PageLoad = async ({ params, fetch }) => {
 
 	const { data: state, error: apiErrorWrapped } = await productsApi.getProductV3(params.barcode, {
 		product_type: 'all',
-		fields: ['all', 'knowledge_panels']
+		fields: ['all', 'knowledge_panels'],
+		// @ts-expect-error - This is a temporary workaround until the SDK supports this parameter.
+		knowledge_panels_client: 'web'
 	});
 
 	handleProductApiError(apiErrorWrapped);


### PR DESCRIPTION
Always include the `knowledge_panels_client=web` when requesting Knowledge Panels.

Refactor `Action.svelte` to make it translatable and allow expanding it with more handlers.

Fixes #637 