### PR TITLE
feat: Add debouncing to search autocomplete to prevent excessive API calls

### DIFF
--- a/src/lib/ui/SearchBar.svelte
+++ b/src/lib/ui/SearchBar.svelte
@@ -3,7 +3,6 @@
 	import { _, getBrowserLocale } from '$lib/i18n';
 	import { onDestroy } from 'svelte';
 
-
 	import IconMdiBarcodeScan from '@iconify-svelte/mdi/barcode-scan';
 
 	let {
@@ -25,7 +24,7 @@
 
 	// debounce for autocomplete
 	let debounceTimeoutId: ReturnType<typeof setTimeout> | undefined;
-	const DEBOUNCE_DELAY_MS = 300;
+	const DEBOUNCE_DELAY_MS = 100;
 
 	// used for aborting previously executing autocomplete requests
 	let autocompleteAbortController: AbortController | null = null;
@@ -68,8 +67,8 @@
 
 	function debouncedFetchAutocomplete(query: string) {
 		if (debounceTimeoutId !== undefined) {
-  			clearTimeout(debounceTimeoutId);
-  			debounceTimeoutId = undefined;
+			clearTimeout(debounceTimeoutId);
+			debounceTimeoutId = undefined;
 		}
 
 		if (query.trim().length < minQueryLength) {
@@ -79,18 +78,18 @@
 			}
 			autocompleteLoading = false;
 			autocompleteList = null;
-			return;  
-   		 }
+			return;
+		}
 
-		debounceTimeoutId = window.setTimeout(() => {
+		debounceTimeoutId = setTimeout(() => {
 			fetchAutocomplete(query);
 		}, DEBOUNCE_DELAY_MS);
 	}
 
 	onDestroy(() => {
-	  if (debounceTimeoutId !== undefined) {
-	    clearTimeout(debounceTimeoutId);
-	  }
+		if (debounceTimeoutId !== undefined) {
+			clearTimeout(debounceTimeoutId);
+		}
 	});
 
 	function handleEnter() {


### PR DESCRIPTION
Fixes #1054 


### Description

Every keystroke in the search bar triggered an immediate API call to fetch autocomplete suggestions, causing:
- Excessive API requests
- Race conditions where older requests could overwrite newer results
- Poor performance on slower connections

---

### Solution

Added a 300ms debounce mechanism to delay API calls until the user stops typing.

---

### How It Works

1. User types in search box → oninput fires
2. `debouncedFetchAutocomplete()` is called
3. If a previous timeout exists, it's cancelled (clearTimeout)
4. New timeout is set for 300ms
5. If user types again before 300ms → previous timeout cancelled, new one starts
6. Only when user stops typing for 300ms → `fetchAutocomplete()` actually executes

---

## Checklist:

**Author Self-Review:**

- [✔️ ] I have performed a self-review of my own code.
- [✔️ ] I understand the changes I'm proposing and why they are needed.
- [ ✔️] My changes generate no new warnings or errors (linting, console).
- [ ❌] I have made corresponding changes to the documentation (if applicable).
- [ ✔️] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

---

PROOF VIDEO:

https://github.com/user-attachments/assets/26ab36b6-fc5f-4b95-9b62-c34f7ac35ee0

---

`/gemini review`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Autocomplete now uses debounced requests to reduce unnecessary network calls during rapid typing, improving responsiveness.
* **Reliability**
  * Short queries no longer trigger autocomplete; any in-flight autocomplete requests are canceled when no longer needed.
* **Stability**
  * Pending autocomplete timers and requests are cleaned up when the search component is unmounted to prevent leaks or stray updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->