### PR TITLE
fix(ui): make top loading bar span full width on desktop

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -213,7 +213,8 @@
 </div>
 
 {#if navigating.to != null}
-	<progress class="progress progress-secondary fixed top-0 h-1 rounded-none"></progress>
+	<progress class="progress progress-secondary fixed top-0 left-0 z-50 h-1 w-full rounded-none"
+	></progress>
 {/if}
 
 <!-- Desktop Header -->


### PR DESCRIPTION
## Description

Fix the top navigation loading bar so it spans the full viewport width on desktop.

Previously, during route navigation, the loading indicator looked clipped/cut off on desktop because it was not anchored to full-width positioning. Mobile behavior was already fine.

### What changed
In `src/routes/+layout.svelte`, updated the progress bar classes to include:
- `left-0`
- `w-full`
- `z-50`

This keeps the loading bar pinned to the full top width and visible above layout content.

### Screenshot

<img width="6062" height="3012" alt="image" src="https://github.com/user-attachments/assets/5d7f052d-5925-455a-8971-e3875634934e" />

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).  
      (`pnpm check` and `pnpm run build` pass; repo-wide `pnpm lint` currently fails due pre-existing formatting drift not introduced by this change.)
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.
