### PR TITLE
fix: close sort panel after selecting option

### DIFF
--- a/src/lib/ui/SearchOptionsFooter.svelte
+++ b/src/lib/ui/SearchOptionsFooter.svelte
@@ -25,7 +25,10 @@
 				<button
 					class="hover:bg-base-200 flex w-full items-center gap-3 px-4 py-2 text-sm"
 					class:bg-base-200={sortBy === option.value}
-					onclick={() => onSortOptionSelect(option.value)}
+					onclick={() => {
+						onSortOptionSelect(option.value);
+						sortDropdownOpen = false;
+					}}
 				>
 					<span>{option.label}</span>
 					{#if sortBy === option.value}


### PR DESCRIPTION
## Summary
Close the mobile sort dropdown in `SearchOptionsFooter` after a user selects a sort option so the UI does not remain open. This improves UX on small screens and matches expected behavior for selection controls.

---

## How to Test
1. Open the site in **mobile emulation**.
2. Open the sticky footer **Sort** panel.
3. Select any option.
4. The panel should **close immediately** after selection.
---

## Closes #1090 