### PR TITLE
fix(Robotoff): Correct dryRun logic to protect production data

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -200,7 +200,7 @@
 			'en'}
 		assets-images-path="/assets/webcomponents"
 		robotoff-configuration={JSON.stringify({
-			dryRun: !dev,
+			dryRun: dev,
 			apiUrl: ROBOTOFF_URL + '/api/v1',
 			imgUrl: IMAGE_HOST + '/images/products'
 		})}


### PR DESCRIPTION
This commit fixes a logical error in the Robotoff configuration inside +layout.svelte

Previously, dryRun was set to !dev. This inverted the expected behavior

 #1006 