### PR TITLE
ci: add vitest test step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - run: pnpm build
         if: always()
 
+      - name: Run tests
+        run: pnpm test
+
   dependency-review:
     name: 'Dependency Review'
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"api:prices": "openapi-typescript https://prices.openfoodfacts.net/api/schema --output src/lib/api/prices.d.ts",
 		"api": "pnpm run api:folksonomy && pnpm run api:prices",
 		"prepare": "husky",
-		"pre-commit": "pnpm format"
+		"pre-commit": "pnpm format",
+		"test": "vitest run --passWithNoTests"
 	},
 	"devDependencies": {
 		"@crowdin/cli": "^4.12.0",


### PR DESCRIPTION
This PR adds a test step to the CI workflow.

- Added "test" script in package.json
- Added pnpm test step in CI after build

Uses --passWithNoTests to allow CI to pass when no test files are present.