### PR TITLE
feat(ui): add reusable CountUp component for animated stats

### DIFF
--- a/src/lib/ui/CountUp.svelte
+++ b/src/lib/ui/CountUp.svelte
@@ -6,15 +6,17 @@
 	interface Props {
 		value: number;
 		duration?: number;
+		suffix?: string;
 	}
 
-	let { value, duration = 1500 }: Props = $props();
+	let { value, duration = 1500, suffix = '' }: Props = $props();
 
 	const count = new Tween(0, { easing: cubicOut });
 
 	let element: HTMLElement | undefined = $state();
 	let display = $derived(Math.floor(count.current));
 	let hasStarted = false;
+
 	const formatter = new Intl.NumberFormat();
 
 	onMount(() => {
@@ -33,8 +35,14 @@
 
 		return () => observer.disconnect();
 	});
+
+	$effect(() => {
+		if (hasStarted) {
+			count.set(value, { duration });
+		}
+	});
 </script>
 
 <span bind:this={element}>
-	{formatter.format(display)}
+	{formatter.format(display)}{suffix}
 </span>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -161,7 +161,7 @@
 	>
 		<IconMdiLicense class="text-primary mb-4 h-12 w-12" />
 		<h2 class="text-xl font-bold">
-			<CountUp value={100} />%
+			<CountUp value={100} suffix="%" />
 		</h2>
 		<p class="text-base-content/70">{$_('landing.open_data')}</p>
 	</a>


### PR DESCRIPTION
### Summary
This PR addresses issue https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1141 a reusable `CountUp` Svelte component to animate numeric stats when they enter the viewport.  
It improves the UI/UX for key metrics like products count, contributors, or open data percentage on the homepage or other stats sections.

### Features
- Smooth animation using `Tween` from `svelte/motion` with `cubicOut` easing
- Automatically triggers animation when the element becomes visible using `IntersectionObserver`
- Props supported:
  - `value`: target number
  - `duration` (optional): animation duration in milliseconds
- Numbers formatted using `Intl.NumberFormat`
- Fully reusable across multiple cards or sections

### Example Usage
```svelte
<h2 class="text-xl font-bold">
  <CountUp value={data.productCount} />
</h2>

<h2 class="text-xl font-bold">
  <CountUp value={100} suffix="%" />
</h2>
```
### Demo

https://github.com/user-attachments/assets/14a6a4b0-eb7a-4c08-876c-bd4e80f06e08

Fixes https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated number counters on the landing page: product count, contributor count, and completion percentage now animate when scrolled into view.
  * Counters use localized number formatting, support an adjustable animation duration (default 1.5s), and optional suffixes (e.g., "%").
  * Animations begin on first visibility and update smoothly when values change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->