### PR TITLE
fix: URL encode search query in global navigation bar

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -139,7 +139,7 @@
 
 	async function gotoProductsSearch() {
 		isSearching = true;
-		await goto('/search?q=' + searchQuery);
+		await goto('/search?q=' + encodeURIComponent(searchQuery));
 		isSearching = false;
 	}
 


### PR DESCRIPTION
This PR fixes a bug in the global navigation bar where search queries containing special characters (like &, #, or %) would break the search URL because they were not being properly URL-encoded.

I have updated src/routes/+layout.svelte
 to wrap the searchQuery in encodeURIComponent() before passing it to goto().
 
 #958 