### PR TITLE
fix: sending credentials safely

### DIFF
--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -10,11 +10,11 @@ import { wrapFetchWithCredentials } from './utils';
 export function createProductsApi(fetch: typeof window.fetch) {
 	let fetchToUse = wrapFetchWithAuth(fetch);
 	let urlToUse = new URL(API_HOST);
-	
+
 	const { fetch: credentialsFetch, url: cleanUrl } = wrapFetchWithCredentials(fetchToUse, urlToUse);
 	fetchToUse = credentialsFetch;
 	urlToUse = cleanUrl;
-	
+
 	return new OpenFoodFacts(fetchToUse, { host: urlToUse.toString() });
 }
 


### PR DESCRIPTION
Was facing the internal server errors whenever I click on any product.
- The error happened because the API was putting the username and password directly in the URL like `https://user:pass@host`. And it was getting blocked. So instead of sending the request, it throws an error and your server returns a 500. Just removed the credentials from the URL and sending them in headers. 
