### PR TITLE
fix: remove loading flash when no prices in Prices.svelte

### DIFF
--- a/src/routes/products/[barcode]/Prices.svelte
+++ b/src/routes/products/[barcode]/Prices.svelte
@@ -26,10 +26,10 @@
 <Card>
 	<h1 class="my-4 text-2xl font-bold sm:text-4xl">Prices Map</h1>
 
-	{#if PricesMap == null}
-		{$_('product.prices.loading')}
-	{:else if prices.length === 0}
+	{#if prices.length === 0}
 		{$_('product.prices.no_prices_found')}
+	{:else if PricesMap == null}
+		{$_('product.prices.loading')}
 	{:else}
 		{#await PricesMap}
 			{$_('product.prices.loading')}


### PR DESCRIPTION
## Summary

Fixes a UX issue where the **Prices Map** section briefly showed **"Loading..."** before displaying **"No prices found"** for products that have zero prices.

---

## Problem

`PricesMap` is initialized as `null` on mount and only resolves after the lazy import completes (~50–200ms).

The original condition checked `PricesMap == null` first, causing a **"Loading..." flash** before switching to the empty state when `prices.length === 0`.

---

## Fix

Update the condition order to check `prices.length === 0` first.

If there are **no prices**, the UI immediately shows the **empty state** without waiting for the map component to load.

---

## Closes #1035 