### PR TITLE
fix: switch home label and metric from editors to contributors

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -400,7 +400,7 @@
 		"discover_project": "Discover the Project",
 		"contribute": "Contribute",
 		"products_count": "Products",
-		"editors_count": "Editors",
+		"contributors_count": "Contributors",
 		"open_data": "Open Data",
 		"help_improve_title": "Help Improve Open Food Facts",
 		"help_improve_desc": "Help us improve Open Food Facts by editing or answering questions about these products."

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -167,7 +167,7 @@
 		"discover_project": "Scopri il Progetto",
 		"contribute": "Contribuisci",
 		"products_count": "Prodotti",
-		"editors_count": "Editor",
+		"contributors_count": "Contributori",
 		"open_data": "Open Data"
 	},
 	"compare": {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -143,12 +143,12 @@
 		<p class="text-base-content/70">{$_('landing.products_count')}</p>
 	</a>
 	<a
-		href={resolve('/facets/[facet]', { facet: 'editors' })}
+		href={resolve('/facets/[facet]', { facet: 'contributors' })}
 		class="border-secondary hover:bg-base-200 focus:bg-base-200 focus:ring-primary flex flex-col items-center rounded-lg border p-6 text-center transition outline-none focus:ring-2"
 	>
 		<IconMdiAccountGroup class="text-primary mb-4 h-12 w-12" />
-		<h2 class="text-xl font-bold">{Intl.NumberFormat().format(data.editorCount)}</h2>
-		<p class="text-base-content/70">{$_('landing.editors_count')}</p>
+		<h2 class="text-xl font-bold">{Intl.NumberFormat().format(data.contributorCount)}</h2>
+		<p class="text-base-content/70">{$_('landing.contributors_count')}</p>
 	</a>
 	<a
 		href={resolve('/static/[id]', { id: 'data' })}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -9,7 +9,7 @@ async function getNumberOfProducts(fetch: typeof window.fetch): Promise<number> 
 	return data?.count || 0;
 }
 
-async function getNumberOfEditors(fetch: typeof window.fetch): Promise<number> {
+async function getNumberOfContributors(fetch: typeof window.fetch): Promise<number> {
 	const { fetch: wrappedFetch, url } = wrapFetchWithCredentials(fetch, new URL(API_HOST));
 	const res = await wrappedFetch(`${url}facets/contributors.json`);
 	const data = await res.json();
@@ -18,9 +18,9 @@ async function getNumberOfEditors(fetch: typeof window.fetch): Promise<number> {
 
 export const load: PageLoad = async ({ fetch }) => {
 	const productCount = getNumberOfProducts(fetch);
-	const editorCount = getNumberOfEditors(fetch);
+	const contributorCount = getNumberOfContributors(fetch);
 	return {
 		productCount: await productCount,
-		editorCount: await editorCount
+		contributorCount: await contributorCount
 	};
 };


### PR DESCRIPTION
## Description

Small consistency fix for the homepage KPI card.

The card was labeled **Editors**, but we decided to use the **Contributors** metric.  
This PR aligns label, facet link, and count to contributors so naming and data are consistent.

Fixes #953