### PR TITLE
feat: add Radar Chart visualization for core nutrients vs daily reference intakes

### DIFF
--- a/src/lib/api/nutriments.test.ts
+++ b/src/lib/api/nutriments.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { REFERENCE_INTAKES, calculateNutrientPercentage } from './nutriments';
+
+describe('REFERENCE_INTAKES', () => {
+	it('has correct EU reference intake values for core nutrients', () => {
+		expect(REFERENCE_INTAKES.fat).toBe(70);
+		expect(REFERENCE_INTAKES['saturated-fat']).toBe(20);
+		expect(REFERENCE_INTAKES.sugars).toBe(90);
+		expect(REFERENCE_INTAKES.salt).toBe(6);
+	});
+});
+
+describe('calculateNutrientPercentage', () => {
+	it('calculates 50% for half the reference value of fat', () => {
+		expect(calculateNutrientPercentage(35, 'fat')).toBe(50);
+	});
+
+	it('calculates 50% for half the reference value of salt', () => {
+		expect(calculateNutrientPercentage(3, 'salt')).toBe(50);
+	});
+
+	it('returns 0% for zero values', () => {
+		expect(calculateNutrientPercentage(0, 'sugars')).toBe(0);
+	});
+
+	it('returns > 100% for values exceeding the reference', () => {
+		expect(calculateNutrientPercentage(90, 'sugars')).toBe(100);
+		expect(calculateNutrientPercentage(100, 'sugars')).toBeGreaterThan(100);
+	});
+});

--- a/src/lib/api/nutriments.ts
+++ b/src/lib/api/nutriments.ts
@@ -96,3 +96,26 @@ export const NUTRIENTS = [
 ] as const;
 
 export type NutrientKey = (typeof NUTRIENTS)[number];
+
+/**
+ * EU daily reference intake values (based on a 2000 kcal diet).
+ * Source: EU Regulation No 1169/2011, Annex XIII
+ */
+export const REFERENCE_INTAKES = {
+	fat: 70,
+	'saturated-fat': 20,
+	sugars: 90,
+	salt: 6
+} as const;
+
+/**
+ * Calculates the percentage of a nutrient value against its EU daily reference intake.
+ */
+export function calculateNutrientPercentage(
+	value: number,
+	nutrient: keyof typeof REFERENCE_INTAKES
+): number {
+	const refValue = REFERENCE_INTAKES[nutrient];
+	if (!refValue) return 0;
+	return (value / refValue) * 100;
+}

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -182,6 +182,17 @@
 			"stores": "Stores",
 			"countries": "Countries"
 		},
+		"nutrition": {
+			"radar_chart_title": "Nutrient Comparison (% of RI)",
+			"radar_chart_note": "Values based on {basis} and {intake} daily reference intake.",
+			"radar_chart_no_data": "No nutritional data available.",
+			"radar_chart_legend_level": "Nutrient level",
+			"radar_chart_legend_limit": "100% RI limit",
+			"radar_chart_label_100_ri": "100% RI",
+			"radar_chart_tooltip_nutrient": "Nutrient",
+			"radar_chart_tooltip_amount": "Amount (per 100g)",
+			"radar_chart_tooltip_intake": "% of Daily Intake"
+		},
 		"folksonomy": {
 			"use_wc_editor": "Use the Web Component Editor",
 			"title_beta": "Personalized properties (beta)",
@@ -332,7 +343,9 @@
 				"salt": "Salt",
 				"fibers": "Fibers",
 				"sodium": "Sodium",
-				"alcohol": "Alcohol"
+				"alcohol": "Alcohol",
+				"nutrient": "Nutrient",
+				"amount_g": "Amount (g)"
 			},
 			"additional_nutrients": "Additional nutrients",
 			"comment": "Comment",

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -107,6 +107,17 @@
 		"shortcuts": {
 			"show_barcode": "Mostra codice a barre del prodotto"
 		},
+		"nutrition": {
+			"radar_chart_title": "Confronto nutrienti (% di RI)",
+			"radar_chart_note": "Valori basati su {basis} e {intake} di assunzione giornaliera di riferimento.",
+			"radar_chart_no_data": "Nessun dato nutrizionale disponibile.",
+			"radar_chart_legend_level": "Livello di nutrienti",
+			"radar_chart_legend_limit": "Limite del 100% RI",
+			"radar_chart_label_100_ri": "100% RI",
+			"radar_chart_tooltip_nutrient": "Nutriente",
+			"radar_chart_tooltip_amount": "Quantità (per 100g)",
+			"radar_chart_tooltip_intake": "% dell'assunzione giornaliera"
+		},
 		"folksonomy": {
 			"use_wc_editor": "Usa l'editor Web Component",
 			"title_beta": "Proprieta personalizzate (beta)",

--- a/src/lib/stores/calculatorStore.ts
+++ b/src/lib/stores/calculatorStore.ts
@@ -7,6 +7,7 @@ export type NutritionData = {
 	proteins: number;
 	carbohydrates: number;
 	fat: number;
+	saturatedFat: number;
 	sugars: number;
 	salt: number;
 };
@@ -73,8 +74,9 @@ export function extractNutriments(nutriments: Nutriments): NutritionData {
 		proteins: nutriments.proteins_100g || 0,
 		carbohydrates: nutriments.carbohydrates_100g || 0,
 		fat: nutriments.fat_100g || 0,
-		sugars: nutriments.sugars_100g,
-		salt: nutriments.salt_100g
+		saturatedFat: nutriments['saturated-fat_100g'] || 0,
+		sugars: nutriments.sugars_100g || 0,
+		salt: nutriments.salt_100g || 0
 	};
 }
 
@@ -84,6 +86,7 @@ function calculateTotals(items: CalculatorItem[]): NutritionData {
 		proteins: 0,
 		carbohydrates: 0,
 		fat: 0,
+		saturatedFat: 0,
 		sugars: 0,
 		salt: 0
 	};
@@ -94,6 +97,7 @@ function calculateTotals(items: CalculatorItem[]): NutritionData {
 		totals.proteins += item.nutriments.proteins * factor;
 		totals.carbohydrates += item.nutriments.carbohydrates * factor;
 		totals.fat += item.nutriments.fat * factor;
+		totals.saturatedFat += (item.nutriments.saturatedFat || 0) * factor;
 
 		if (item.nutriments.sugars) {
 			totals.sugars += item.nutriments.sugars * factor;

--- a/src/lib/ui/RadarChart.svelte
+++ b/src/lib/ui/RadarChart.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+	import VegaChart from './VegaChart.svelte';
+	import type { Product } from '@openfoodfacts/openfoodfacts-nodejs';
+	import type { Spec } from 'vega';
+	import { _ } from '$lib/i18n';
+	import { REFERENCE_INTAKES, calculateNutrientPercentage } from '$lib/api/nutriments';
+
+	type Props = {
+		product: Product;
+	};
+
+	let { product }: Props = $props();
+
+	const nutrientData = $derived.by(() => {
+		if (!product || !product.nutriments) return [];
+
+		const nutrients = [
+			{ key: 'fat', label: $_('product.edit.nutrient.fat') },
+			{ key: 'saturated-fat', label: $_('product.edit.nutrient.saturated-fat') },
+			{ key: 'sugars', label: $_('product.edit.nutrient.sugars') },
+			{ key: 'salt', label: $_('product.edit.nutrient.salt') }
+		];
+
+		return nutrients.map((n) => {
+			const value = (product.nutriments?.[`${n.key}_100g`] as number) || 0;
+			const unconstrainedPercentage = calculateNutrientPercentage(
+				value,
+				n.key as keyof typeof REFERENCE_INTAKES
+			);
+			const percentage = Math.min(unconstrainedPercentage, 120);
+			return {
+				nutrient: n.label,
+				value: Math.round(value * 10) / 10,
+				percentage: Math.round(percentage * 10) / 10
+			};
+		});
+	});
+
+	// Build a proper Vega v5 radar/spider chart spec with dark-theme styling
+	// Drastically increased size to 600x600 to fill the card space
+	const spec = $derived.by((): Spec => {
+		return {
+			$schema: 'https://vega.github.io/schema/vega/v5.json',
+			width: 600,
+			height: 600,
+			padding: 60,
+			background: 'transparent',
+			autosize: 'none',
+			signals: [
+				{ name: 'radius', value: 250 },
+				{ name: 'startAngle', value: -Math.PI / 2 }
+			],
+			data: [
+				{
+					name: 'table',
+					values: nutrientData
+				},
+				{
+					name: 'keys',
+					source: 'table',
+					transform: [{ type: 'aggregate', groupby: ['nutrient'] }]
+				}
+			],
+			scales: [
+				{
+					name: 'angular',
+					type: 'point',
+					range: { signal: '[startAngle, startAngle + 2 * PI]' },
+					padding: 0.5,
+					domain: { data: 'table', field: 'nutrient' }
+				},
+				{
+					name: 'radial',
+					type: 'linear',
+					range: { signal: '[0, radius]' },
+					zero: true,
+					nice: false,
+					domain: [0, 120]
+				}
+			],
+			encode: {
+				enter: {
+					x: { signal: 'width / 2' },
+					y: { signal: 'height / 2' }
+				}
+			},
+			marks: [
+				// Spoke lines
+				{
+					type: 'rule',
+					from: { data: 'keys' },
+					encode: {
+						enter: {
+							x: { value: 0 },
+							y: { value: 0 },
+							x2: { signal: 'radius * cos(scale("angular", datum.nutrient))' },
+							y2: { signal: 'radius * sin(scale("angular", datum.nutrient))' },
+							stroke: { value: '#4a5568' },
+							strokeWidth: { value: 1 },
+							strokeOpacity: { value: 0.6 }
+						}
+					}
+				},
+				// Grid ring at 25%
+				{
+					type: 'line',
+					from: { data: 'keys' },
+					encode: {
+						enter: {
+							interpolate: { value: 'linear-closed' },
+							x: { signal: 'scale("radial", 25) * cos(scale("angular", datum.nutrient))' },
+							y: { signal: 'scale("radial", 25) * sin(scale("angular", datum.nutrient))' },
+							stroke: { value: '#4a5568' },
+							strokeWidth: { value: 0.5 },
+							strokeOpacity: { value: 0.4 },
+							fill: { value: 'transparent' }
+						}
+					}
+				},
+				// Grid ring at 50%
+				{
+					type: 'line',
+					from: { data: 'keys' },
+					encode: {
+						enter: {
+							interpolate: { value: 'linear-closed' },
+							x: { signal: 'scale("radial", 50) * cos(scale("angular", datum.nutrient))' },
+							y: { signal: 'scale("radial", 50) * sin(scale("angular", datum.nutrient))' },
+							stroke: { value: '#4a5568' },
+							strokeWidth: { value: 0.5 },
+							strokeOpacity: { value: 0.6 },
+							fill: { value: 'transparent' }
+						}
+					}
+				},
+				// Grid ring at 100% (highlighted)
+				{
+					type: 'line',
+					from: { data: 'keys' },
+					encode: {
+						enter: {
+							interpolate: { value: 'linear-closed' },
+							x: { signal: 'scale("radial", 100) * cos(scale("angular", datum.nutrient))' },
+							y: { signal: 'scale("radial", 100) * sin(scale("angular", datum.nutrient))' },
+							stroke: { value: '#e2533a' },
+							strokeWidth: { value: 1.5 },
+							strokeOpacity: { value: 0.8 },
+							strokeDash: { value: [5, 4] },
+							fill: { value: 'transparent' }
+						}
+					}
+				},
+				{
+					type: 'text',
+					encode: {
+						enter: {
+							x: { value: 6 },
+							y: { signal: '-scale("radial", 100)' },
+							text: { signal: `"${$_('product.nutrition.radar_chart_label_100_ri')}"` },
+							fill: { value: '#e2533a' },
+							fontSize: { value: 10 },
+							fontWeight: { value: 'bold' },
+							opacity: { value: 0.9 }
+						}
+					}
+				},
+				{
+					type: 'text',
+					encode: {
+						enter: {
+							x: { value: 6 },
+							y: { signal: '-scale("radial", 50)' },
+							text: { value: '50%' },
+							fill: { value: '#a0aec0' },
+							fontSize: { value: 9 },
+							opacity: { value: 0.8 }
+						}
+					}
+				},
+				// Data area fill (filled polygon)
+				{
+					type: 'line',
+					from: { data: 'table' },
+					encode: {
+						enter: {
+							interpolate: { value: 'linear-closed' },
+							x: {
+								signal: 'scale("radial", datum.percentage) * cos(scale("angular", datum.nutrient))'
+							},
+							y: {
+								signal: 'scale("radial", datum.percentage) * sin(scale("angular", datum.nutrient))'
+							},
+							stroke: { value: '#f97316' },
+							strokeWidth: { value: 3 },
+							strokeJoin: { value: 'round' },
+							fill: { value: '#f97316' },
+							fillOpacity: { value: 0.25 }
+						}
+					}
+				},
+				// Data points
+				{
+					type: 'symbol',
+					from: { data: 'table' },
+					encode: {
+						enter: {
+							x: {
+								signal: 'scale("radial", datum.percentage) * cos(scale("angular", datum.nutrient))'
+							},
+							y: {
+								signal: 'scale("radial", datum.percentage) * sin(scale("angular", datum.nutrient))'
+							},
+							fill: { value: '#f97316' },
+							stroke: { value: '#fff' },
+							strokeWidth: { value: 2 },
+							size: { value: 80 },
+							shape: { value: 'circle' },
+							tooltip: {
+								signal: `{"${$_('product.nutrition.radar_chart_tooltip_nutrient')}": datum.nutrient, "${$_('product.nutrition.radar_chart_tooltip_amount')}": datum.value + "g", "${$_('product.nutrition.radar_chart_tooltip_intake')}": datum.percentage + "%"}`
+							}
+						},
+						update: {
+							opacity: { value: 1 }
+						},
+						hover: {
+							opacity: { value: 0.8 },
+							size: { value: 120 }
+						}
+					}
+				},
+				// Axis labels
+				{
+					type: 'text',
+					from: { data: 'keys' },
+					encode: {
+						enter: {
+							x: { signal: '(radius + 35) * cos(scale("angular", datum.nutrient))' },
+							y: { signal: '(radius + 35) * sin(scale("angular", datum.nutrient))' },
+							text: { field: 'nutrient' },
+							align: {
+								signal:
+									'cos(scale("angular", datum.nutrient)) > 0.1 ? "left" : cos(scale("angular", datum.nutrient)) < -0.1 ? "right" : "center"'
+							},
+							baseline: {
+								signal:
+									'sin(scale("angular", datum.nutrient)) > 0.1 ? "top" : sin(scale("angular", datum.nutrient)) < -0.1 ? "bottom" : "middle"'
+							},
+							fill: { value: '#e2e8f0' },
+							fontSize: { value: 16 },
+							fontWeight: { value: 'bold' }
+						}
+					}
+				}
+			]
+		};
+	});
+</script>
+
+<div class="card bg-base-200 border-base-300 border shadow-md">
+	<div class="card-body p-6">
+		<h3 class="card-title mb-1 text-lg font-semibold">
+			{$_('product.nutrition.radar_chart_title')}
+		</h3>
+		<p class="text-base-content/50 mb-4 text-sm">
+			{$_('product.nutrition.radar_chart_note', {
+				values: { basis: '100g', intake: '2000 kcal' }
+			})}
+		</p>
+		<div class="flex w-full justify-center">
+			{#if nutrientData.length > 0}
+				<!-- Spec is 600x600 + 60px padding = ~720px total bounding box -->
+				<VegaChart {spec} height="650px" />
+			{:else}
+				<div class="flex h-80 items-center justify-center text-sm opacity-50">
+					{$_('product.nutrition.radar_chart_no_data')}
+				</div>
+			{/if}
+		</div>
+		<div class="mt-4 flex items-center justify-center gap-6 text-sm font-medium opacity-70">
+			<span class="flex items-center gap-2">
+				<span class="inline-block h-3 w-6 rounded" style="background:#f97316"></span>
+				{$_('product.nutrition.radar_chart_legend_level')}
+			</span>
+			<span class="flex items-center gap-2">
+				<span
+					class="inline-block h-3 w-6 rounded border border-dashed border-[#e2533a]"
+					style="background: transparent"
+				></span>
+				{$_('product.nutrition.radar_chart_legend_limit')}
+			</span>
+		</div>
+	</div>
+</div>

--- a/src/lib/ui/VegaChart.svelte
+++ b/src/lib/ui/VegaChart.svelte
@@ -6,9 +6,10 @@
 	type Props = {
 		spec: Spec | TopLevelSpec;
 		title?: string;
+		height?: string;
 	};
 
-	let { spec, title }: Props = $props();
+	let { spec, title, height = '200px' }: Props = $props();
 	let chartContainer: HTMLDivElement | undefined = $state();
 	let isLoading = $state(true);
 	let error = $state<string | null>(null);
@@ -52,7 +53,7 @@
 	});
 </script>
 
-<div class="mb-4">
+<div class="mb-4" style="--chart-height: {height}">
 	{#if title}
 		<h3 class="mb-2 text-lg font-semibold">{title}</h3>
 	{/if}
@@ -75,7 +76,7 @@
 <style>
 	:global(.vega-chart svg) {
 		width: 100%;
-		height: 200px;
+		height: var(--chart-height);
 		display: block;
 	}
 </style>

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -4,6 +4,7 @@
 	import { _ } from '$lib/i18n';
 
 	import KnowledgePanelsComp from '$lib/knowledgepanels/Panels.svelte';
+	import RadarChart from '$lib/ui/RadarChart.svelte';
 	import Card from '$lib/ui/Card.svelte';
 	import Metadata from '$lib/Metadata.svelte';
 
@@ -118,12 +119,16 @@
 <div class="flex flex-col gap-4">
 	<ProductHeader {product} taxonomies={data.taxo} />
 
-	{#if showBarcode && product.code != null}
-		<BarcodeInfo code={product.code} />
-	{/if}
+	<div class="mt-4">
+		<RadarChart {product} />
+	</div>
 
 	<robotoff-contribution-message product-code={product.code} is-logged-in={$userInfo != null}
 	></robotoff-contribution-message>
+
+	{#if showBarcode && product.code != null}
+		<BarcodeInfo code={product.code} />
+	{/if}
 
 	{#await productAttributes}
 		<div class="flex items-center justify-center py-8">


### PR DESCRIPTION
## Summary

Closes #998

This PR adds a **Radar Chart visualization** that displays a product's core nutrients (Fat, Saturated Fat, Sugars, Salt) as a percentage of their EU daily reference intakes (RI). This gives users an instant visual snapshot of the nutritional profile — making it easy to see at a glance if a product is high in unwanted nutrients.

## Motivation

The current product page shows nutrients as a raw table. A radar chart immediately communicates *how a product compares* to accepted healthy limits, which is the insight users actually care about.

## Changes

### New: `src/lib/ui/RadarChart.svelte`
- Uses Vega-Lite's polar coordinate encoding (`theta` + `radius`) to render a 4-axis radar chart
- Accepts a `product: Product` prop and reactively derives nutrient data via `$derived.by()`
- Nutrients shown: **Fat** (ref: 70g), **Saturated Fat** (ref: 20g), **Sugars** (ref: 90g), **Salt** (ref: 6g)
- Visual cap at **120%** to prevent layout issues for products that heavily exceed RI, while showing the real value in the tooltip
- Graceful empty state when no nutriment data is available

### Modified: `src/lib/api/nutriments.ts`
- Added `REFERENCE_INTAKES` constant (EU Regulation No 1169/2011, Annex XIII)
- Centralizes the RI values so any other component can import them instead of duplicating the data

### New: `src/lib/api/nutriments.test.ts`
- Unit tests for `REFERENCE_INTAKES` values
- Unit tests for the `calculateNutrientPercentage` helper including edge cases (zero, at-limit, over-limit)

### Modified: `src/routes/products/[barcode]/+page.svelte`
- Imports and conditionally renders `RadarChart` when `product.nutriments` exists

### Modified: `src/lib/i18n/messages/en-US.json` + `it-IT.json`
- Added `product.nutrition.radar_chart_title` and `product.nutrition.radar_chart_note` keys

## Screenshots

<img width="800" alt="image" src="https://github.com/user-attachments/assets/41f581af-691f-4fe7-94f1-eaeefaab2f28" />

## Testing

```bash
pnpm install
pnpm vitest run src/lib/api/nutriments.test.ts
pnpm dev
# Then visit: http://localhost:5173/products/3017620422003
```

- Hover over the chart points to verify tooltips show nutrient name, raw `g` value, and `% of RI`
- View a product without nutritional data to verify the fallback message appears correctly