### PR TITLE
fix: rename footer "Producers" link to "Producer platform"

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -87,7 +87,7 @@
 		"links": {
 			"newsletter": "Newsletter",
 			"forum": "Forum",
-			"producers": "Producer Platform",
+			"producers": "Producers Platform",
 			"translators": "Translators",
 			"github": "GitHub",
 			"data_api_sdks": "Data, API, SDKs",


### PR DESCRIPTION
## Summary

The footer "Producers" link under the **Contribute** section was pointing to a different page than the "Producers" link in the top navigation, but both used identical labels causing user confusion.

As suggested , the footer label has been updated to **"Producer platform"** to clearly differentiate the two links and improve navigation clarity.

## Screenshot 
<img width="664" height="339" alt="image" src="https://github.com/user-attachments/assets/af872c4d-68d6-4ac1-b3c1-658a2bf838f3" />


## Closes #976 