### PR TITLE
fix: add handler for add_origins KP action (#668)

### DIFF
--- a/src/lib/knowledgepanels/Action.svelte
+++ b/src/lib/knowledgepanels/Action.svelte
@@ -71,19 +71,6 @@
 		const handler = HANDLED_ACTIONS.find((a) => a.type === action);
 		return handler ? handler.action : () => DEFAULT_ACTION(action);
 	}
-
-	function handleHtmlActionElementClick(event: MouseEvent) {
-		// If the click was on a link, let it handle the navigation
-		const target = event.target as HTMLElement;
-		if (target.tagName === 'A' || target.closest('a')) {
-			return;
-		}
-		//Call the handler for the first action in the list
-		const action = element.action_element.actions?.[0];
-		if (action) {
-			getActionHandler(action)();
-		}
-	}
 </script>
 
 <div


### PR DESCRIPTION
## What
Adds a missing handler for the `add_origins` action type in the 
Knowledge Panel action component.

## Why
The Origins KP action button was not working because `add_origins` 
was not in the `HANDLED_ACTIONS` array, causing it to fall through 
to the default warning handler and do nothing when clicked.

## Changes
- Added `add_origins` handler in `src/lib/knowledgepanels/Action.svelte`

## Testing
1. Open any product with missing origins (e.g. the one from the issue)
2. Click the "Ajouter les origines des ingrédients" button
3. Should now navigate to `/products/[barcode]/edit#origins`

Fixes #668


https://github.com/user-attachments/assets/7c2b986f-c8c9-4d54-934f-9ebbb0ba6e3a



