### PR TITLE
fix: browse products button in compare mode redirects to wrong link

### DIFF
--- a/src/routes/compare/+page.svelte
+++ b/src/routes/compare/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { resolve } from '$app/paths';
 
 	import Card from '$lib/ui/Card.svelte';
 	import { compareStore } from '$lib/stores/compareStore';
@@ -169,7 +170,7 @@
 				<div class="py-8 text-center">
 					<p class="mb-4 text-lg">{$_('compare.no_products_selected')}</p>
 					<p class="mb-4 text-sm text-gray-600">{$_('compare.add_products_hint')}</p>
-					<a href="/products/search?q=chocolate" class="btn btn-primary">
+					<a href={resolve('/explore')} class="btn btn-primary">
 						{$_('compare.browse_products')}
 					</a>
 				</div>

--- a/src/routes/compare/shared/+page.svelte
+++ b/src/routes/compare/shared/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+
 	import Card from '$lib/ui/Card.svelte';
 	import ComparisonDisplay from '$lib/ui/ComparisonDisplay.svelte';
 	import { compareStore } from '$lib/stores/compareStore';
@@ -98,9 +100,7 @@
 				<p class="mb-4 text-sm text-gray-600">
 					{$_('compare.invalid_link_hint')}
 				</p>
-				<a href="/products/search?q=chocolate" class="btn btn-primary"
-					>{$_('compare.browse_products')}</a
-				>
+				<a href={resolve('/explore')} class="btn btn-primary">{$_('compare.browse_products')}</a>
 			</div>
 		{:else}
 			<ComparisonDisplay products={data.products} {comparisonMode} readonly />


### PR DESCRIPTION
## Description

This PR fixes an issue where, if you clicked on "Browse Products" while in the "Compare Products" page, you were redirected to a predefined search link for "chocolate" instead of the "Explore Products" page.

- Fixes #1077 