### PR TITLE
fix: avoid string 'null' for prices authToken

### DIFF
--- a/src/lib/api/prices.ts
+++ b/src/lib/api/prices.ts
@@ -10,9 +10,10 @@ export function isConfigured() {
 }
 
 export const createPricesApi = (fetch: typeof window.fetch): PricesApi => {
+	const authToken = get(preferences)?.prices?.authToken ?? undefined;
 	const pricesApi = new PricesApi(fetch, {
 		baseUrl: BASE_URL,
-		authToken: `${get(preferences)?.prices?.authToken}`
+		authToken
 	});
 	return pricesApi;
 };


### PR DESCRIPTION
## Summary

Prevents the preferences auth token from being coerced into the literal string `"null"`, which could be mistakenly treated as a valid token.

---

## Change

Use the actual preference value or `undefined` instead of string interpolation (`"${...}"`).

---

## Closes #1060 