### PR TITLE
fix: add response.ok checks to API calls

### DIFF
--- a/src/lib/api/facets.ts
+++ b/src/lib/api/facets.ts
@@ -52,6 +52,13 @@ export async function getFacetKnowledgePanels(
 		params.set('value_tag', value);
 	}
 
-	const response = await fetch(`${FACETS_KP_HOST}/knowledge_panel?${params}`);
+	const url = `${FACETS_KP_HOST}/knowledge_panel?${params.toString()}`;
+	const response = await fetch(url);
+	if (!response.ok) {
+		const statusText = response.statusText || 'Unknown status';
+		throw new Error(
+			`Failed to fetch facet knowledge panels (${response.status} ${statusText}) for ${url}`
+		);
+	}
 	return (await response.json()) as FacetKnowledgePanelResponse;
 }

--- a/src/lib/api/taxonomy/api.ts
+++ b/src/lib/api/taxonomy/api.ts
@@ -6,6 +6,11 @@ export async function getTaxo<T extends TaxoNode>(
 	taxo: string,
 	fetch: (url: string, options?: RequestInit) => Promise<Response>
 ): Promise<Taxonomy<T>> {
-	const res = await wrapFetch(fetch)(TAXONOMY_URL(taxo));
+	const url = TAXONOMY_URL(taxo);
+	const res = await wrapFetch(fetch)(url);
+	if (!res.ok) {
+		const statusText = res.statusText || 'No status text available';
+		throw new Error(`Failed to fetch taxonomy "${taxo}" from ${url}: ${res.status} ${statusText}`);
+	}
 	return await res.json();
 }


### PR DESCRIPTION
## Summary

This fix adds proper HTTP response validation to prevent unhandled promise rejections when APIs return error responses.

## Changes

- Add response.ok validation in `getTaxo()` before parsing JSON to ensure taxonomy API calls succeed
- Add response.ok validation in `getFacetKnowledgePanels()` before parsing JSON to ensure facet knowledge panel API calls succeed  
- Both functions now throw descriptive errors when API responses indicate failure

## Impact

This improves error handling throughout the application by:
- Preventing silent failures when external APIs return error status codes
- Providing clear error messages that indicate which API call failed and why
- Allowing proper error propagation and handling in consuming code

## Testing

All existing checks pass:
- TypeScript validation ✓
- ESLint & Prettier ✓  
- Production build ✓


Closes #986