### PR TITLE
fix: fix scanner restart failure if a product is not found

### DIFF
--- a/src/routes/qr/+page.svelte
+++ b/src/routes/qr/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy, onMount, tick } from 'svelte';
 	import type { Html5Qrcode } from 'html5-qrcode';
 
 	import { goto } from '$app/navigation';
@@ -105,6 +105,9 @@
 			productNotFound = false;
 			error = null;
 			lastScannedCode = '';
+
+			// Ensure page is fully rendered before restarting the scan
+			await tick();
 
 			if (html5QrCode) {
 				await startScanning(html5QrCode);


### PR DESCRIPTION
## Description
This PR fixes a bug where the "Scan again" button failed to restart the scanner if a product is not found.

Basically we were not awaiting the DOM to update before restarting the scanner.

Fixes #1044 