### PR TITLE
fix(ui): add missing help.button translation key

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -58,6 +58,9 @@
 			"moderator": "Moderator"
 		}
 	},
+	"help": {
+		"button": "Help and Shortcuts"
+	},
 	"general": {
 		"language": "Language",
 		"country": "Country",

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -29,6 +29,9 @@
 		"status": "Status",
 		"actions": "Actions"
 	},
+	"help": {
+		"button": "Aiuto e scorciatoie"
+	},
 	"general": {
 		"language": "Language",
 		"country": "Paese",


### PR DESCRIPTION
### Description
This PR addresses issue #1132 where the help button in the navigation header was displaying the raw translation key `help.button` instead of the intended text.

### Changes
- Added `"help": { "button": "Help and Shortcuts" }` to [src/lib/i18n/messages/en-US.json](cci:7://file:///e:/projects/openfoodfacts-explorer/src/lib/i18n/messages/en-US.json:0:0-0:0).
- Added `"help": { "button": "Aiuto e scorciatoie" }` to [src/lib/i18n/messages/it-IT.json](cci:7://file:///e:/projects/openfoodfacts-explorer/src/lib/i18n/messages/it-IT.json:0:0-0:0).

### How to test

1. Run the project locally (`pnpm dev`).
2. Hover over the question mark icon in the top-right corner.
3. Verify that the tooltip/aria-label now correctly displays "Help and Shortcuts" instead of the raw key.
4. (Optional) Switch language to Italian and verify it shows "Aiuto e scorciatoie".

### GSoC 2026
I am a candidate for GSoC 2026. This is my initial contribution to the project to demonstrate my understanding of the codebase and the contribution workflow.

<img width="432" height="113" alt="fixed" src="https://github.com/user-attachments/assets/ffc1279e-6203-49f4-8314-45dfb96fd3e7" />


Fixes #1132
