### PR TITLE
feat: pass keycloak token to folksonomy editor web-component

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -163,7 +163,7 @@
 			</label>
 
 			{#if useWCFolksonomyEditor}
-				<!-- TODO: use the SDK directly in the webcomponent -->
+				<!-- TODO: This solution is far from optimal. Embedding tokens into the DOM is a security risk -->
 				<folksonomy-editor
 					page-type="edit"
 					product-code={product.code}


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

- Imports the `userAuthTokens` store in the product page and passes the current Keycloak `access_token` to the 
<folksonomy-editor> via the auth token attribute.

Fixes #1145 

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [ ] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Product editor component now authenticates user sessions with proper credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->