### PR TITLE
fix: potential N+1 API calls when fetching prices

### DIFF
--- a/src/lib/utils/promises.ts
+++ b/src/lib/utils/promises.ts
@@ -1,0 +1,47 @@
+/**
+ * Runs an array of async tasks with a bounded number of concurrent executions.
+ *
+ * Unlike `Promise.all`, this does not fire every task simultaneously. Instead it
+ * spins up at most `limit` workers that each pull the next task from a shared
+ * queue, which keeps downstream APIs from being overwhelmed.
+ *
+ * Each task's outcome is reported independently via `PromiseSettledResult`, so
+ * a single rejection never short-circuits the rest of the batch.
+ *
+ * @param tasks  Factory functions that each produce a Promise when invoked.
+ * @param limit  Maximum number of tasks running at the same time. Values that
+ *               are not finite positive numbers are clamped up to `1`.
+ * @returns      One settled result per input task, in the original order.
+ */
+export async function withConcurrencyLimit<T>(
+	tasks: (() => Promise<T>)[],
+	limit: number
+): Promise<PromiseSettledResult<T>[]> {
+	if (tasks.length === 0) return [];
+
+	// Normalise the limit to a safe positive integer so a bad input can never
+	// stall the worker pool.
+	const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 1;
+
+	const results: PromiseSettledResult<T>[] = new Array(tasks.length);
+	let nextIndex = 0;
+
+	const worker = async () => {
+		while (true) {
+			const currentIndex = nextIndex++;
+			if (currentIndex >= tasks.length) return;
+
+			try {
+				const value = await tasks[currentIndex]();
+				results[currentIndex] = { status: 'fulfilled', value };
+			} catch (reason) {
+				results[currentIndex] = { status: 'rejected', reason };
+			}
+		}
+	};
+
+	const workerCount = Math.min(safeLimit, tasks.length);
+	await Promise.all(Array.from({ length: workerCount }, worker));
+
+	return results;
+}

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -6,6 +6,13 @@ import { PricesApi, SearchApi, type SearchBody } from '@openfoodfacts/openfoodfa
 import { createSearchApi, type SearchResult } from '$lib/api/search';
 import { createPricesApi, isConfigured as isPricesConfigured } from '$lib/api/prices';
 import { createProductsApi, getBulkProductAttributes } from '$lib/api/product';
+import { withConcurrencyLimit } from '$lib/utils/promises';
+
+// Maximum number of Prices API requests allowed to run in parallel.
+// A full page of search results can contain ~24 products, and firing every
+// price lookup simultaneously risks rate-limiting and slows the page down.
+// 5 is a conservative value that balances throughput with backend safety.
+const PRICES_CONCURRENCY_LIMIT = 5;
 
 function isValidEAN13(code: string): boolean {
 	if (!/^\d{13}$/.test(code)) {
@@ -23,17 +30,43 @@ function isValidEAN13(code: string): boolean {
 }
 
 async function getPrices(api: PricesApi, barcodes: string[]): Promise<Record<string, number>> {
-	const prices: Record<string, number> = {};
-	const results = await Promise.all(
-		barcodes.map(async (code) => ({
-			code: code,
-			prices: await api.getPrices({ product_code: code })
-		}))
-	);
+	if (barcodes.length === 0) return {};
 
-	for (const result of results) {
-		if (result.prices.data && result.prices.data.items) {
-			prices[result.code] = result.prices.data.total;
+	// Each task preserves its barcode on failure so rejected results can be
+	// logged against the specific product that failed.
+	const tasks = barcodes.map((code) => async () => {
+		try {
+			const pricesResponse = await api.getPrices({ product_code: code });
+			return { code, pricesResponse };
+		} catch (err) {
+			throw { code, error: err };
+		}
+	});
+
+	const settled = await withConcurrencyLimit(tasks, PRICES_CONCURRENCY_LIMIT);
+
+	const prices: Record<string, number> = {};
+	for (const result of settled) {
+		if (result.status === 'rejected') {
+			const { code, error: fetchError } = (result.reason ?? {}) as {
+				code?: string;
+				error?: unknown;
+			};
+			if (code) {
+				console.warn(`[getPrices] Failed to fetch price for barcode ${code}:`, fetchError);
+			} else {
+				console.warn('[getPrices] Failed to fetch price for a barcode:', result.reason);
+			}
+			continue;
+		}
+
+		const { code, pricesResponse } = result.value;
+
+		// Store the total whenever the API returned a numeric value. Products
+		// with zero recorded prices are still valid data and must appear in the
+		// map, otherwise the UI renders "undefined prices" in the badge.
+		if (pricesResponse.data != null && typeof pricesResponse.data.total === 'number') {
+			prices[code] = pricesResponse.data.total;
 		}
 	}
 

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -32,14 +32,17 @@ function isValidEAN13(code: string): boolean {
 async function getPrices(api: PricesApi, barcodes: string[]): Promise<Record<string, number>> {
 	if (barcodes.length === 0) return {};
 
-	// Each task preserves its barcode on failure so rejected results can be
-	// logged against the specific product that failed.
+	// Each task wraps a failure in a real Error so stack traces are preserved,
+	// and attaches the barcode as `code` so rejected results can be logged
+	// against the specific product that failed.
 	const tasks = barcodes.map((code) => async () => {
 		try {
 			const pricesResponse = await api.getPrices({ product_code: code });
 			return { code, pricesResponse };
 		} catch (err) {
-			throw { code, error: err };
+			throw Object.assign(new Error(`Failed to fetch price for barcode ${code}`, { cause: err }), {
+				code
+			});
 		}
 	});
 
@@ -48,12 +51,10 @@ async function getPrices(api: PricesApi, barcodes: string[]): Promise<Record<str
 	const prices: Record<string, number> = {};
 	for (const result of settled) {
 		if (result.status === 'rejected') {
-			const { code, error: fetchError } = (result.reason ?? {}) as {
-				code?: string;
-				error?: unknown;
-			};
+			const reason = result.reason as (Error & { code?: string }) | undefined;
+			const code = reason?.code;
 			if (code) {
-				console.warn(`[getPrices] Failed to fetch price for barcode ${code}:`, fetchError);
+				console.warn(`[getPrices] Failed to fetch price for barcode ${code}:`, reason?.cause);
 				// Guarantee every attempted barcode has a numeric entry so the UI
 				// never renders "undefined prices" when a single lookup fails.
 				prices[code] = 0;

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -54,6 +54,9 @@ async function getPrices(api: PricesApi, barcodes: string[]): Promise<Record<str
 			};
 			if (code) {
 				console.warn(`[getPrices] Failed to fetch price for barcode ${code}:`, fetchError);
+				// Guarantee every attempted barcode has a numeric entry so the UI
+				// never renders "undefined prices" when a single lookup fails.
+				prices[code] = 0;
 			} else {
 				console.warn('[getPrices] Failed to fetch price for a barcode:', result.reason);
 			}
@@ -62,12 +65,13 @@ async function getPrices(api: PricesApi, barcodes: string[]): Promise<Record<str
 
 		const { code, pricesResponse } = result.value;
 
-		// Store the total whenever the API returned a numeric value. Products
-		// with zero recorded prices are still valid data and must appear in the
-		// map, otherwise the UI renders "undefined prices" in the badge.
-		if (pricesResponse.data != null && typeof pricesResponse.data.total === 'number') {
-			prices[code] = pricesResponse.data.total;
-		}
+		// Store the total whenever the API returned a numeric value (including 0).
+		// Products with zero recorded prices are still valid data and must appear
+		// in the map, otherwise the UI renders "undefined prices" in the badge.
+		prices[code] =
+			pricesResponse.data != null && typeof pricesResponse.data.total === 'number'
+				? pricesResponse.data.total
+				: 0;
 	}
 
 	return prices;


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description

This PR fixes the issue where price data for every product on the search results page was being fetched all at once using "Promise.all". When there are a lot of search results, this causes a huge spike in API requests which can overload the Prices API or trigger rate limiting.

##Solution

To fix this, I added a concurrency limiter that allows only **5 requests to run at a time**:
```js
const PRICES_CONCURRENCY_LIMIT = 5
```

The remaining requests queue up and execute as slots free up, which makes the whole thing a lot more stable.

Fixes #1147 



---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

Requesting review from maintainers. Please let me know if any changes or improvements are required.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added concurrency-limited execution for price lookups to improve throughput and resource use.
  * Introduced a reusable concurrency utility to run bounded async tasks in original order.

* **Bug Fixes**
  * Empty barcode queries now return immediately with no work.
  * Individual lookup failures are logged and defaulted to zero without aborting the overall fetch.
  * Zero totals are preserved correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->