### PR TITLE
fix: add rel='noopener noreferrer' to external links in footer

### DIFF
--- a/src/lib/ui/Footer.svelte
+++ b/src/lib/ui/Footer.svelte
@@ -80,6 +80,7 @@
 				<a
 					href="https://twitter.com/OpenFoodFacts"
 					target="_blank"
+					rel="noopener noreferrer"
 					aria-label={$_('footer.social.x')}
 				>
 					<IconSimpleIconsX class="h-6 w-5" />
@@ -87,6 +88,7 @@
 				<a
 					href="https://www.instagram.com/open.food.facts/"
 					target="_blank"
+					rel="noopener noreferrer"
 					aria-label={$_('footer.social.instagram')}
 				>
 					<IconMdiInstagram class="h-6 w-6" />
@@ -94,6 +96,7 @@
 				<a
 					href="https://github.com/openfoodfacts/openfoodfacts-explorer"
 					target="_blank"
+					rel="noopener noreferrer"
 					aria-label={$_('footer.social.github')}
 				>
 					<IconMdiGithub class="h-6 w-6" />
@@ -101,6 +104,7 @@
 				<a
 					href="https://www.facebook.com/OpenFoodFacts"
 					target="_blank"
+					rel="noopener noreferrer"
 					aria-label={$_('footer.social.facebook')}
 				>
 					<IconMdiFacebook class="h-6 w-6" />
@@ -108,6 +112,7 @@
 				<a
 					href="https://slack.openfoodfacts.org/"
 					target="_blank"
+					rel="noopener noreferrer"
 					aria-label={$_('footer.social.slack')}
 				>
 					<IconMdiSlack class="h-6 w-6" />


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->
## Description

Adds `rel="noopener noreferrer"` to external links that use `target="_blank"` in the `Footer.svelte` component.

This improves security by preventing reverse tabnabbing and follows recommended HTML best practices for external links.

No functional or visual changes are introduced.

Fixes # (issue)  
N/A

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
