### PR TITLE
fix(layout): correct navigation timeout cleanup

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -172,13 +172,15 @@
 	let navigationTooSlow: Promise<void> | null = $state(null);
 	$effect(() => {
 		if (navigating.to != null) {
+			let timeout: ReturnType<typeof setTimeout>;
+
 			navigationTooSlow = new Promise((resolve) => {
-				const timeout = setTimeout(() => {
+				timeout = setTimeout(() => {
 					resolve();
 				}, 5000);
-
-				return () => clearTimeout(timeout);
 			});
+
+			return () => clearTimeout(timeout);
 		} else {
 			navigationTooSlow = null;
 		}


### PR DESCRIPTION
### Problem 
 the 5-second navigationTooSlow timeout used to display the "slow server" dialog was not being cleared on fast navigations
 
### Changes 
 This PR fixes the issue by moving the timeout variable declaration outside the promise and returning the cleanup function directly from the $effect block so it gets properly destroyed when navigation completes.