### PR TITLE
fix: mobile Account link navigates to internal profile page instead of Keycloak

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,13 +23,7 @@
 	import CompareFloatingButton from '$lib/ui/CompareFloatingButton.svelte';
 
 	import { _, getLocaleFromNavigator, locale } from '$lib/i18n';
-	import {
-		IMAGE_HOST,
-		KEYCLOAK_ACCOUNT_URL,
-		MATOMO_HOST,
-		MATOMO_SITE_ID,
-		ROBOTOFF_URL
-	} from '$lib/const';
+	import { IMAGE_HOST, MATOMO_HOST, MATOMO_SITE_ID, ROBOTOFF_URL } from '$lib/const';
 	import { userInfo } from '$lib/stores/user';
 	import { extractQuery } from '$lib/facets';
 	import { dev } from '$app/environment';
@@ -350,7 +344,10 @@
 		</a>
 
 		{#if $userInfo != null}
-			<a class="btn btn-outline link" href={KEYCLOAK_ACCOUNT_URL}>Account</a>
+			<a
+				class="btn btn-outline link"
+				href={resolve('/users/[user]', { user: $userInfo.preferred_username })}>Account</a
+			>
 			<a class="btn btn-outline link" href={resolve('/oauth/logout')}>Log out</a>
 		{:else}
 			<a class="btn btn-outline link" href={resolve('/oauth/login')}> Login </a>


### PR DESCRIPTION
### Problem
The mobile **Account** link was navigating to the external Keycloak account management UI (`KEYCLOAK_ACCOUNT_URL`), while the desktop version correctly navigated to the internal `/users/{username}` profile page. This caused an inconsistent user experience across screen sizes.

### Changes
- **Fixed** the mobile Account link in `+layout.svelte` to use `resolve('/users/[user]', { user: $userInfo.preferred_username })` — matching the desktop behavior
- **Removed** the now-unused `KEYCLOAK_ACCOUNT_URL` import

 fix #996 

