### PR TITLE
feat(edit): add Prices placeholder section linking to Open Prices

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -240,6 +240,7 @@
 				"languages": "Add product names and descriptions in different languages to make the product accessible to more users.",
 				"ingredients": "List all the ingredients present in the product. This helps users with allergies or dietary preferences.",
 				"nutrition": "Enter nutritional values per 100g/ml as shown on the packaging. This helps users compare products.",
+				"prices": "Help track this product's price history on Open Prices.",
 				"comment": "Optionally, add a comment to describe your changes or provide additional context.",
 				"packaging": "Describe each packaging component (bottle, cap, box, etc.) with its shape, material, and recycling instructions. You can add multiple components."
 			},
@@ -375,6 +376,7 @@
 				"ingredients": "Ingredients",
 				"nutrition": "Nutritional Information",
 				"packaging": "Packaging",
+				"prices": "Prices",
 				"comment": "Comment"
 			},
 			"legal_warning_title": "Do not upload copyrighted images",
@@ -425,7 +427,10 @@
 				"report_image": "Report Image",
 				"save_changes": "Save Changes"
 			},
-			"comment_description": "Add a comment about your changes (optional)"
+			"comment_description": "Add a comment about your changes (optional)",
+			"prices": {
+				"add_price_btn": "Add a price on Open Prices"
+			}
 		},
 		"prices": {
 			"no_prices_found": "No prices found for this product",

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -14,6 +14,8 @@
 	import IconMdiNutrition from '@iconify-svelte/mdi/nutrition';
 	import IconMdiPackageVariant from '@iconify-svelte/mdi/package-variant';
 	import IconMdiCommentText from '@iconify-svelte/mdi/comment-text';
+	import IconMdiTagMultiple from '@iconify-svelte/mdi/tag-multiple';
+	import IconMdiOpenInNew from '@iconify-svelte/mdi/open-in-new';
 
 	import type { Product } from '$lib/api';
 	import { _ } from '$lib/i18n';
@@ -135,6 +137,29 @@
 		</div>
 		<div class="collapse-content">
 			<NutritionStep bind:product {getNutritionImage} {handleNutrimentInput} />
+		</div>
+	</div>
+
+	<!-- Prices Section -->
+	<div class="collapse-arrow bg-base-200 collapse shadow-md">
+		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
+		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+			<IconMdiTagMultiple class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+			{$_('product.edit.sections.prices')}
+		</div>
+		<div class="collapse-content">
+			<p class="text-base-content/70 mt-2 mb-4 text-sm">
+				{$_('product.edit.info.prices')}
+			</p>
+			<a
+				href={`https://prices.openfoodfacts.org/prices/add/single?code=${encodeURIComponent(product.code ?? '')}`}
+				class="btn btn-secondary btn-sm"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				<IconMdiOpenInNew class="mr-1 h-4 w-4" />
+				{$_('product.edit.prices.add_price_btn')}
+			</a>
 		</div>
 	</div>
 

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -68,6 +68,11 @@
 		isSubmitting,
 		submit
 	}: Props = $props();
+
+	function getOpenPricesUrl(code: string): string {
+		const params = new URLSearchParams({ code });
+		return `https://prices.openfoodfacts.org/prices/add/single?${params}`;
+	}
 </script>
 
 <div class="space-y-4">
@@ -151,15 +156,17 @@
 			<p class="text-base-content/70 mt-2 mb-4 text-sm">
 				{$_('product.edit.info.prices')}
 			</p>
-			<a
-				href={`https://prices.openfoodfacts.org/prices/add/single?code=${encodeURIComponent(product.code ?? '')}`}
-				class="btn btn-secondary btn-sm"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				<IconMdiOpenInNew class="mr-1 h-4 w-4" />
-				{$_('product.edit.prices.add_price_btn')}
-			</a>
+			{#if product.code != null}
+				<a
+					href={getOpenPricesUrl(product.code)}
+					class="btn btn-secondary btn-sm"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<IconMdiOpenInNew class="mr-1 h-4 w-4" />
+					{$_('product.edit.prices.add_price_btn')}
+				</a>
+			{/if}
 		</div>
 	</div>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

Adds a new **Prices** placeholder section to the product edit form, allowing contributors to easily deep-link to Open Prices to add price data for the current product.

The edit form previously had no entry point for price contribution. This change introduces a dedicated collapsible section between "Nutritional Information" and "Comment" with an informational call-to-action button that opens the Open Prices add-price flow pre-filled with the product's barcode.

**Changes:**
- Added a new `Prices` accordion section to [EditProductForm.svelte](file:///d:/webDev/more-projects/open-source/GSOC/openfoodfacts-explorer/src/lib/ui/EditProductForm.svelte) with a deep link to `https://prices.openfoodfacts.org/prices/add/single?code={barcode}`
- Added 3 new i18n keys to [en-US.json](file:///d:/webDev/more-projects/open-source/GSOC/openfoodfacts-explorer/src/lib/i18n/messages/en-US.json) for the section title, description, and button label
- Section respects the user's `expandAllSections` preference

Fixes #672

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

---
## Screenshots
### Before
<img width="1891" height="769" alt="Screenshot 2026-03-08 214553" src="https://github.com/user-attachments/assets/98070ef7-10b3-4b70-b0a0-f63b42f34eef" />

### After
<img width="1919" height="867" alt="Screenshot 2026-03-08 211949" src="https://github.com/user-attachments/assets/6d002ecc-c583-48ac-be1c-ece5ab70411d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible "Prices" section in the product editor to view and track price history.
  * Added an "Add a price on Open Prices" button that opens the product on Open Prices in a new tab.
  * Section respects the editor's section expand/collapse behavior.

* **Documentation**
  * Added explanatory help text describing price history tracking and updated in-app comment wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->