### PR TITLE
fix(api): allow all printable ASCII characters in password credentials

### DIFF
--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -8,7 +8,7 @@ export function formBody(params: Record<string, string | null | undefined>) {
 	return formBody;
 }
 
-const ALLOWED_CREDENTIALS_REGEX = /^[A-Za-z]*$/;
+const ALLOWED_CREDENTIALS_REGEX = /^[\x20-\x7E]*$/;
 
 export function wrapFetchWithCredentials(
 	fetch: typeof globalThis.fetch,


### PR DESCRIPTION
###Description
This PR updates the credential validation logic in wrapFetchWithCredentials.

##Changes

Replaced the previous validation regex:
/^[A-Za-z]*$/
(which allowed only alphabetic characters)

With:
/^[\x20-\x7E]*$/
(which allows all printable ASCII characters)

Motivation
The original regex was overly restrictive and rejected valid credentials containing:
  Numbers
  Special characters
  Symbols
  Common password characters

Since HTTP Basic authentication supports printable ASCII characters, this change aligns validation with standard credential formats and improves real-world compatibility.

##Impact

Allows credentials containing numbers and common special characters.
Prevents unnecessary validation errors for legitimate usernames/passwords.
No changes to authentication flow or API surface.
Only affects credential validation behavior.

Checklist:
✅ I have performed a self-review of my own code.
✅ I understand the changes I'm proposing and why they are needed.
 ✅My changes generate no new warnings or errors (linting, console).
✅ I have made corresponding changes to the documentation (if applicable).

LLM Usage Disclosure:
✅  I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.