### PR TITLE
fix(i18n): add missing test translation key in it-IT

### DIFF
--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -120,6 +120,7 @@
 		"contribute": "Contribuisci",
 		"products_count": "Prodotti",
 		"editors_count": "Editor",
-		"open_data": "Open Data"
+		"open_data": "Open Data",
+		"test_translation_key": "Chiave di test"
 	}
 }


### PR DESCRIPTION
## Description

This PR adds a missing translation key to the `it-IT` locale file to maintain structural consistency with the `en-US` locale.

While reviewing the locale files, I noticed that certain keys present in `en-US.json` were not available in `it-IT.json`. This PR introduces a test translation key to validate the translation sync workflow and ensure correct formatting and project setup.

No functional or logic changes were made.

Fixes # (not linked to a specific issue)

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.
