### PR TITLE
fix: use globalThis.fetch for SSR compatibility and ensure string typing for config values

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,14 +11,17 @@ export * from './api/nutriments';
 
 export * from './api/knowledgepanels';
 
-export function createRobotoffApi(fetch: typeof window.fetch) {
-	const { fetch: wrappedFetch, url } = wrapFetchWithCredentials(fetch, new URL(ROBOTOFF_URL));
+export function createRobotoffApi(fetch: typeof globalThis.fetch) {
+	const { fetch: wrappedFetch, url } = wrapFetchWithCredentials(
+		fetch,
+		new URL(ROBOTOFF_URL as string)
+	);
 	return new Robotoff(wrappedFetch, { baseUrl: url.toString() });
 }
 
-export function createKeycloakApi(fetch: typeof window.fetch, url: URL) {
-	const keycloakUrl = KEYCLOAK_URL;
-	const clientId = OAUTH_CLIENT_ID;
+export function createKeycloakApi(fetch: typeof globalThis.fetch, url: URL) {
+	const keycloakUrl = KEYCLOAK_URL as string;
+	const clientId = OAUTH_CLIENT_ID as string;
 
 	const cleanUrl = new URL(url.pathname, url.origin);
 	const redirectUri = OAUTH_REDIRECT_URI(cleanUrl);


### PR DESCRIPTION
###Description

This PR improves type safety and environment compatibility in the API layer.

###Changes
Replaced typeof window.fetch with typeof globalThis.fetch in:
   createRobotoffApi
   createKeycloakApi

This removes the browser-only dependency and ensures compatibility across:
   Browser
   Node.js (v18+)
   SSR environments (e.g., SvelteKit)
   Testing environments

Ensured configuration values (ROBOTOFF_URL, KEYCLOAK_URL, OAUTH_CLIENT_ID) are treated as string to satisfy TypeScript requirements when used in APIs such as new URL().

###Motivation
window.fetch is not available in SSR or non-browser environments.
TypeScript infers environment variables as string | undefined, which causes type errors when passed to APIs expecting string.
Explicit string typing ensures the compiler recognizes these values as valid strings.
This PR introduces no runtime behavior changes and focuses purely on improving typing and portability.
Checklist:
 ✅I have performed a self-review of my own code.
✅ I understand the changes I'm proposing and why they are needed.
✅ My changes generate no new warnings or errors (linting, console).
✅ I have made corresponding changes to the documentation (if applicable).

LLM Usage Disclosure:
✅I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.