### PR TITLE
fix: fix arrow size of back link and removed duplication

### DIFF
--- a/src/lib/ui/facets/BackLink.svelte
+++ b/src/lib/ui/facets/BackLink.svelte
@@ -10,6 +10,6 @@
 </script>
 
 <a {href} class="btn btn-secondary btn-outline w-full">
-	<IconMdiArrowLeft class="w-4" />
+	<IconMdiArrowLeft class="h-4 w-4 shrink-0" />
 	{label}
 </a>

--- a/src/routes/facets/[facet]/+page.svelte
+++ b/src/routes/facets/[facet]/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import KnowledgePanels from '$lib/knowledgepanels/Panels.svelte';
 	import Pagination from '$lib/Pagination.svelte';
 	import { _ } from '$lib/i18n';
-	import BackLink from '$lib/ui/BackLink.svelte';
+	import BackLink from '$lib/ui/facets/BackLink.svelte';
 
 	import type { PageProps } from './$types';
 	import { goto } from '$app/navigation';
@@ -27,7 +28,7 @@
 />
 
 <div class="mb-4">
-	<BackLink href="/facets/" label={$_('facets.facet_back_to_list')} />
+	<BackLink href={resolve('/facets')} label={$_('facets.facet_back_to_list')} />
 </div>
 
 <h2 class="my-8 text-3xl font-bold">Exploring {facet}</h2>

--- a/src/routes/facets/[facet]/[value]/+page.svelte
+++ b/src/routes/facets/[facet]/[value]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
@@ -11,7 +12,7 @@
 	import Metadata from '$lib/Metadata.svelte';
 	import ProductGrid from '$lib/ui/ProductGrid.svelte';
 	import PersonalizedSearchToggle from '$lib/ui/PersonalizedSearchToggle.svelte';
-	import BackLink from '$lib/ui/BackLink.svelte';
+	import BackLink from '$lib/ui/facets/BackLink.svelte';
 
 	import type { PageProps } from './$types';
 
@@ -32,7 +33,7 @@
 
 <div class="mb-4">
 	<BackLink
-		href={`/facets/${facet.name}`}
+		href={resolve('/facets/[facet]', { facet: facet.name })}
 		label={$_('facets.facet_back_to_overview', { values: { facet: facet.name } })}
 	/>
 </div>


### PR DESCRIPTION
## Description

This PR fixes a UI bug where the "Back to contributors overview" and "Back to editors overview" links were showing an oversized arrow. While investigating the issue, I realized the arrow definition was actually duplicated in both facets and their values, so I created a shared component to avoid similar drifts from happening again in the future.

## Changes
- Added shared UI component for the back arrow link
- Replaced duplicated definitions of the back arrow links in the relevant files
- Ensured consistent styling with existing “Back to facets” link

Fixes #1001