### PR TITLE
fix: bind collapse checkbox to reactive expanded

### DIFF
--- a/src/lib/knowledgepanels/Panel.svelte
+++ b/src/lib/knowledgepanels/Panel.svelte
@@ -37,7 +37,7 @@
 			'type' in title && `kp-panel-type-${title.type}`
 		]}
 	>
-		<input type="checkbox" checked={expanded} />
+		<input type="checkbox" bind:checked={expanded} />
 
 		<div
 			class={[


### PR DESCRIPTION
## Summary
Make the DaisyUI collapse reflect programmatic state changes by using two-way binding on the toggle checkbox.

---

## Changes
- **Updated `Panel.svelte`** replaced `checked={expanded}` with `bind:checked={expanded}`.
---

- Closes #1079 