### PR TITLE
feat: NetworkError UX improvements - retry, offline detection, error details

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -338,7 +338,10 @@
 		"network": {
 			"title": "Connection Error",
 			"message": "Failed to connect to the Open Food Facts server. Please check your internet connection and try again.",
-			"instructions": "If the problem persists, visit the Open Food Facts Status Page."
+			"instructions": "If the problem persists, visit the Open Food Facts Status Page.",
+			"retry": "Retry",
+			"offline": "You appear to be offline. Please check your internet connection.",
+			"details": "Show error details"
 		}
 	},
 	"common": {

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -154,7 +154,10 @@
 		"network": {
 			"title": "Errore di Connessione",
 			"message": "Impossibile connettersi al server di Open Food Facts. Controlla la tua connessione a Internet e riprova.",
-			"instructions": "Se il problema persiste, visita la pagina di stato di Open Food Facts."
+			"instructions": "Se il problema persiste, visita la pagina di stato di Open Food Facts.",
+			"retry": "Riprova",
+			"offline": "Sembra che tu sia offline. Controlla la tua connessione a Internet.",
+			"details": "Mostra dettagli errore"
 		}
 	},
 	"landing": {

--- a/src/lib/ui/NetworkError.svelte
+++ b/src/lib/ui/NetworkError.svelte
@@ -1,14 +1,49 @@
 <script lang="ts">
 	import { _ } from '$lib/i18n';
+	import { createEventDispatcher, onMount } from 'svelte';
+
+	type Props = {
+		errorDetails?: string;
+	};
+	let { errorDetails = '' }: Props = $props();
+
+	const dispatch = createEventDispatcher<{ retry: void }>();
+
+	let isOffline = $state(false);
+	let showDetails = $state(false);
+
+	onMount(() => {
+		isOffline = !navigator.onLine;
+
+		const handleOffline = () => (isOffline = true);
+		const handleOnline = () => (isOffline = false);
+
+		window.addEventListener('offline', handleOffline);
+		window.addEventListener('online', handleOnline);
+
+		return () => {
+			window.removeEventListener('offline', handleOffline);
+			window.removeEventListener('online', handleOnline);
+		};
+	});
+
+	function retry() {
+		dispatch('retry');
+	}
 </script>
 
-<div class="flex flex-col">
-	<h1 class="mb-3 text-xl font-bold">{$_('errors.network.title')}</h1>
+<div class="flex flex-col gap-3">
+	<h1 class="text-xl font-bold">{$_('errors.network.title')}</h1>
 
-	<p class="mb-4 text-sm">
-		{$_('errors.network.message')}
-		<br />
-	</p>
+	{#if isOffline}
+		<div class="alert alert-warning text-sm">
+			<span>{$_('errors.network.offline')}</span>
+		</div>
+	{:else}
+		<p class="text-sm">
+			{$_('errors.network.message')}
+		</p>
+	{/if}
 
 	<p class="text-sm">
 		{$_('errors.network.instructions')}
@@ -16,4 +51,17 @@
 			Open Food Facts Status Page
 		</a>
 	</p>
+
+	<button class="btn btn-primary btn-sm w-fit" onclick={retry}>
+		{$_('errors.network.retry')}
+	</button>
+
+	{#if errorDetails}
+		<details bind:open={showDetails} class="mt-2">
+			<summary class="text-base-content/60 hover:text-base-content cursor-pointer text-sm">
+				{$_('errors.network.details')}
+			</summary>
+			<pre class="bg-base-200 mt-2 overflow-auto rounded p-3 text-xs">{errorDetails}</pre>
+		</details>
+	{/if}
 </div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { invalidateAll } from '$app/navigation';
 	import { _ } from '$lib/i18n';
 	import NetworkError from '$lib/ui/NetworkError.svelte';
 	import StandardError from '$lib/ui/StandardError.svelte';
@@ -22,11 +23,22 @@
 		// track the error event with Matomo
 		$tracker?.trackEvent('Error', 'Error Occurred', errorMessage, errorDetails.length);
 	});
+
+	function handleRetry() {
+		invalidateAll();
+	}
+
+	let networkErrorDetails = $derived(
+		errorDetails
+			.map((e) => (typeof e === 'string' ? e : (e.message?.id ?? JSON.stringify(e))))
+			.filter(Boolean)
+			.join('\n')
+	);
 </script>
 
 <div class="flex min-h-[60vh] w-full flex-col items-center justify-center p-6">
 	{#if isNetworkError}
-		<NetworkError />
+		<NetworkError errorDetails={networkErrorDetails} on:retry={handleRetry} />
 	{:else if isGlobal404}
 		<div class="animate-in fade-in max-w-md text-center duration-500">
 			<div class="mb-4 text-8xl grayscale-[20%]">🧭</div>


### PR DESCRIPTION
## Summary

Improves the NetworkError experience by adding recovery, offline detection, and optional debug details.

## Changes

### NetworkError.svelte
- Added **Retry** button that dispatches a `retry` event
- Added offline detection using `navigator.onLine`
- Shows dedicated offline message when device has no internet
- Added collapsible `<details>` section for raw error output
- Accepts optional `errorDetails` prop

### +error.svelte
- Handles `retry` event using `invalidateAll()` (no hard reload)
- Passes serialized error details to `NetworkError`

### i18n
Added new keys under `errors.network`:
- `retry`
- `offline`
- `details`

## Result

- Retry works without page refresh
- Offline state clearly indicated