### PR TITLE
fix(ui): remove underline from footer links

### DIFF
--- a/src/lib/ui/Footer.svelte
+++ b/src/lib/ui/Footer.svelte
@@ -74,7 +74,7 @@
 		<h2 class="text-3xl font-extrabold">{$_('footer.stay_updated')}</h2>
 		<div class="flex flex-col gap-0">
 			{#each stayUpdatedLinks as stayUpdatedLink (stayUpdatedLink.url)}
-				<a href={stayUpdatedLink.url} class="no-underline">{$_(stayUpdatedLink.key)}</a>
+				<a href={stayUpdatedLink.url} class="link link-hover">{$_(stayUpdatedLink.key)}</a>
 			{/each}
 			<div class="mt-1 flex gap-3">
 				<a
@@ -118,7 +118,7 @@
 		<h2 class="mt-3 text-3xl font-extrabold">{$_('footer.contribute')}</h2>
 		<div class="flex flex-wrap gap-3">
 			{#each contributeLinks as contributeLink (contributeLink.url)}
-				<a href={contributeLink.url} class="no-underline">{$_(contributeLink.key)}</a>
+				<a href={contributeLink.url} class="link link-hover">{$_(contributeLink.key)}</a>
 			{/each}
 		</div>
 	</div>
@@ -164,7 +164,7 @@
 
 	<div class="text-primary relative z-10 mt-5 flex w-full flex-wrap justify-center gap-3 text-sm">
 		{#each footerLinks as footerLink (footerLink.url)}
-			<a href={footerLink.url} class="no-underline">{$_(footerLink.key)}</a>
+			<a href={footerLink.url} class="link link-hover">{$_(footerLink.key)}</a>
 		{/each}
 	</div>
 </div>


### PR DESCRIPTION
## Description

Remove underlines from footer links to make the footer look cleaner, while keeping hover and focus effects for accessibility.

## Screenshot after changes 

<img width="682" height="340" alt="image" src="https://github.com/user-attachments/assets/0e27d4da-61aa-4358-8048-3fbe384deb2d" />

## Closes #1116 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling and hover interaction behavior for footer navigation links to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->