### PR TITLE
feat: add sticky floating save button to product edit form

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -338,6 +338,7 @@
 			"comment": "Comment",
 			"comment_placeholder": "Add a comment to this edit",
 			"save_btn": "Save",
+			"changes_summary": "Changes summary",
 			"toast": {
 				"save_success": "Product saved successfully!",
 				"save_error": "Failed to save product. Please try again."

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -147,6 +147,7 @@
 			"comment": "Comment",
 			"comment_placeholder": "Add a comment to this edit",
 			"save_btn": "Save",
+			"changes_summary": "Changes summary",
 			"debug": "Debug"
 		}
 	},

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -6,6 +6,7 @@
 	import NutritionStep from './edit-product-steps/NutritionStep.svelte';
 	import PackagingStep from './edit-product-steps/PackagingStep.svelte';
 	import CommentStep from './edit-product-steps/CommentStep.svelte';
+	import StickyEditSaveButton from './StickyEditSaveButton.svelte';
 
 	import IconMdiTranslate from '@iconify-svelte/mdi/translate';
 	import IconMdiImageMultiple from '@iconify-svelte/mdi/image-multiple';
@@ -66,6 +67,29 @@
 		isSubmitting,
 		submit
 	}: Props = $props();
+
+	/**
+	 * Track whether the inline save button at the bottom is out of viewport.
+	 * When it scrolls out of view, the sticky floating button becomes visible.
+	 */
+	let inlineSaveButtonEl: HTMLDivElement | undefined = $state();
+	let showStickyButton = $state(false);
+
+	$effect(() => {
+		if (!inlineSaveButtonEl) return;
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				// Show sticky button when inline button is NOT visible
+				showStickyButton = !entry.isIntersecting;
+			},
+			{ threshold: 0.1 }
+		);
+
+		observer.observe(inlineSaveButtonEl);
+
+		return () => observer.disconnect();
+	});
 </script>
 
 <div class="space-y-4">
@@ -162,7 +186,8 @@
 		</div>
 	</div>
 
-	<div class="mt-8 flex justify-end">
+	<!-- Inline save button at form bottom — acts as anchor for the IntersectionObserver -->
+	<div class="mt-8 flex justify-end" bind:this={inlineSaveButtonEl}>
 		<button
 			class="btn btn-primary w-full text-sm sm:w-auto sm:text-base"
 			class:loading={isSubmitting}
@@ -174,3 +199,6 @@
 		</button>
 	</div>
 </div>
+
+<!-- Sticky floating save button — appears when inline button scrolls out of view -->
+<StickyEditSaveButton {isSubmitting} {submit} visible={showStickyButton} />

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -5,7 +5,7 @@
 	import IngredientsStep from './edit-product-steps/IngredientsStep.svelte';
 	import NutritionStep from './edit-product-steps/NutritionStep.svelte';
 	import PackagingStep from './edit-product-steps/PackagingStep.svelte';
-	import CommentStep from './edit-product-steps/CommentStep.svelte';
+
 	import StickyEditSaveButton from './StickyEditSaveButton.svelte';
 
 	import IconMdiTranslate from '@iconify-svelte/mdi/translate';
@@ -14,7 +14,7 @@
 	import IconMdiFormatListBulleted from '@iconify-svelte/mdi/format-list-bulleted';
 	import IconMdiNutrition from '@iconify-svelte/mdi/nutrition';
 	import IconMdiPackageVariant from '@iconify-svelte/mdi/package-variant';
-	import IconMdiCommentText from '@iconify-svelte/mdi/comment-text';
+
 	import IconMdiTagMultiple from '@iconify-svelte/mdi/tag-multiple';
 	import IconMdiOpenInNew from '@iconify-svelte/mdi/open-in-new';
 
@@ -76,8 +76,8 @@
 	}
 </script>
 
-<!-- pb-24 ensures the last section is not hidden behind the fixed floating bar -->
-<div class="space-y-4 pb-24">
+<!-- pb-28 on mobile accounts for the two-row floating bar; sm+ fits within pb-24 -->
+<div class="space-y-4 pb-28 sm:pb-24">
 	<!-- Languages Section -->
 	<div class="collapse-arrow bg-base-200 collapse shadow-md">
 		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
@@ -184,17 +184,7 @@
 		</div>
 	</div>
 
-	<!-- Comment Section -->
-	<div class="collapse-arrow bg-base-200 collapse shadow-md">
-		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
-			<IconMdiCommentText class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-			{$_('product.edit.sections.comment')}
-		</div>
-		<div class="collapse-content">
-			<CommentStep bind:comment />
-		</div>
-	</div>
+
 </div>
 
 <!-- Floating comment + save bar — always visible at bottom of viewport -->

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -195,7 +195,6 @@
 			<CommentStep bind:comment />
 		</div>
 	</div>
-
 </div>
 
 <!-- Floating comment + save bar — always visible at bottom of viewport -->

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -67,32 +67,10 @@
 		isSubmitting,
 		submit
 	}: Props = $props();
-
-	/**
-	 * Track whether the inline save button at the bottom is out of viewport.
-	 * When it scrolls out of view, the sticky floating button becomes visible.
-	 */
-	let inlineSaveButtonEl: HTMLDivElement | undefined = $state();
-	let showStickyButton = $state(false);
-
-	$effect(() => {
-		if (!inlineSaveButtonEl) return;
-
-		const observer = new IntersectionObserver(
-			([entry]) => {
-				// Show sticky button when inline button is NOT visible
-				showStickyButton = !entry.isIntersecting;
-			},
-			{ threshold: 0.1 }
-		);
-
-		observer.observe(inlineSaveButtonEl);
-
-		return () => observer.disconnect();
-	});
 </script>
 
-<div class="space-y-4">
+<!-- pb-24 ensures the last section is not hidden behind the fixed floating bar -->
+<div class="space-y-4 pb-24">
 	<!-- Languages Section -->
 	<div class="collapse-arrow bg-base-200 collapse shadow-md">
 		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
@@ -185,20 +163,7 @@
 			<CommentStep bind:comment />
 		</div>
 	</div>
-
-	<!-- Inline save button at form bottom — acts as anchor for the IntersectionObserver -->
-	<div class="mt-8 flex justify-end" bind:this={inlineSaveButtonEl}>
-		<button
-			class="btn btn-primary w-full text-sm sm:w-auto sm:text-base"
-			class:loading={isSubmitting}
-			onclick={submit}
-			disabled={isSubmitting}
-			type="button"
-		>
-			{$_('product.edit.save_btn')}
-		</button>
-	</div>
 </div>
 
-<!-- Sticky floating save button — appears when inline button scrolls out of view -->
-<StickyEditSaveButton {isSubmitting} {submit} visible={showStickyButton} />
+<!-- Floating comment + save bar — always visible at bottom of viewport -->
+<StickyEditSaveButton {isSubmitting} {submit} bind:comment />

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -183,8 +183,6 @@
 			<PackagingStep bind:product {getPackagingImage} />
 		</div>
 	</div>
-
-
 </div>
 
 <!-- Floating comment + save bar — always visible at bottom of viewport -->

--- a/src/lib/ui/StickyEditSaveButton.svelte
+++ b/src/lib/ui/StickyEditSaveButton.svelte
@@ -18,26 +18,30 @@
 	}
 </script>
 
-<div class="floating-edit-bar">
+<div
+	class="border-base-300 fixed inset-x-0 bottom-0 z-100 flex flex-wrap items-center gap-2 border-t bg-[#341100] p-3.5 sm:gap-2.5"
+>
 	<!-- Comment input -->
 	<input
 		type="text"
-		class="floating-edit-bar__input"
+		class="border-base-300 h-9 flex-1 basis-full rounded-none border bg-white p-2 text-sm text-gray-700 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-300/30 disabled:cursor-not-allowed disabled:opacity-60 sm:basis-0"
 		placeholder="Changes summary"
 		bind:value={comment}
 		disabled={isSubmitting}
 	/>
 
 	<!-- Save button -->
-	<button type="button" class="floating-edit-bar__save" onclick={submit} disabled={isSubmitting}>
+	<button
+		type="button"
+		class="inline-flex h-9 w-[234px] shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg bg-[#4fa125] text-[13px] font-semibold whitespace-nowrap text-white transition-colors hover:bg-[#3d8a1c] disabled:cursor-not-allowed disabled:opacity-60 max-sm:min-w-0 max-sm:flex-1 max-sm:basis-0"
+		onclick={submit}
+		disabled={isSubmitting}
+	>
 		{#if isSubmitting}
-			<IconMdiLoading
-				class="floating-edit-bar__icon floating-edit-bar__icon--spin"
-				aria-hidden="true"
-			/>
+			<IconMdiLoading class="h-4 w-4 shrink-0 animate-spin" aria-hidden="true" />
 		{:else}
 			<svg
-				class="floating-edit-bar__icon"
+				class="h-4 w-4 shrink-0"
 				viewBox="0 0 24 24"
 				fill="none"
 				stroke="currentColor"
@@ -53,8 +57,13 @@
 	</button>
 
 	<!-- Cancel button -->
-	<button type="button" class="floating-edit-bar__cancel" onclick={cancel} disabled={isSubmitting}>
-		<svg class="floating-edit-bar__icon" viewBox="0 0 24 24" aria-hidden="true">
+	<button
+		type="button"
+		class="inline-flex h-9 w-[234px] shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg bg-[#ede0db] text-[13px] font-semibold whitespace-nowrap text-gray-700 transition-colors hover:bg-[#d5cab8] disabled:cursor-not-allowed disabled:opacity-60 max-sm:min-w-0 max-sm:flex-1 max-sm:basis-0"
+		onclick={cancel}
+		disabled={isSubmitting}
+	>
+		<svg class="h-4 w-4 shrink-0" viewBox="0 0 24 24" aria-hidden="true">
 			<circle cx="12" cy="12" r="10" fill="#555" stroke="none" />
 			<line x1="8" y1="8" x2="16" y2="16" stroke="#fff" stroke-width="2.5" stroke-linecap="round" />
 			<line x1="16" y1="8" x2="8" y2="16" stroke="#fff" stroke-width="2.5" stroke-linecap="round" />
@@ -62,146 +71,3 @@
 		<span>{$_('common.cancel')}</span>
 	</button>
 </div>
-
-<style>
-	/* ── Desktop layout (single row) ── */
-	.floating-edit-bar {
-		position: fixed;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		z-index: 100;
-		background-color: #341100;
-		border-top: 1px solid #eee;
-		padding: 14px;
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 10px;
-	}
-
-	/* Input: 8/12 columns on desktop → full width on mobile */
-	.floating-edit-bar__input {
-		flex: 1 1 auto;
-		/* Desktop: ~66% via flex, remaining space is taken by 2 buttons */
-		height: 37px;
-		padding: 8px;
-		font-size: 14px;
-		color: #333;
-		background-color: #fff;
-		border: 1px solid #ccc;
-		border-radius: 0;
-		outline: none;
-		box-sizing: border-box;
-	}
-
-	.floating-edit-bar__input:focus {
-		border-color: #66afe9;
-		box-shadow: 0 0 0 3px rgba(102, 175, 233, 0.3);
-	}
-
-	.floating-edit-bar__input:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	/* Save: 2/12 columns on desktop → 50% on mobile */
-	.floating-edit-bar__save {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		gap: 8px;
-		width: 234px;
-		height: 37px;
-		padding: 0;
-		font-size: 13px;
-		font-weight: 600;
-		color: #fff;
-		background-color: #4fa125;
-		border: none;
-		border-radius: 8px;
-		cursor: pointer;
-		white-space: nowrap;
-		flex-shrink: 0;
-		transition: background-color 0.15s ease;
-	}
-
-	.floating-edit-bar__save:hover:not(:disabled) {
-		background-color: #3d8a1c;
-	}
-
-	.floating-edit-bar__save:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	/* Cancel: 2/12 columns on desktop → 50% on mobile */
-	.floating-edit-bar__cancel {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		gap: 8px;
-		width: 234px;
-		height: 37px;
-		padding: 0;
-		font-size: 13px;
-		font-weight: 600;
-		color: #333;
-		background-color: #ede0db;
-		border: none;
-		border-radius: 8px;
-		cursor: pointer;
-		white-space: nowrap;
-		flex-shrink: 0;
-		transition: background-color 0.15s ease;
-	}
-
-	.floating-edit-bar__cancel:hover:not(:disabled) {
-		background-color: #d5cab8;
-	}
-
-	.floating-edit-bar__cancel:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.floating-edit-bar__icon {
-		width: 16px;
-		height: 16px;
-		flex-shrink: 0;
-	}
-
-	.floating-edit-bar__icon--spin {
-		animation: spin 1s linear infinite;
-	}
-
-	@keyframes spin {
-		from {
-			transform: rotate(0deg);
-		}
-		to {
-			transform: rotate(360deg);
-		}
-	}
-
-	/* ── Mobile / small screens (matches Foundation small-12 + small-6 + small-6) ── */
-	@media (max-width: 640px) {
-		.floating-edit-bar {
-			gap: 8px;
-		}
-
-		/* Input goes full width (row 1) */
-		.floating-edit-bar__input {
-			flex: 0 0 100%;
-			width: 100%;
-		}
-
-		/* Buttons go side by side, each ~50% (row 2) */
-		.floating-edit-bar__save,
-		.floating-edit-bar__cancel {
-			flex: 1 1 0;
-			width: auto;
-			min-width: 0;
-		}
-	}
-</style>

--- a/src/lib/ui/StickyEditSaveButton.svelte
+++ b/src/lib/ui/StickyEditSaveButton.svelte
@@ -25,7 +25,8 @@
 	<input
 		type="text"
 		class="border-base-300 h-9 flex-1 basis-full rounded-none border bg-white p-2 text-sm text-gray-700 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-300/30 disabled:cursor-not-allowed disabled:opacity-60 sm:basis-0"
-		placeholder="Changes summary"
+		placeholder={$_('product.edit.changes_summary')}
+		aria-label={$_('product.edit.changes_summary')}
 		bind:value={comment}
 		disabled={isSubmitting}
 	/>

--- a/src/lib/ui/StickyEditSaveButton.svelte
+++ b/src/lib/ui/StickyEditSaveButton.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { _ } from '$lib/i18n';
+	import { fly } from 'svelte/transition';
+
+	import IconMdiContentSave from '@iconify-svelte/mdi/content-save';
+	import IconMdiLoading from '@iconify-svelte/mdi/loading';
+
+	type Props = {
+		isSubmitting: boolean;
+		submit: () => Promise<void>;
+		/** Whether the sticky button is visible (i.e. edit mode is active) */
+		visible?: boolean;
+	};
+
+	let { isSubmitting, submit, visible = true }: Props = $props();
+</script>
+
+{#if visible}
+	<div class="fixed right-6 bottom-6 z-50" transition:fly={{ y: 24, duration: 200 }} role="none">
+		<button
+			type="button"
+			class="btn btn-primary flex items-center gap-2 rounded-full px-5 shadow-xl"
+			class:loading={isSubmitting}
+			onclick={submit}
+			disabled={isSubmitting}
+			aria-label={$_('product.edit.save_btn')}
+			title={$_('product.edit.save_btn')}
+		>
+			{#if isSubmitting}
+				<IconMdiLoading class="h-5 w-5 animate-spin" aria-hidden="true" />
+			{:else}
+				<IconMdiContentSave class="h-5 w-5" aria-hidden="true" />
+			{/if}
+			<span class="hidden sm:inline">{$_('product.edit.save_btn')}</span>
+		</button>
+	</div>
+{/if}

--- a/src/lib/ui/StickyEditSaveButton.svelte
+++ b/src/lib/ui/StickyEditSaveButton.svelte
@@ -4,6 +4,8 @@
 	import { page } from '$app/state';
 
 	import IconMdiLoading from '@iconify-svelte/mdi/loading';
+	import IconMdiCheck from '@iconify-svelte/mdi/check';
+	import IconMdiCloseCircle from '@iconify-svelte/mdi/close-circle';
 
 	type Props = {
 		isSubmitting: boolean;
@@ -19,12 +21,12 @@
 </script>
 
 <div
-	class="border-base-300 fixed inset-x-0 bottom-0 z-100 flex flex-wrap items-center gap-2 border-t bg-[#341100] p-3.5 sm:gap-2.5"
+	class="border-base-300 bg-base-200 fixed inset-x-0 bottom-0 z-100 flex flex-wrap items-center gap-2 border-t p-3.5 shadow-lg sm:gap-2.5"
 >
 	<!-- Comment input -->
 	<input
 		type="text"
-		class="border-base-300 h-9 flex-1 basis-full rounded-none border bg-white p-2 text-sm text-gray-700 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-300/30 disabled:cursor-not-allowed disabled:opacity-60 sm:basis-0"
+		class="input input-bordered h-9 flex-1 basis-full text-sm sm:basis-0"
 		placeholder={$_('product.edit.changes_summary')}
 		aria-label={$_('product.edit.changes_summary')}
 		bind:value={comment}
@@ -34,25 +36,14 @@
 	<!-- Save button -->
 	<button
 		type="button"
-		class="inline-flex h-9 w-[234px] shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg bg-[#4fa125] text-[13px] font-semibold whitespace-nowrap text-white transition-colors hover:bg-[#3d8a1c] disabled:cursor-not-allowed disabled:opacity-60 max-sm:min-w-0 max-sm:flex-1 max-sm:basis-0"
+		class="btn btn-success h-9 w-[234px] shrink-0 gap-2 text-sm max-sm:min-w-0 max-sm:flex-1 max-sm:basis-0"
 		onclick={submit}
 		disabled={isSubmitting}
 	>
 		{#if isSubmitting}
 			<IconMdiLoading class="h-4 w-4 shrink-0 animate-spin" aria-hidden="true" />
 		{:else}
-			<svg
-				class="h-4 w-4 shrink-0"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="3"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				aria-hidden="true"
-			>
-				<polyline points="20 6 9 17 4 12"></polyline>
-			</svg>
+			<IconMdiCheck class="h-4 w-4 shrink-0" aria-hidden="true" />
 		{/if}
 		<span>{$_('product.edit.save_btn')}</span>
 	</button>
@@ -60,15 +51,11 @@
 	<!-- Cancel button -->
 	<button
 		type="button"
-		class="inline-flex h-9 w-[234px] shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg bg-[#ede0db] text-[13px] font-semibold whitespace-nowrap text-gray-700 transition-colors hover:bg-[#d5cab8] disabled:cursor-not-allowed disabled:opacity-60 max-sm:min-w-0 max-sm:flex-1 max-sm:basis-0"
+		class="btn btn-ghost h-9 w-[234px] shrink-0 gap-2 text-sm max-sm:min-w-0 max-sm:flex-1 max-sm:basis-0"
 		onclick={cancel}
 		disabled={isSubmitting}
 	>
-		<svg class="h-4 w-4 shrink-0" viewBox="0 0 24 24" aria-hidden="true">
-			<circle cx="12" cy="12" r="10" fill="#555" stroke="none" />
-			<line x1="8" y1="8" x2="16" y2="16" stroke="#fff" stroke-width="2.5" stroke-linecap="round" />
-			<line x1="16" y1="8" x2="8" y2="16" stroke="#fff" stroke-width="2.5" stroke-linecap="round" />
-		</svg>
+		<IconMdiCloseCircle class="h-4 w-4 shrink-0" aria-hidden="true" />
 		<span>{$_('common.cancel')}</span>
 	</button>
 </div>

--- a/src/lib/ui/StickyEditSaveButton.svelte
+++ b/src/lib/ui/StickyEditSaveButton.svelte
@@ -1,37 +1,207 @@
 <script lang="ts">
 	import { _ } from '$lib/i18n';
-	import { fly } from 'svelte/transition';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 
-	import IconMdiContentSave from '@iconify-svelte/mdi/content-save';
 	import IconMdiLoading from '@iconify-svelte/mdi/loading';
 
 	type Props = {
 		isSubmitting: boolean;
 		submit: () => Promise<void>;
-		/** Whether the sticky button is visible (i.e. edit mode is active) */
-		visible?: boolean;
+		comment: string;
 	};
 
-	let { isSubmitting, submit, visible = true }: Props = $props();
+	let { isSubmitting, submit, comment = $bindable() }: Props = $props();
+
+	function cancel() {
+		goto('/products/' + page.params.barcode);
+	}
 </script>
 
-{#if visible}
-	<div class="fixed right-6 bottom-6 z-50" transition:fly={{ y: 24, duration: 200 }} role="none">
-		<button
-			type="button"
-			class="btn btn-primary flex items-center gap-2 rounded-full px-5 shadow-xl"
-			class:loading={isSubmitting}
-			onclick={submit}
-			disabled={isSubmitting}
-			aria-label={$_('product.edit.save_btn')}
-			title={$_('product.edit.save_btn')}
-		>
-			{#if isSubmitting}
-				<IconMdiLoading class="h-5 w-5 animate-spin" aria-hidden="true" />
-			{:else}
-				<IconMdiContentSave class="h-5 w-5" aria-hidden="true" />
-			{/if}
-			<span class="hidden sm:inline">{$_('product.edit.save_btn')}</span>
-		</button>
-	</div>
-{/if}
+<div class="floating-edit-bar">
+	<!-- Comment input -->
+	<input
+		type="text"
+		class="floating-edit-bar__input"
+		placeholder="Changes summary"
+		bind:value={comment}
+		disabled={isSubmitting}
+	/>
+
+	<!-- Save button -->
+	<button type="button" class="floating-edit-bar__save" onclick={submit} disabled={isSubmitting}>
+		{#if isSubmitting}
+			<IconMdiLoading
+				class="floating-edit-bar__icon floating-edit-bar__icon--spin"
+				aria-hidden="true"
+			/>
+		{:else}
+			<svg
+				class="floating-edit-bar__icon"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="3"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				aria-hidden="true"
+			>
+				<polyline points="20 6 9 17 4 12"></polyline>
+			</svg>
+		{/if}
+		<span>{$_('product.edit.save_btn')}</span>
+	</button>
+
+	<!-- Cancel button -->
+	<button type="button" class="floating-edit-bar__cancel" onclick={cancel} disabled={isSubmitting}>
+		<svg class="floating-edit-bar__icon" viewBox="0 0 24 24" aria-hidden="true">
+			<circle cx="12" cy="12" r="10" fill="#555" stroke="none" />
+			<line x1="8" y1="8" x2="16" y2="16" stroke="#fff" stroke-width="2.5" stroke-linecap="round" />
+			<line x1="16" y1="8" x2="8" y2="16" stroke="#fff" stroke-width="2.5" stroke-linecap="round" />
+		</svg>
+		<span>{$_('common.cancel')}</span>
+	</button>
+</div>
+
+<style>
+	/* ── Desktop layout (single row) ── */
+	.floating-edit-bar {
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		z-index: 100;
+		background-color: #341100;
+		border-top: 1px solid #eee;
+		padding: 14px;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 10px;
+	}
+
+	/* Input: 8/12 columns on desktop → full width on mobile */
+	.floating-edit-bar__input {
+		flex: 1 1 auto;
+		/* Desktop: ~66% via flex, remaining space is taken by 2 buttons */
+		height: 37px;
+		padding: 8px;
+		font-size: 14px;
+		color: #333;
+		background-color: #fff;
+		border: 1px solid #ccc;
+		border-radius: 0;
+		outline: none;
+		box-sizing: border-box;
+	}
+
+	.floating-edit-bar__input:focus {
+		border-color: #66afe9;
+		box-shadow: 0 0 0 3px rgba(102, 175, 233, 0.3);
+	}
+
+	.floating-edit-bar__input:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	/* Save: 2/12 columns on desktop → 50% on mobile */
+	.floating-edit-bar__save {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		width: 234px;
+		height: 37px;
+		padding: 0;
+		font-size: 13px;
+		font-weight: 600;
+		color: #fff;
+		background-color: #4fa125;
+		border: none;
+		border-radius: 8px;
+		cursor: pointer;
+		white-space: nowrap;
+		flex-shrink: 0;
+		transition: background-color 0.15s ease;
+	}
+
+	.floating-edit-bar__save:hover:not(:disabled) {
+		background-color: #3d8a1c;
+	}
+
+	.floating-edit-bar__save:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	/* Cancel: 2/12 columns on desktop → 50% on mobile */
+	.floating-edit-bar__cancel {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		width: 234px;
+		height: 37px;
+		padding: 0;
+		font-size: 13px;
+		font-weight: 600;
+		color: #333;
+		background-color: #ede0db;
+		border: none;
+		border-radius: 8px;
+		cursor: pointer;
+		white-space: nowrap;
+		flex-shrink: 0;
+		transition: background-color 0.15s ease;
+	}
+
+	.floating-edit-bar__cancel:hover:not(:disabled) {
+		background-color: #d5cab8;
+	}
+
+	.floating-edit-bar__cancel:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.floating-edit-bar__icon {
+		width: 16px;
+		height: 16px;
+		flex-shrink: 0;
+	}
+
+	.floating-edit-bar__icon--spin {
+		animation: spin 1s linear infinite;
+	}
+
+	@keyframes spin {
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	/* ── Mobile / small screens (matches Foundation small-12 + small-6 + small-6) ── */
+	@media (max-width: 640px) {
+		.floating-edit-bar {
+			gap: 8px;
+		}
+
+		/* Input goes full width (row 1) */
+		.floating-edit-bar__input {
+			flex: 0 0 100%;
+			width: 100%;
+		}
+
+		/* Buttons go side by side, each ~50% (row 2) */
+		.floating-edit-bar__save,
+		.floating-edit-bar__cancel {
+			flex: 1 1 0;
+			width: auto;
+			min-width: 0;
+		}
+	}
+</style>


### PR DESCRIPTION
## What this PR does 

Adds a **sticky floating save button** that appears in the bottom-right corner of the screen when editing a product. The button intelligently shows/hides based on scroll position — it only appears when the inline save button at the bottom of the form is scrolled out of view.

## Problem 

The product edit form has 6 expandable sections (Languages, Images, Basic Info, Ingredients, Nutrition, Comment), making it extremely long. Previously, the only "Save" button was at the very bottom, forcing users to scroll through the entire form just to save. This is especially painful on mobile devices .



Related to #125


https://github.com/user-attachments/assets/8e2ab12c-81f3-4082-8b4d-b1613abe96c4










<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product edit form now includes a persistent sticky save bar at the bottom while scrolling.
  * Comment input moved into the sticky bar with two-way binding and disabled/loading state during save.
  * Added Cancel action to exit editing and return to the product page.
  * Adjusted form spacing so the last section isn’t hidden by the sticky controls.

* **Localization**
  * Added translation key for "Changes summary".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->