### PR TITLE
docs: add self-hosted deployment documentation and docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,51 @@ pnpm run build
 
 You can preview the production build with `pnpm run preview`.
 
+## Deploying (Self-Hosted / Docker)
+
+The Explorer can be deployed as a standalone Docker container using the
+[Node adapter](https://kit.svelte.dev/docs/adapter-node).
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and
+  [Docker Compose](https://docs.docker.com/compose/install/) (v2)
+
+### 1. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` to configure your deployment. See [`.env.example`](.env.example) for the full list of available variables.
+
+### 2. Start with Docker Compose
+
+```bash
+docker compose up -d
+```
+
+The container listens on port **3000** by default.
+
+### 3. Reverse proxy (nginx)
+
+If you are placing the app behind nginx, here is a basic configuration example:
+
+```nginx
+server {
+    listen 80;
+    server_name explorer.yourdomain.com;
+
+    location / {
+        proxy_pass         http://localhost:3000;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Forwarded-Host  $host;
+    }
+}
+```
+
 ## Contributors
 
 The app was initially created by @VaiTon. Since then, many people have contributed to it:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  explorer:
+    build: .
+    container_name: openfoodfacts-explorer
+    restart: unless-stopped
+    ports:
+      - '3000:3000'
+    env_file:
+      - .env


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

This PR introduces a self-hosted deployment option using Docker and Nginx, making it easy for developers and self-hosters to run their own instance of the Open Food Facts Explorer. 

**Implementation Details & Context:**
- I added a [docker-compose.yml](cci:7://file:///d:/webDev/more-projects/open-source/GSOC/openfoodfacts-explorer/docker-compose.yml:0:0-0:0) file pre-configured for the Node.js adapter.
- I noticed the existing [Dockerfile](cci:7://file:///d:/webDev/more-projects/open-source/GSOC/openfoodfacts-explorer/Dockerfile:0:0-0:0) already handles setting `NODE_ENV=production` and `PORT=3000`, as well as setting up the `HEALTHCHECK`. To align seamlessly with your existing architecture, I kept the [docker-compose.yml](cci:7://file:///d:/webDev/more-projects/open-source/GSOC/openfoodfacts-explorer/docker-compose.yml:0:0-0:0) lean and avoided duplicating those environment variables or health checks.
- I've included extensive additions to the [README.md](cci:7://file:///d:/webDev/more-projects/open-source/GSOC/openfoodfacts-explorer/README.md:0:0-0:0) containing full instructions on how to copy `.env` files, run the container, and set up an Nginx reverse proxy.

*Note: I carefully reviewed the existing [Dockerfile](cci:7://file:///d:/webDev/more-projects/open-source/GSOC/openfoodfacts-explorer/Dockerfile:0:0-0:0) and [svelte.config.js](cci:7://file:///d:/webDev/more-projects/open-source/GSOC/openfoodfacts-explorer/svelte.config.js:0:0-0:0) to ensure these deployment instructions and compose configs integrate smoothly. I'm very open to feedback, if there are any specific structural changes or naming conventions you’d prefer for the compose file or README additions, please let me know and I'd be happy to adjust!*

Fixes #1121

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.
