### PR TITLE
feat: add setting to disable prices in search results (#607)

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -114,6 +114,7 @@
 		"login": "Login (saved in localStorage) [UNSAFE - DEBUG ONLY]",
 		"news": "News",
 		"expand_all_sections": "Expand all sections",
+		"display_prices_in_search": "Display prices in search results",
 		"logged_in_as": "Logged in as: {username}",
 		"not_logged_in": "Not logged in",
 		"github_link": "GitHub",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -2,7 +2,7 @@ import { persisted } from 'svelte-local-storage-store';
 import { get } from 'svelte/store';
 
 const DEFAULT_PREFERENCES = {
-	version: 3,
+	version: 4,
 	lang: undefined as string | undefined,
 	country: 'world',
 	currency: 'USD',
@@ -17,6 +17,8 @@ const DEFAULT_PREFERENCES = {
 	editing: {
 		expandAllSections: false
 	},
+
+	displayPricesInSearch: true,
 
 	moderator: false
 };
@@ -82,6 +84,16 @@ const MIGRATIONS: {
 			}
 			if ('folksonomy' in preferences) {
 				delete preferences.folksonomy;
+			}
+			return preferences;
+		}
+	},
+	{
+		version: 4,
+		upgrade: (preferences) => {
+			if (!('displayPricesInSearch' in preferences)) {
+				// @ts-expect-error - adding new field
+				preferences.displayPricesInSearch = true;
 			}
 			return preferences;
 		}

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -6,6 +6,7 @@
 	import { goto } from '$app/navigation';
 
 	import { _ } from '$lib/i18n';
+	import { preferences } from '$lib/settings';
 	import { SORT_OPTIONS } from '$lib/const';
 	import {
 		addIncludeFacet,
@@ -62,7 +63,6 @@
 
 	// State for showing/hiding preferences
 	let showPreferences = $state(false);
-	let showPrices = $state(true);
 
 	// Update facets when search results change or facetBarComponent changes
 	$effect(() => {
@@ -256,7 +256,7 @@
 		<div class="mt-4 grid w-full grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
 			{#each sortedProducts.filter(({ product }) => product.code != null) as { product, scoreData } (product.code)}
 				<div class="indicator block w-full">
-					{#if showPrices}
+					{#if $preferences.displayPricesInSearch}
 						<span class="indicator-item badge badge-secondary badge-sm right-4 z-20">
 							{$_('search.prices_badge', {
 								values: { count: data.prices[product.code] }

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -138,6 +138,16 @@
 			class="toggle toggle-primary"
 			bind:checked={$preferences.editing.expandAllSections}
 		/>
+
+		<label for="display-prices">
+			{$_('settings.display_prices_in_search')}:
+		</label>
+		<input
+			id="display-prices"
+			type="checkbox"
+			class="toggle toggle-primary"
+			bind:checked={$preferences.displayPricesInSearch}
+		/>
 	</div>
 
 	<p class="mt-8 mb-4 font-semibold">{$_('settings.influences')}</p>


### PR DESCRIPTION
## Description
This PR implements a global setting to enable or disable the display of price badges in search results, as requested in #607.

## Motivation and Context
Some users find the price badges in search results distracting. To improve the user experience, this PR adds a persistent configuration that allows users to toggle this feature on or off according to their preference.

## Key Changes

###  Persistent Preference
- Added `displayPricesInSearch` to the global preferences store in `src/lib/settings.ts`.

###  Migration Logic
- Bumped the preferences version from **3 → 4**.
- Added a migration handler to ensure existing users have this new field initialized to `true` by default.

###  Settings UI
- Added a new toggle in the **"Editing"** section of the Settings page.
- Users can now control whether price badges appear in search results.

###  Search Integration
- Refactored `src/routes/search/+page.svelte` to use the global `$preferences.displayPricesInSearch` state.
- Replaced the previous temporary local state.

---

**Fixes:** #607