### PR TITLE
fix: center compared items & add Product Image label

### DIFF
--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -452,7 +452,7 @@
 	<table class="table-zebra table w-full table-fixed">
 		<thead>
 			<tr>
-				<th class="bg-base-100 sticky left-0 z-10 w-40"></th>
+				<th class="bg-base-100 sticky left-0 z-10 w-40 text-white">Product Image</th>
 				{#each products as product, index (product.code)}
 					<th
 						animate:flip={{ duration: 300 }}
@@ -613,12 +613,12 @@
 			{#each availableNutrients as nutrient (nutrient.key)}
 				<tr>
 					<td
-						class="bg-base-100 sticky left-0 w-40 overflow-hidden leading-tight font-semibold break-words whitespace-normal"
+						class="bg-base-100 sticky left-0 z-10 w-40 overflow-hidden leading-tight font-semibold break-words whitespace-normal"
 						>{nutrient.label}</td
 					>
 					{#each products as product, index (product.code)}
 						{@const comparison = getNutrientComparison(product, nutrient.key, products, index)}
-						<td animate:flip={{ duration: 300 }}>
+						<td class="text-center" animate:flip={{ duration: 300 }}>
 							{@render nutrientValueDesktop(comparison, nutrient.unit)}
 						</td>
 					{/each}


### PR DESCRIPTION
### Summary
This PR addresses issue https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1143

### What I changed
- Added the missing label for the product image.
- Adjusted the alignment so that all sections of the comparison table have consistent centering.


### Screenshots

## First Problem 

<img width="1920" height="1020" alt="Compare Products and 1 more page - Profile 1 - Microsoft​ Edge 3_14_2026 1_38_40 AM" src="https://github.com/user-attachments/assets/baf9f86c-60da-4b74-89af-1054946cebd7" />

## Second Problem 

<img width="1920" height="1020" alt="Compare Products and 1 more page - Profile 1 - Microsoft​ Edge 3_14_2026 1_38_24 AM" src="https://github.com/user-attachments/assets/fa7509e5-6f4e-420b-8fe2-faaf5e56a6a3" />

fixes: https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1143
