### PR TITLE
test: add unit tests for wrapFetchWithCredentials

### DIFF
--- a/src/lib/api/utils.test.ts
+++ b/src/lib/api/utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { wrapFetchWithCredentials } from './utils';
+
+describe('wrapFetchWithCredentials', () => {
+	it('removes credentials from URL', () => {
+		const url = new URL('https://user:pass@example.com/api');
+		const mockFetch = vi.fn();
+
+		const { url: cleanedUrl } = wrapFetchWithCredentials(mockFetch as typeof fetch, url);
+
+		expect(cleanedUrl.toString()).toBe('https://example.com/api');
+	});
+
+	it('does not modify fetch when no credentials are present', () => {
+		const url = new URL('https://example.com/api');
+		const mockFetch = vi.fn();
+
+		const result = wrapFetchWithCredentials(mockFetch as typeof fetch, url);
+
+		expect(result.fetch).toBe(mockFetch);
+	});
+});


### PR DESCRIPTION
This PR adds unit tests for wrapFetchWithCredentials.

Recreated the branch from latest main to avoid duplicate commits and conflicts.