### PR TITLE
feat: update /health endpoint to meet Docker acceptance criteria

### DIFF
--- a/src/routes/health/+server.ts
+++ b/src/routes/health/+server.ts
@@ -1,9 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import pkg from '../../../package.json';
 
 export const GET: RequestHandler = () => {
 	return json(
-		{ status: 'up' },
+		{
+			status: 'ok',
+			version: pkg.version
+		},
 		{
 			status: 200,
 			headers: { 'Cache-Control': 'no-cache' }


### PR DESCRIPTION
## Description

Hey team! 

I picked up this issue. While looking into it, I noticed that the `src/routes/health/+server.ts` file and the Docker `HEALTHCHECK` instruction were already set up on `main`. 

However, the existing endpoint returned `{"status": "up"}`, which didn't quite match the structure in the new issue's acceptance criteria. I updated the formatting to fit the requirements.

**Changes:**
- Updated the response to return `{"status": "ok"}`.
- Dynamically imported `package.json` to include the project `version` in the payload.
- Kept the existing `Cache-Control: no-cache` headers to ensure Docker always gets an accurate, uncached ping.

Here is the output from testing the route locally:

<img width="588" height="259" alt="image" src="https://github.com/user-attachments/assets/b58dc818-4ec9-4391-a8fa-5bd5db0e7da3" />

Fixes #1120

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [ ] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request a code review by commenting `/gemini review` on this PR after it's been created.