### PR TITLE
fix: add handler for add_packaging_image KP action (#608)

### DIFF
--- a/src/lib/knowledgepanels/Action.svelte
+++ b/src/lib/knowledgepanels/Action.svelte
@@ -68,33 +68,28 @@
 
 	function getActionHandler(action: string) {
 		const handler = HANDLED_ACTIONS.find((a) => a.type === action);
-		return handler ? handler.action : DEFAULT_ACTION.bind(null, action);
-	}
-
-	function handleHtmlActionElementClick(event: MouseEvent) {
-		// If the click was on a link, let it handle the navigation
-		const target = event.target as HTMLElement;
-		if (target.tagName === 'A' || target.closest('a')) {
-			return;
-		}
-		const action = element.action_element.actions?.[0];
-		if (action) {
-			getActionHandler(action)();
-		}
+		return handler ? handler.action : () => DEFAULT_ACTION(action);
 	}
 </script>
 
-{#if element.action_element.html != ''}
-	<button class="btn btn-primary" onclick={handleHtmlActionElementClick}>
-		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-		{@html element.action_element.html}
-	</button>
-{:else}
-	{#each element.action_element.actions as action (action)}
-		{@const actionHandler = getActionHandler(action)}
+<div
+	class={[element.action_element.html != '' && 'border-accent bg-accent/10 rounded border-s p-4']}
+>
+	{#if element.action_element.html != ''}
+		<div class="mb-4 text-sm">
+			<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+			{@html element.action_element.html}
+		</div>
+	{/if}
 
-		<button class="btn btn-primary" onclick={actionHandler}>
-			{$_(`product.knowledge_panels.action.${action}`, { default: action })}
-		</button>
-	{/each}
-{/if}
+	{#if element.action_element.actions && element.action_element.actions.length > 0}
+		<div class="flex flex-wrap gap-2">
+			{#each element.action_element.actions as action (action)}
+				{@const actionHandler = getActionHandler(action)}
+				<button class="btn btn-primary btn-sm" onclick={actionHandler}>
+					{$_(`product.knowledge_panels.action.${action}`, { default: action })}
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## What
Adds a missing handler for the `add_packaging_image` action type in
the Knowledge Panel action component.

## Why
The Packaging KP action button was not working because `add_packaging_image`
was not in the `HANDLED_ACTIONS` array, causing it to fall through
to the default warning handler and do nothing when clicked.

## Changes
- Added `add_packaging_image` handler in `src/lib/knowledgepanels/Action.svelte`

## Testing
1. Open https://openfoodfacts-explorer.vercel.app/products/0720516026553
2. Scroll to **Packaging** section and expand it
3. Click "Take a photo of the recycling information" button
4. Should now navigate to `/products/[barcode]/edit#packaging`

https://github.com/user-attachments/assets/22bc17dc-c847-4aef-933a-11ae3d06baa1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for adding packaging images to products.

* **Improvements**
  * Action lists now render each action as its own button and reliably invoke the correct handler.
  * HTML content in panels is displayed inside a styled wrapper (accented border/background) for clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->