### PR TITLE
feat(kp): adopt visual syntax for single-link KP text blocks

### DIFF
--- a/src/lib/knowledgepanels/TextElement.svelte
+++ b/src/lib/knowledgepanels/TextElement.svelte
@@ -2,12 +2,15 @@
 	import type { KnowledgeElementText } from '$lib/api';
 	import { _ } from '$lib/i18n';
 	import HtmlPurify from '$lib/ui/HtmlPurify.svelte';
+	import { extractSingleListLink } from './textElement';
 
 	let { element }: { element: KnowledgeElementText } = $props();
 
 	let { type, edit_field_type, html, source_url, source_text, source_language } = $derived(
 		element.text_element
 	);
+
+	let actionLink = $derived(extractSingleListLink(html));
 </script>
 
 <div class="mb-2 flex items-center space-x-2">
@@ -21,7 +24,11 @@
 </div>
 
 <!-- Specialization for ingredients_text -->
-{#if edit_field_type == 'ingredients_text'}
+{#if actionLink}
+	<a href={actionLink.href} class="btn btn-soft btn-block rounded-none text-left normal-case">
+		{actionLink.label}
+	</a>
+{:else if edit_field_type == 'ingredients_text'}
 	<div class="prose w-full max-w-full dark:text-white">
 		<HtmlPurify dirty={html} />
 	</div>

--- a/src/lib/knowledgepanels/textElement.test.ts
+++ b/src/lib/knowledgepanels/textElement.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { extractSingleListLink } from './textElement';
+
+describe('extractSingleListLink', () => {
+	it('extracts a single CTA list link used in KP text blocks', () => {
+		const html =
+			"<ul><li><p><a href='https://hunger.openfoodfacts.org/questions?type=category&value_tag=en%3Acocoa-and-its-products'><em>Answer robotoff questions about category en:cocoa-and-its-products</em></a></p></li></ul>";
+
+		expect(extractSingleListLink(html)).toEqual({
+			href: 'https://hunger.openfoodfacts.org/questions?type=category&value_tag=en%3Acocoa-and-its-products',
+			label: 'Answer robotoff questions about category en:cocoa-and-its-products'
+		});
+	});
+
+	it('returns null when there is additional content around the link', () => {
+		const html = "<ul><li><p>Before <a href='https://example.org'>click</a> after</p></li></ul>";
+
+		expect(extractSingleListLink(html)).toBeNull();
+	});
+
+	it('returns null when there are multiple links', () => {
+		const html =
+			"<ul><li><a href='https://example.org/a'>A</a></li><li><a href='https://example.org/b'>B</a></li></ul>";
+
+		expect(extractSingleListLink(html)).toBeNull();
+	});
+});

--- a/src/lib/knowledgepanels/textElement.ts
+++ b/src/lib/knowledgepanels/textElement.ts
@@ -1,0 +1,43 @@
+export type TextElementActionLink = {
+	href: string;
+	label: string;
+};
+
+const WRAPPER_TAGS_REGEX = /<\/?(?:ul|li|p|em|strong|span)\b[^>]*>/gi;
+const TAG_REGEX = /<[^>]*>/g;
+const NBSP_REGEX = /&(nbsp|#160);/gi;
+
+function stripTags(input: string): string {
+	return input.replace(TAG_REGEX, '');
+}
+
+/**
+ * Some KP text blocks are rendered as a single list item containing one link.
+ * Convert those to actionable CTA links so they match KP visual syntax.
+ */
+export function extractSingleListLink(html: string): TextElementActionLink | null {
+	const anchorMatches = [...html.matchAll(/<a\s+[^>]*href=(['"])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi)];
+
+	if (anchorMatches.length !== 1) {
+		return null;
+	}
+
+	const [fullAnchorMatch, , href, anchorInnerHtml] = anchorMatches[0];
+	const withoutAnchor = html
+		.replace(fullAnchorMatch, '')
+		.replace(WRAPPER_TAGS_REGEX, '')
+		.replace(NBSP_REGEX, ' ')
+		.trim();
+
+	if (withoutAnchor.length > 0) {
+		return null;
+	}
+
+	const label = stripTags(anchorInnerHtml).replace(NBSP_REGEX, ' ').replace(/\s+/g, ' ').trim();
+
+	if (label.length === 0 || href.trim().length === 0) {
+		return null;
+	}
+
+	return { href: href.trim(), label };
+}


### PR DESCRIPTION
Fixes #830

## Description
This PR implements the KP visual syntax for single-link KnowledgePanel (KP) text blocks, making them actionable CTA buttons and edge-to-edge as requested in #830.


## Changes
- Added `extractSingleListLink` utility to detect KP blocks containing a single <a> link.
- Updated `TextElement.svelte` to render such links as buttons (`btn btn-soft btn-block rounded-none text-left normal-case`).
- Added tests (`textElement.test.ts`) to ensure correct extraction of single-link blocks and handle edge cases.

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

### Screenshots

Before:
<img width="1920" height="1080" alt="Before" src="https://github.com/user-attachments/assets/510c6652-8440-4e73-9fe2-02a226cca96e" />


After:
<img width="1920" height="1080" alt="After" src="https://github.com/user-attachments/assets/83ea4da5-fb54-4b77-9abb-1522491efd24" />

