### PR TITLE
feat(pagination): improve pagination accessibility by using semantic HTML

### DIFF
--- a/src/lib/Pagination.svelte
+++ b/src/lib/Pagination.svelte
@@ -9,7 +9,7 @@
 		<a href={pageUrl(1)} class="btn join-item"> 1 </a>
 	{/if}
 	{#if page > 3}
-		<button class="btn btn-disabled join-item">...</button>
+		<span class="btn btn-disabled join-item" aria-hidden="true">...</span>
 	{/if}
 
 	{#if page > 2}
@@ -18,14 +18,14 @@
 		</a>
 	{/if}
 
-	<button class="btn join-item btn-active">{page}</button>
+	<span class="btn join-item btn-active">{page}</span>
 
 	{#if totalPages > page + 1}
 		<a href={pageUrl(page + 1)} class="btn join-item"> {page + 1}</a>
 	{/if}
 
 	{#if totalPages > page + 2}
-		<button class="btn btn-disabled join-item">...</button>
+		<span class="btn btn-disabled join-item" aria-hidden="true">...</span>
 	{/if}
 
 	{#if totalPages > page}


### PR DESCRIPTION
## Description

This PR fixes accessibility issues in the pagination component where decorative elements and non-interactive elements were incorrectly using `<button>` tags.

## Changes Made

- **Decorative ellipsis**: Replaced `<button>` with `<span aria-hidden="true">` for the decorative "..." elements between page numbers
- **Current page indicator**: Changed from `<button>` to `<span>` since it represents the current page and is not clickable

## Why This Matters

### Before
- Screen readers announced ellipsis as "disabled button", which is confusing
- Keyboard users could tab through these unnecessary button elements
- Current page was clickable but did nothing when clicked
- Violated semantic HTML principles (buttons should be for interactive elements)

### After
- Ellipsis elements are properly hidden from screen readers with `aria-hidden="true"`
- Current page indicator is semantic (non-interactive span)
- Keyboard navigation is cleaner (no unnecessary tab stops)
- Improved accessibility for screen reader users

## Testing

Tested that:
- ✅ Visual appearance remains unchanged (pagination looks identical)
- ✅ Keyboard navigation skips over ellipsis and current page
- ✅ Page number links still work correctly
- ✅ No console errors or TypeScript issues

## Related Issue

Fixes #1046

## Screenshots

The visual appearance is unchanged, but the HTML structure is now semantically correct and accessible.

---

**Note**: This is a pure accessibility improvement with no visual changes. All pagination functionality remains the same.
