### PR TITLE
fix(facets): prevent crash when results.products is undefined

### DIFF
--- a/src/routes/facets/[facet]/[value]/+page.ts
+++ b/src/routes/facets/[facet]/[value]/+page.ts
@@ -6,6 +6,7 @@ import {
 	getFacetValue,
 	type FacetSortOption
 } from '$lib/api/facets';
+
 import type { PageLoad } from './$types';
 import { requireInt } from '$lib/utils';
 import { getBulkProductAttributes } from '$lib/api';
@@ -13,12 +14,14 @@ import { getBulkProductAttributes } from '$lib/api';
 export const load: PageLoad = async ({ fetch, params, url }) => {
 	const { facet, value } = params;
 
+	// Pagination
 	const pageStr = url.searchParams.get('page') || '1';
 	const page = requireInt(pageStr, () => error(400, 'Invalid page number'));
 
 	const pageSizeStr = url.searchParams.get('page_size') || '50';
 	const pageSize = requireInt(pageSizeStr, () => error(400, 'Invalid page size'));
 
+	// Sorting
 	const sortByStr = url.searchParams.get('sort_by');
 	if (sortByStr && !FACETS_SORT_OPTIONS.includes(sortByStr as FacetSortOption)) {
 		error(400, 'Invalid sort option');
@@ -31,20 +34,27 @@ export const load: PageLoad = async ({ fetch, params, url }) => {
 		sortBy
 	};
 
-	const results = getFacetValue(fetch, facet, value, searchOptions);
-	const kp = getFacetKnowledgePanels(fetch, facet, value);
+	// Start requests in parallel
+	const resultsPromise = getFacetValue(fetch, facet, value, searchOptions);
+	const knowledgePanelsPromise = getFacetKnowledgePanels(fetch, facet, value);
 
-	const productCodes = (async () => {
-		const productCodes = (await results).products.map((state) => state.code as string);
-		const attrs = await getBulkProductAttributes(fetch, productCodes);
-		return attrs;
-	})();
+	// Await main results
+	const results = await resultsPromise;
+
+	// Prevent crash if products is undefined
+	const products = results.products ?? [];
+
+	const productCodes = products.map((state) => state.code as string);
+
+	// Only fetch attributes if we actually have product codes
+	const productAttributes =
+		productCodes.length > 0 ? await getBulkProductAttributes(fetch, productCodes) : {};
 
 	return {
 		searchOptions,
 		facet: { name: facet, value },
-		results: await results,
-		knowledgePanels: (await kp).knowledge_panels,
-		productAttributes: await productCodes
+		results,
+		knowledgePanels: (await knowledgePanelsPromise).knowledge_panels,
+		productAttributes
 	};
 };


### PR DESCRIPTION
## Description

Fixes #1014

This PR prevents a runtime crash on facet pages when
`results.products` is undefined.

Previously, the code directly called `.map()` on
`results.products`, which could throw a TypeError if
the API returned an unexpected or empty response.

This update:

- Safely falls back to an empty array when `products` is undefined
- Avoids unnecessary attribute fetching when there are no product codes
- Keeps the existing behavior unchanged for valid responses

This ensures facet pages do not crash even if the API
response is malformed or temporarily empty.

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.