### PR TITLE
refactor(api): removed the duplicated facet sort option and improved types

### DIFF
--- a/src/lib/api/facets.ts
+++ b/src/lib/api/facets.ts
@@ -19,7 +19,8 @@ export async function getFacet(
 	opts?: { page?: number; pageSize?: number; sortBy?: FacetSortOption }
 ) {
 	const client = createProductsApi(fetch);
-	return client.getFacet(facet, { ...opts, sortBy: opts?.sortBy as ProductFacetsSortOption });
+	// @ts-expect-error - TODO: sortBy does not contain all possible values
+	return client.getFacet(facet, opts);
 }
 
 export async function getFacetValue(
@@ -29,10 +30,8 @@ export async function getFacetValue(
 	opts: { page?: number; pageSize?: number; sortBy?: FacetSortOption }
 ) {
 	const client = createProductsApi(fetch);
-	return client.getFacetValue(facet, value, {
-		...opts,
-		sortBy: opts.sortBy as ProductFacetsSortOption
-	});
+	// @ts-expect-error - TODO: sortBy does not contain all possible values
+	return client.getFacetValue(facet, value, opts);
 }
 
 const FACETS_KP_HOST = 'https://facets-kp.openfoodfacts.org';


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description
- Removed the redundant `last_modified_t` entry in `FACETS_SORT_OPTIONS`.
-  Added `nutriscore_score` to the sort options.

 *Note*: A temporary `// @ts-expect-error` is used for the API calls involving `nutriscore_score` as a workaround until the SDK is updated to the next version.


---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [ ] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
