### PR TITLE
fix: Escape key does not close autocomplete dropdown in SearchBar

### DIFF
--- a/src/lib/ui/SearchBar.svelte
+++ b/src/lib/ui/SearchBar.svelte
@@ -103,6 +103,7 @@
 			}
 		} else if (e.key === 'Escape') {
 			highlightedIndex = null;
+			autocompleteList = null;
 		}
 	}
 </script>


### PR DESCRIPTION
## Summary

Fixes a bug where pressing **Escape** in the search bar did not close the autocomplete dropdown.

---

## Problem

In `SearchBar.svelte`, the Escape key handler only reset `highlightedIndex` but left `autocompleteList` non-null.  
Since the dropdown renders conditionally on `autocompleteList`, it remained visible after pressing Escape.

## Fix

Also set autocompleteList = null on Escape to properly dismiss the dropdown.

## Testing

Type in the search bar to trigger autocomplete suggestions
Press Escape
The dropdown closes immediately.

--- 

## Closes #1025 