### PR TITLE
fix(i18n): respect stored user locale over browser language

### DIFF
--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,4 +1,4 @@
-import { init, register, getLocaleFromNavigator, isLoading } from 'svelte-i18n';
+import { init, register, getLocaleFromNavigator, isLoading, locale } from 'svelte-i18n';
 import { get } from 'svelte/store';
 import { preferences } from '$lib/settings';
 import { browser } from '$app/environment';
@@ -14,9 +14,19 @@ locales.forEach((locale) => {
 	});
 });
 
+const storedLang = browser ? JSON.parse(localStorage.getItem('preferences') || '{}')?.lang : null;
+
+const normalizedLang = locales.includes(storedLang)
+	? storedLang
+	: storedLang === 'it'
+		? 'it-IT'
+		: storedLang === 'en'
+			? 'en-US'
+			: FALLBACK_LOCALE;
+
 init({
 	fallbackLocale: FALLBACK_LOCALE,
-	initialLocale: getLocale()
+	initialLocale: normalizedLang || FALLBACK_LOCALE
 });
 
 export function getLocale() {

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,12 +1,18 @@
 import { locale, waitLocale } from '$lib/i18n';
 import { browser } from '$app/environment';
 import type { LayoutLoad } from './$types';
-
 export const load: LayoutLoad = async () => {
 	if (browser) {
-		locale.set(window.navigator.language);
-		console.log('i18n: Set locale to', window.navigator.language);
+		const stored = JSON.parse(localStorage.getItem('preferences') || '{}')?.lang;
+
+		const normalized = stored === 'it' ? 'it-IT' : stored === 'en' ? 'en-US' : stored;
+
+		const finalLocale = normalized || window.navigator.language || 'en-US';
+
+		locale.set(finalLocale);
+		console.log('i18n: Set locale to', finalLocale);
 	}
+
 	await waitLocale();
 
 	return {};


### PR DESCRIPTION
## Description

This PR fixes an issue where the application always reset the locale to the browser language on refresh, ignoring the user's previously selected language stored in preferences.

### Changes:
- Normalized stored language codes (`it` → `it-IT`, `en` → `en-US`)
- Updated layout logic to prioritize stored user preference over `window.navigator.language`
- Ensured correct fallback behavior

Now the selected language persists correctly after refresh.

Fixes unexpected locale override on reload.

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).

**LLM Usage Disclosure:**

- [x] I used AI assistance for debugging and reasoning but reviewed and validated the changes manually.
