### PR TITLE
fix: migrate NutritionCalculator to Svelte 5 event syntax

### DIFF
--- a/src/lib/ui/NutritionCalculator.svelte
+++ b/src/lib/ui/NutritionCalculator.svelte
@@ -24,7 +24,7 @@
 <div class="fixed right-6 bottom-6 z-50">
 	<button
 		class="btn btn-circle btn-primary shadow-lg"
-		on:click={toggleCalculator}
+		onclick={toggleCalculator}
 		aria-label="Nutrition Calculator"
 	>
 		<IconMdiCalculator class="h-6 w-6" />
@@ -46,7 +46,7 @@
 			<h3 class="text-lg font-bold">Nutrition Calculator</h3>
 			<button
 				class="btn btn-sm btn-circle"
-				on:click={toggleCalculator}
+				onclick={toggleCalculator}
 				aria-label="Close calculator"
 			>
 				<IconMdiClose class="h-5 w-5" />
@@ -77,21 +77,21 @@
 						<div class="flex items-center">
 							<button
 								class="btn btn-sm btn-square"
-								on:click={() => updateItemQuantity(item.id, -25)}
+								onclick={() => updateItemQuantity(item.id, -25)}
 								aria-label="Decrease quantity"
 							>
 								<IconMdiMinus class="h-4 w-4" />
 							</button>
 							<button
 								class="btn btn-sm btn-square ml-1"
-								on:click={() => updateItemQuantity(item.id, 25)}
+								onclick={() => updateItemQuantity(item.id, 25)}
 								aria-label="Increase quantity"
 							>
 								<IconMdiPlus class="h-4 w-4" />
 							</button>
 							<button
 								class="btn btn-sm btn-square ml-1"
-								on:click={() => removeItem(item.id)}
+								onclick={() => removeItem(item.id)}
 								aria-label="Remove item"
 							>
 								<IconMdiDelete class="h-4 w-4" />
@@ -118,7 +118,7 @@
 			</div>
 
 			<div class="mt-4 flex justify-end">
-				<button class="btn btn-sm btn-error" on:click={clearCalculator}> Clear All </button>
+				<button class="btn btn-sm btn-error" onclick={clearCalculator}> Clear All </button>
 			</div>
 		{/if}
 	</div>


### PR DESCRIPTION
## Summary

`NutritionCalculator.svelte` was the only component still using the deprecated Svelte 4 `on:click` event directive.  
This PR migrates it to the Svelte 5 `onclick` syntax, aligning it with the rest of the codebase.

---

## Changes

- `src/lib/ui/NutritionCalculator.svelte`
- Replaced 6 occurrences of `on:click` with `onclick`

---

## Why

The project runs on **Svelte 5.45.5**, where `on:click` is deprecated in favor of the `onclick` attribute syntax.  
All other components already use `onclick`, making this file the only outlier.

---

## Closes #1010 