### PR TITLE
chore(csp): conditionally exclude vercel scripts from csp for self ho…

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,6 +8,8 @@ function runningOnVercel() {
 
 const adapter = runningOnVercel() ? vercelAdapter() : nodejsAdapter();
 
+const vercelScripts = runningOnVercel() ? ['https://va.vercel-scripts.com/'] : [];
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
@@ -24,7 +26,7 @@ const config = {
 				'script-src': [
 					'self',
 					'unsafe-eval', // Required for Vega charts
-					'https://va.vercel-scripts.com/',
+					...vercelScripts,
 					'https://analytics.openfoodfacts.org/matomo.js'
 				],
 				'img-src': [


### PR DESCRIPTION
## Description

Hey team! 👋 

This PR addresses the issue where Vercel-specific analytics scripts were hardcoded into the Content Security Policy (CSP), which slightly weakened the CSP for self-hosted Node/Docker deployments.

**Changes:**
- Replaced the hardcoded `https://va.vercel-scripts.com/` string in the `script-src` array with a dynamic `...vercelScripts` spread.
- Used the existing `runningOnVercel()` helper to ensure the Vercel analytics script is strictly included *only* when the app is actually deployed on Vercel.

**Local Testing:**
I verified this by running the standard dev server locally without the Vercel environment variables:
`pnpm run dev`

As shown in the network headers below, the Vercel script is successfully excluded from the `script-src` directive in a standard Node environment:

<img width="598" height="170" alt="image" src="https://github.com/user-attachments/assets/de8faf2f-ae3d-4215-8db0-56a4f6e7417d" />

To check other way around i ran command `$env:VERCEL="true"; pnpm run dev` and output is 
<img width="595" height="187" alt="image" src="https://github.com/user-attachments/assets/37ca4041-264c-49da-9ce1-f8cf49f8c13d" />

Fixes #1122

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [ ] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.