### PR TITLE
fix: dynamically retrieve language for oauth login

### DIFF
--- a/src/routes/oauth/login/+page.ts
+++ b/src/routes/oauth/login/+page.ts
@@ -5,7 +5,6 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 import { createKeycloakApi } from '$lib/api';
-import { getLocale } from '$lib/i18n';
 
 /**
  * Encodes a Uint8Array to a base64 URL-safe string.
@@ -44,7 +43,6 @@ export const load: PageLoad = async ({ url }) => {
 
 	const oauthLoginUrl = api.loginUrl({
 		state: state,
-		lang: getLocale().split('-')[0],
 		scope: 'openid profile offline_access',
 		codeChallenge,
 		codeChallengeMethod: 'S256'


### PR DESCRIPTION
### Description

This PR dynamically fetches the user's preferred language using the getLocale() utility for Keycloak OAuth login.Previously, the lang parameter was hardcoded to en, forcing the login UI into English regardless of the user's actual language settings.


Fixes #1007 



