### PR TITLE
fix: facet unselect and select

### DIFF
--- a/src/routes/search/FacetCard.svelte
+++ b/src/routes/search/FacetCard.svelte
@@ -24,16 +24,10 @@
 
 	function handleSelect(item: FacetItem) {
 		onSelect(item);
-		if (dropdownElement) {
-			dropdownElement.open = false;
-		}
 	}
 
 	function handleUnselect(item: FacetItem) {
 		onUnselect(item);
-		if (dropdownElement) {
-			dropdownElement.open = false;
-		}
 	}
 
 	let searchQuery: string = $state('');


### PR DESCRIPTION
## Description

Removes the automatic `dropdownElement.open = false` from `handleSelect` and `handleUnselect` in `FacetCard.svelte`.

---

## Reason

Previously, the facet dropdown closed whenever a user selected or unselected an item.  
Keeping the dropdown open allows users to quickly select or unselect multiple items, improving usability and workflow.

---

## Testing

1. Open a facet dropdown.
2. Select or unselect multiple items.
3. The dropdown should remain open during these actions.

---

## Closes #1065 