### PR TITLE
refactor: remove legacy packaging state from product addition

### DIFF
--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -328,7 +328,7 @@ export type Product = ProductDataSection & {
 	ecoscore_grade: string;
 	nova_group: number;
 
-	packaging: string;
+	packaging?: string;
 	manufacturing_places: string;
 
 	brands: string;

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -69,7 +69,6 @@
 			ingredients_text: '',
 			ingredients_text_en: '',
 			serving_size: '',
-			packaging: '',
 			manufacturing_places: '',
 			product_type: '',
 


### PR DESCRIPTION
## Description

This PR finishes removing the old free-text packaging field from the product addition and editing process.

**Context & Motivation:**
During a codebase review, I found that while the UI input for the "classic" packaging field had been removed, the property was still being initialized in the `emptyProduct` state in `+page.svelte`. This meant the application might be sending unnecessary empty strings to the API.

Also, the `Product` interface needed this field, which would create a conflict with the shift to the new structured packaging input system (#764).

**Summary of Changes:**
* **State Management:** I removed the `packaging` initialization from the `emptyProduct` object in `src/routes/products/[barcode]/edit/+page.svelte`. 
* **Type Definition:** I updated the `Product` interface in `src/lib/api/product.ts` to make `packaging` optional (`packaging?: string`). This keeps compatibility with old product data from the backend while allowing the frontend form to work without the field.

Fixes #765

---

## Checklist:

**Author Self-Review:**

- [x] I have reviewed my own code.
- [x] I understand the changes I'm making and why they are needed.
- [x] My changes do not produce any new warnings or errors (linting, console).
- [x] I have updated the documentation as needed.

**LLM Usage Disclosure:**

- [x] If I used an AI Large Language Model, I have checked the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request a code review by commenting `/gemini review` on this PR after it's been created.