### PR TITLE
fix: resolve strict type errors caused by undefined environment varia…

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,13 +12,16 @@ export * from './api/nutriments';
 export * from './api/knowledgepanels';
 
 export function createRobotoffApi(fetch: typeof window.fetch) {
-	const { fetch: wrappedFetch, url } = wrapFetchWithCredentials(fetch, new URL(ROBOTOFF_URL));
+	const { fetch: wrappedFetch, url } = wrapFetchWithCredentials(
+		fetch,
+		new URL(ROBOTOFF_URL as string)
+	);
 	return new Robotoff(wrappedFetch, { baseUrl: url.toString() });
 }
 
 export function createKeycloakApi(fetch: typeof window.fetch, url: URL) {
-	const keycloakUrl = KEYCLOAK_URL;
-	const clientId = OAUTH_CLIENT_ID;
+	const keycloakUrl = KEYCLOAK_URL as string;
+	const clientId = OAUTH_CLIENT_ID as string;
 
 	const cleanUrl = new URL(url.pathname, url.origin);
 	const redirectUri = OAUTH_REDIRECT_URI(cleanUrl);

--- a/src/lib/api/prices.ts
+++ b/src/lib/api/prices.ts
@@ -11,7 +11,7 @@ export function isConfigured() {
 
 export const createPricesApi = (fetch: typeof window.fetch): PricesApi => {
 	const pricesApi = new PricesApi(fetch, {
-		baseUrl: BASE_URL,
+		baseUrl: BASE_URL || '',
 		authToken: `${get(preferences)?.prices?.authToken}`
 	});
 	return pricesApi;

--- a/src/lib/api/search.ts
+++ b/src/lib/api/search.ts
@@ -8,7 +8,7 @@ import { wrapFetchWithCredentials } from './utils';
 import { env } from '$env/dynamic/public';
 
 export function getSearchBaseUrl() {
-	if (env.PUBLIC_SEARCH_BASE_URL == '') {
+	if (!env.PUBLIC_SEARCH_BASE_URL) {
 		throw new Error(
 			'PUBLIC_SEARCH_BASE_URL is not set. Please set it in your environment variables.'
 		);


### PR DESCRIPTION
This PR fixes strict type errors during pnpm check caused by SvelteKit's environment variables ($env/dynamic/public) implicitly typed as string | undefined


* pnpm check now completes with 0 errors


- #1030