### PR TITLE
fix: sanitize HTML in knowledge panel components

### DIFF
--- a/src/lib/knowledgepanels/Action.svelte
+++ b/src/lib/knowledgepanels/Action.svelte
@@ -4,12 +4,15 @@
 	import { _ } from '$lib/i18n';
 	import { NUTRIPATROL_URL } from '$lib/const';
 	import { resolve } from '$app/paths';
+	import { sanitizeHtml } from '$lib/utils/sanitize';
 
 	type Props = {
 		element: KnowledgeElementAction;
 		code?: string;
 	};
 	let { element, code: code }: Props = $props();
+
+	const sanitizedHtml = $derived(sanitizeHtml(element.action_element.html));
 
 	function requireCode() {
 		if (code == null) {
@@ -70,10 +73,8 @@
 	class={[element.action_element.html != '' && 'border-accent bg-accent/10 rounded border-s p-4']}
 >
 	{#if element.action_element.html != ''}
-		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 		<div class="mb-4 text-sm">
-			<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-			{@html element.action_element.html}
+			{@html sanitizedHtml}
 		</div>
 	{/if}
 

--- a/src/lib/knowledgepanels/Table.svelte
+++ b/src/lib/knowledgepanels/Table.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { KnowledgeElementTable } from '$lib/api';
+	import { sanitizeHtml } from '$lib/utils/sanitize';
 
 	let { element }: { element: KnowledgeElementTable } = $props();
 </script>
@@ -9,8 +10,7 @@
 		<thead>
 			<tr>
 				{#each element.table_element.columns as column, columnIndex (columnIndex)}
-					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-					<th>{@html column.text}</th>
+					<th>{@html sanitizeHtml(column.text)}</th>
 				{/each}
 			</tr>
 		</thead>
@@ -18,8 +18,7 @@
 			{#each element.table_element.rows as row, rowIndex (rowIndex)}
 				<tr>
 					{#each row.values as cell, cellIndex (cellIndex)}
-						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-						<td>{@html cell.text}</td>
+						<td>{@html sanitizeHtml(cell.text)}</td>
 					{/each}
 				</tr>
 			{/each}

--- a/src/lib/knowledgepanels/TextElement.svelte
+++ b/src/lib/knowledgepanels/TextElement.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import type { KnowledgeElementText } from '$lib/api';
 	import { _ } from '$lib/i18n';
+	import { sanitizeHtml } from '$lib/utils/sanitize';
 
 	let { element }: { element: KnowledgeElementText } = $props();
 
 	let { type, edit_field_type, html, source_url, source_text, source_language } = $derived(
 		element.text_element
 	);
+
+	const sanitizedHtml = $derived(sanitizeHtml(html));
 </script>
 
 <div class="mb-2 flex items-center space-x-2">
@@ -22,13 +25,11 @@
 <!-- Specialization for ingredients_text -->
 {#if edit_field_type == 'ingredients_text'}
 	<div class="prose w-full max-w-full dark:text-white">
-		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-		{@html html}
+		{@html sanitizedHtml}
 	</div>
 {:else}
 	<div class="prose w-full max-w-full dark:text-white">
-		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-		{@html html}
+		{@html sanitizedHtml}
 	</div>
 {/if}
 

--- a/src/lib/utils/sanitize.ts
+++ b/src/lib/utils/sanitize.ts
@@ -1,0 +1,34 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+export function sanitizeHtml(dirty: string): string {
+	return DOMPurify.sanitize(dirty, {
+		ALLOWED_TAGS: [
+			'b',
+			'i',
+			'u',
+			'em',
+			'strong',
+			'a',
+			'ul',
+			'ol',
+			'li',
+			'p',
+			'br',
+			'span',
+			'div',
+			'table',
+			'thead',
+			'tbody',
+			'tr',
+			'th',
+			'td',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6'
+		],
+		ALLOWED_ATTR: ['class', 'href', 'target', 'rel']
+	});
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description
Add DOMPurify sanitization to prevent XSS attacks when rendering
HTML content from external APIs.
- Created src/lib/utils/sanitize.ts with DOMPurify configuration
- Updated TextElement.svelte to sanitize HTML before rendering
- Updated Table.svelte to sanitize column and cell text
- Updated Action.svelte to sanitize action element HTML
Allowed tags: b, i, u, em, strong, a, ul, ol, li, p, br, span, div,
table, thead, tbody, tr, th, td, h1-h6
Allowed attributes: class, href, target, rel

Sanitize HTML in knowledge panel components using DOMPurify to prevent XSS vulnerabilities 
Fixes #987 
---

## Checklist:

**Author Self-Review:**

- [ ] I have performed a self-review of my own code.
- [ ] I understand the changes I'm proposing and why they are needed.
- [ ] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [ ] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
