### PR TITLE
fix(ui): truncate overflowing usernames in Data Sources panel

### DIFF
--- a/src/routes/products/[barcode]/DataSources.svelte
+++ b/src/routes/products/[barcode]/DataSources.svelte
@@ -207,7 +207,7 @@
 							title={editor ?? $_('product.datasources.unknown')}
 							class="bg-base-300 text-base-content flex h-10 items-center justify-center rounded p-2 text-center"
 						>
-							<span class="overflow-hidden align-middle overflow-ellipsis">
+							<span class="truncate align-middle">
 								{editor ?? $_('product.datasources.unknown')}
 							</span>
 						</a>


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

This PR fixes the overflow of usernames in Data Sources Panel of ```/products/{barcode}``` page.

- issue: ```whitespace-nowrap``` was required, because of its absence, text wraps to the next line instead of truncating.
- added: ```truncate``` class instead of these ```overflow-hidden overflow-ellipsis``` classes as a shorthand.

Fixes #963 

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
Used claude.ai chat to understand the issue happening here because it was working for some items in the list. 

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.


<!-- You can erase any parts of this template not applicable to your Pull Request. -->
