### PR TITLE
docs: add ORIGIN and WORKERS to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,9 @@ PUBLIC_PRICES_API_URL=https://prices.openfoodfacts.net
 PUBLIC_ROBOTOFF_URL=https://robotoff.openfoodfacts.net
 PUBLIC_IMAGES_URL=https://images.openfoodfacts.net
 PUBLIC_NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.net
+
+# Public-facing URL of the application, required by SvelteKit adapter-node for CSRF protection.
+ORIGIN
+
+# Number of Node.js worker processes used by the server, increasing this can improve performance on multi-core systems.
+WORKERS=4


### PR DESCRIPTION
## Description

Add ORIGIN and WORKERS variables to .env.example.

ORIGIN is required by SvelteKit's @sveltejs/adapter-node to correctly configure CSRF protection for POST requests. It is already used in compose.yml but was not documented in .env.example.

WORKERS is also referenced in the compose configuration but not documented.

Files changed:
- .env.example

Fixes # (issue)
#1123 

## Checklist:

**Author Self-Review:**

- [✅] I have performed a self-review of my own code.
- [✅] I understand the changes I'm proposing and why they are needed.
- [✅] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
- [✅] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.
