### PR TITLE
feat: implement language deletion in product edit page

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -245,6 +245,7 @@
 			"add_product_title": "Add a new product",
 			"edit_product_title": "Edit product",
 			"add_language": "Add a language",
+			"remove_language": "Remove language",
 			"search_languages": "Search languages to add",
 			"no_languages_found": "No languages found",
 			"name": "Name",

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -123,6 +123,7 @@
 		},
 		"edit": {
 			"add_language": "Add a language",
+			"remove_language": "Rimuovi lingua",
 			"search_languages": "Search languages to add",
 			"no_languages_found": "No languages found",
 			"name": "Name",

--- a/src/lib/ui/AddProductForm.svelte
+++ b/src/lib/ui/AddProductForm.svelte
@@ -57,6 +57,7 @@
 		// Language
 
 		addLanguage: (code: string) => void;
+		removeLanguage: (code: string) => void;
 		languages: string[];
 
 		// Taxonomy entries
@@ -74,6 +75,7 @@
 		comment = $bindable(),
 		handleNutrimentInput,
 		addLanguage,
+		removeLanguage,
 		getIngredientsImage,
 		getNutritionImage,
 		languages,
@@ -146,7 +148,7 @@
 		{countriesNames}
 	/>
 {:else if currentStep === 2}
-	<LanguagesStep bind:product codes={languages} {addLanguage} />
+	<LanguagesStep bind:product codes={languages} {addLanguage} {removeLanguage} />
 {:else if currentStep === 3}
 	<IngredientsStep bind:product {getIngredientsImage} />
 {:else if currentStep === 4}

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -33,6 +33,7 @@
 		// Language
 
 		addLanguage: (code: string) => void;
+		removeLanguage: (code: string) => void;
 		languages: string[];
 
 		// Taxonomy entries
@@ -50,6 +51,7 @@
 		comment = $bindable(),
 		handleNutrimentInput,
 		addLanguage,
+		removeLanguage,
 		getIngredientsImage,
 		getNutritionImage,
 		languages,
@@ -73,7 +75,7 @@
 			{$_('product.edit.sections.languages')}
 		</div>
 		<div class="collapse-content">
-			<LanguagesStep bind:product {addLanguage} codes={languages} />
+			<LanguagesStep bind:product {addLanguage} {removeLanguage} codes={languages} />
 		</div>
 	</div>
 

--- a/src/lib/ui/edit-product-steps/LanguagesStep.svelte
+++ b/src/lib/ui/edit-product-steps/LanguagesStep.svelte
@@ -16,9 +16,10 @@
 		codes: string[];
 
 		addLanguage: (code: string) => void;
+		removeLanguage: (code: string) => void;
 	};
 
-	let { product = $bindable(), codes, addLanguage }: Props = $props();
+	let { product = $bindable(), codes, addLanguage, removeLanguage }: Props = $props();
 
 	let languageNames = $derived(
 		codes.map((code) => {
@@ -74,7 +75,7 @@
 
 <fieldset class="fieldset">
 	<legend class="fieldset-legend">{$_('product.edit.main_language')}</legend>
-	<select class="select w-full">
+	<select class="select w-full" bind:value={product.lang}>
 		{#each Object.keys(product.languages_codes) ?? [] as lang (lang)}
 			<option value={lang} selected={product.lang === lang}>{getLanguageName(lang)}</option>
 		{/each}
@@ -106,7 +107,13 @@
 				class="mt-2 grid max-h-96 grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-2 overflow-auto sm:grid-cols-[repeat(auto-fill,minmax(200px,1fr))]"
 			>
 				{#each filteredLanguages as lang (lang)}
-					<button class="btn btn-ghost text-xs sm:text-sm" onclick={() => addLanguage(lang.code)}>
+					<button
+						class="btn btn-ghost text-xs sm:text-sm"
+						onclick={() => {
+							addLanguage(lang.code);
+							languageSearch = '';
+						}}
+					>
 						{lang.locale} ({lang.en}) - {lang.code}
 					</button>
 				{/each}
@@ -132,6 +139,19 @@
 			checked={code === product.lang}
 		/>
 		<div class="tab-content form-control p-6">
+			{#if code !== product.lang}
+				<div class="mb-4 flex justify-end">
+					<button
+						type="button"
+						class="btn btn-ghost btn-sm text-error hover:bg-error hover:text-error-content flex items-center gap-1 text-xs"
+						onclick={() => removeLanguage(code)}
+						aria-label={`Remove language ${getLanguageName(code)}`}
+					>
+						<IconMdiClose class="h-4 w-4" />
+						{$_('product.edit.remove_language')}
+					</button>
+				</div>
+			{/if}
 			<label class="label text-sm sm:text-base" for={`product-name-${code}`}>
 				<span class="flex items-center gap-2">
 					{$_('product.edit.name')} ({getLanguageName(code)})

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -162,7 +162,7 @@
 				};
 	}
 
-	let product = $derived(createProductStore(data));
+	let product = $state(createProductStore(data));
 
 	let comment = $state('');
 
@@ -233,6 +233,17 @@
 		product = {
 			...product,
 			languages_codes: { ...product.languages_codes, [code]: 0 }
+		};
+	}
+
+	function removeLanguage(code: string) {
+		if (code === product.lang) return;
+		const { [code]: _, ...remainingCodes } = product.languages_codes;
+		product = {
+			...product,
+			languages_codes: remainingCodes,
+			[`product_name_${code}`]: '',
+			[`ingredients_text_${code}`]: ''
 		};
 	}
 
@@ -341,6 +352,7 @@
 			bind:product
 			bind:comment
 			{addLanguage}
+			{removeLanguage}
 			{brandNames}
 			{categoryNames}
 			{countriesNames}
@@ -364,6 +376,7 @@
 			{getNutritionImage}
 			{submit}
 			{addLanguage}
+			{removeLanguage}
 			{brandNames}
 			{categoryNames}
 			{countriesNames}


### PR DESCRIPTION
Fixes #309

## Description
Users could add languages to a product but had no way to remove them. This PR implements language deletion in the product edit page.

Changes made:
- Add `removeLanguage()` that clears language-specific fields (`product_name_{code}`, `ingredients_text_{code}`) and removes the language code from `languages_codes` on save
- Show delete button on each language tab, guarded to prevent deletion of the main product language
- Propagate `removeLanguage` through `EditProductForm` and `AddProductForm` down to `LanguagesStep`
- Fix main language `<select>` not binding to `product.lang` (changing the main language had no effect)
- Reset language search input after a language is added
- Add `remove_language` i18n key in `en-US` and `it-IT`

---
## Checklist:
**Author Self-Review:**
- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Screenshots:
<img width="1440" height="900" alt="Screenshot 2026-03-02 at 4 07 31 PM" src="https://github.com/user-attachments/assets/568ba71f-7aab-43b0-bf28-976900b487a2" />
<img width="1440" height="807" alt="Screenshot 2026-03-02 at 9 25 34 PM" src="https://github.com/user-attachments/assets/55bf9be6-719f-4cb0-8b55-9b2b3e83b4b2" />
