### PR TITLE
feat: add keyboard shortcuts for product pages (#656)

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -173,7 +173,7 @@
 			"api_page": "Open product API page",
 			"edit_same_window": "Edit product in current window",
 			"edit_new_window": "Edit product in new window",
-			"view_page": "Get back to product view page"
+			"view_page": "Go back to product page"
 		},
 		"buttons": {
 			"classic_view": "Classic view",

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -169,7 +169,11 @@
 		"attributes_error_title": "Unable to load personalized attributes",
 		"attributes_error_body": "There was an error while loading the personalized attributes. Please try again later.",
 		"shortcuts": {
-			"show_barcode": "Show product barcode"
+			"show_barcode": "Show/hide product barcode",
+			"api_page": "Open product API page",
+			"edit_same_window": "Edit product in current window",
+			"edit_new_window": "Edit product in new window",
+			"view_page": "Get back to product view page"
 		},
 		"buttons": {
 			"classic_view": "Classic view",

--- a/src/lib/stores/shortcuts.ts
+++ b/src/lib/stores/shortcuts.ts
@@ -1,0 +1,18 @@
+import { getContext, setContext } from 'svelte';
+
+export type Shortcut = {
+	description: string;
+	action: () => void;
+};
+
+export type ShortcutContext = Map<string, Shortcut>;
+
+export function setShortcutCtx(ctx: () => ShortcutContext) {
+	setContext('shortcut-ctx', ctx);
+}
+
+export function getShortcutCtx(): ShortcutContext {
+	const lambda = getContext('shortcut-ctx') as () => ShortcutContext;
+	if (!lambda) throw new Error('Shortcut context not found');
+	return lambda();
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, setContext } from 'svelte';
+	import { onMount } from 'svelte';
 	import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
 	import { Matomo } from '@sinnwerkstatt/sveltekit-matomo';
 
@@ -31,7 +31,8 @@
 	import { setWebsiteCtx } from '$lib/stores/website';
 	import type { WebsiteFlavor } from '$lib/flavor';
 	import { setToastCtx, type Toast as ToastType, type ToastContext } from '$lib/stores/toasts';
-	import Shortcuts, { type Shortcut } from './Shortcuts.svelte';
+	import Shortcuts from './Shortcuts.svelte';
+	import { setShortcutCtx, type Shortcut } from '$lib/stores/shortcuts';
 	import { preferences, runPreferencesMigrations } from '$lib/settings';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { shouldBeContainer } from '$lib/layout';
@@ -102,7 +103,7 @@
 		// Add more shortcuts here
 	]);
 
-	setContext('shortcuts', () => shortcuts);
+	setShortcutCtx(() => shortcuts);
 
 	// Load OpenFoodFacts Web Components
 

--- a/src/routes/Shortcuts.svelte
+++ b/src/routes/Shortcuts.svelte
@@ -64,7 +64,7 @@
 	<div class="modal-box">
 		<h3 class="mb-4 text-lg font-bold">Keyboard Shortcuts</h3>
 
-		<div class="grid grid-cols-[1.5fr_2fr] gap-2">
+		<div class="grid grid-cols-2 gap-2">
 			{#each shortcuts as [combo, shortcut] (combo)}
 				<span class="font-mono">
 					{#each combo.split('+') as key, i (key)}
@@ -72,7 +72,7 @@
 					{/each}
 				</span>
 
-				<span>{shortcut.description}</span>
+				<span class="ml-2">{shortcut.description}</span>
 			{/each}
 		</div>
 

--- a/src/routes/Shortcuts.svelte
+++ b/src/routes/Shortcuts.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
 	import { _ } from '$lib/i18n';
+	import type { Shortcut } from '$lib/stores/shortcuts';
 	import { onMount } from 'svelte';
 
 	let helpModal: HTMLDialogElement;
-
-	// Define shortcuts: { combo, description, action }
-	export type Shortcut = {
-		description: string;
-		action: () => void;
-	};
 
 	let { shortcuts }: { shortcuts: Map<string, Shortcut> } = $props();
 

--- a/src/routes/Shortcuts.svelte
+++ b/src/routes/Shortcuts.svelte
@@ -28,6 +28,18 @@
 			if (event.key === 'Escape' && helpModal.open) {
 				helpModal.close();
 			}
+
+			// Ignore if user is typing in an input field
+			const target = event.target as HTMLElement;
+			if (
+				target instanceof HTMLInputElement ||
+				target instanceof HTMLTextAreaElement ||
+				target instanceof HTMLSelectElement ||
+				target.isContentEditable
+			) {
+				return;
+			}
+
 			const combo = getCombo(event);
 			shortcuts.forEach((shortcut, key) => {
 				if (combo === key.replace('?', '?')) {
@@ -52,7 +64,7 @@
 	<div class="modal-box">
 		<h3 class="mb-4 text-lg font-bold">Keyboard Shortcuts</h3>
 
-		<div class="grid grid-cols-2 gap-2">
+		<div class="grid grid-cols-[1.5fr_2fr] gap-2">
 			{#each shortcuts as [combo, shortcut] (combo)}
 				<span class="font-mono">
 					{#each combo.split('+') as key, i (key)}
@@ -60,7 +72,7 @@
 					{/each}
 				</span>
 
-				<span class="ml-2">{shortcut.description}</span>
+				<span>{shortcut.description}</span>
 			{/each}
 		</div>
 

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -26,10 +26,13 @@
 	import { OpenFoodFacts, type Product } from '@openfoodfacts/openfoodfacts-nodejs';
 	import type { KnowledgePanels } from '$lib/api/knowledgepanels';
 	import NutritionCalculator from '$lib/ui/NutritionCalculator.svelte';
-	import { getContext } from 'svelte';
+	import { getContext, onDestroy } from 'svelte';
 	import type { Shortcut } from '../../Shortcuts.svelte';
 	import type { ProductGroupedAttributes } from './types';
 	import { personalizedSearch } from '$lib/stores/preferencesStore';
+	import { PRODUCT_URL } from '$lib/const';
+	import { resolve } from '$app/paths';
+	import { goto } from '$app/navigation';
 
 	let { data }: PageProps = $props();
 	let { state: productState } = $derived(data);
@@ -66,6 +69,40 @@
 	shortcuts.set('Shift+B', {
 		description: $_('product.shortcuts.show_barcode'),
 		action: () => (showBarcode = !showBarcode)
+	});
+
+	shortcuts.set('A', {
+		description: $_('product.shortcuts.api_page'),
+		action: () => {
+			if (product.code) {
+				window.open(PRODUCT_URL(product.code), '_blank');
+			}
+		}
+	});
+
+	shortcuts.set('E', {
+		description: $_('product.shortcuts.edit_same_window'),
+		action: () => {
+			if (product.code) {
+				goto(resolve('/products/[barcode]/edit', { barcode: product.code }));
+			}
+		}
+	});
+
+	shortcuts.set('Shift+E', {
+		description: $_('product.shortcuts.edit_new_window'),
+		action: () => {
+			if (product.code) {
+				window.open(resolve('/products/[barcode]/edit', { barcode: product.code }), '_blank');
+			}
+		}
+	});
+
+	onDestroy(() => {
+		shortcuts.delete('A');
+		shortcuts.delete('E');
+		shortcuts.delete('Shift+E');
+		shortcuts.delete('Shift+B');
 	});
 
 	async function getProductAttributes(code: string): Promise<ProductGroupedAttributes[]> {

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -26,8 +26,8 @@
 	import { OpenFoodFacts, type Product } from '@openfoodfacts/openfoodfacts-nodejs';
 	import type { KnowledgePanels } from '$lib/api/knowledgepanels';
 	import NutritionCalculator from '$lib/ui/NutritionCalculator.svelte';
-	import { getContext, onDestroy } from 'svelte';
-	import type { Shortcut } from '../../Shortcuts.svelte';
+	import { onDestroy } from 'svelte';
+	import { getShortcutCtx } from '$lib/stores/shortcuts';
 	import type { ProductGroupedAttributes } from './types';
 	import { personalizedSearch } from '$lib/stores/preferencesStore';
 	import { PRODUCT_URL } from '$lib/const';
@@ -65,13 +65,13 @@
 
 	let showBarcode = $state(false);
 
-	let shortcuts: Map<string, Shortcut> = getContext<() => Map<string, Shortcut>>('shortcuts')();
-	shortcuts.set('Shift+B', {
+	const shortcutCtx = getShortcutCtx();
+	shortcutCtx.set('Shift+B', {
 		description: $_('product.shortcuts.show_barcode'),
 		action: () => (showBarcode = !showBarcode)
 	});
 
-	shortcuts.set('A', {
+	shortcutCtx.set('A', {
 		description: $_('product.shortcuts.api_page'),
 		action: () => {
 			if (product.code) {
@@ -80,7 +80,7 @@
 		}
 	});
 
-	shortcuts.set('E', {
+	shortcutCtx.set('E', {
 		description: $_('product.shortcuts.edit_same_window'),
 		action: () => {
 			if (product.code) {
@@ -89,7 +89,7 @@
 		}
 	});
 
-	shortcuts.set('Shift+E', {
+	shortcutCtx.set('Shift+E', {
 		description: $_('product.shortcuts.edit_new_window'),
 		action: () => {
 			if (product.code) {
@@ -99,10 +99,10 @@
 	});
 
 	onDestroy(() => {
-		shortcuts.delete('A');
-		shortcuts.delete('E');
-		shortcuts.delete('Shift+E');
-		shortcuts.delete('Shift+B');
+		shortcutCtx.delete('A');
+		shortcutCtx.delete('E');
+		shortcutCtx.delete('Shift+E');
+		shortcutCtx.delete('Shift+B');
 	});
 
 	async function getProductAttributes(code: string): Promise<ProductGroupedAttributes[]> {

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -26,7 +26,7 @@
 	import { OpenFoodFacts, type Product } from '@openfoodfacts/openfoodfacts-nodejs';
 	import type { KnowledgePanels } from '$lib/api/knowledgepanels';
 	import NutritionCalculator from '$lib/ui/NutritionCalculator.svelte';
-	import { onDestroy } from 'svelte';
+	import { onMount } from 'svelte';
 	import { getShortcutCtx } from '$lib/stores/shortcuts';
 	import type { ProductGroupedAttributes } from './types';
 	import { personalizedSearch } from '$lib/stores/preferencesStore';
@@ -66,43 +66,46 @@
 	let showBarcode = $state(false);
 
 	const shortcutCtx = getShortcutCtx();
-	shortcutCtx.set('Shift+B', {
-		description: $_('product.shortcuts.show_barcode'),
-		action: () => (showBarcode = !showBarcode)
-	});
 
-	shortcutCtx.set('A', {
-		description: $_('product.shortcuts.api_page'),
-		action: () => {
-			if (product.code) {
-				window.open(PRODUCT_URL(product.code), '_blank');
+	onMount(() => {
+		shortcutCtx.set('Shift+B', {
+			description: $_('product.shortcuts.show_barcode'),
+			action: () => (showBarcode = !showBarcode)
+		});
+
+		shortcutCtx.set('A', {
+			description: $_('product.shortcuts.api_page'),
+			action: () => {
+				if (product.code) {
+					window.open(PRODUCT_URL(product.code), '_blank');
+				}
 			}
-		}
-	});
+		});
 
-	shortcutCtx.set('E', {
-		description: $_('product.shortcuts.edit_same_window'),
-		action: () => {
-			if (product.code) {
-				goto(resolve('/products/[barcode]/edit', { barcode: product.code }));
+		shortcutCtx.set('E', {
+			description: $_('product.shortcuts.edit_same_window'),
+			action: () => {
+				if (product.code) {
+					goto(resolve('/products/[barcode]/edit', { barcode: product.code }));
+				}
 			}
-		}
-	});
+		});
 
-	shortcutCtx.set('Shift+E', {
-		description: $_('product.shortcuts.edit_new_window'),
-		action: () => {
-			if (product.code) {
-				window.open(resolve('/products/[barcode]/edit', { barcode: product.code }), '_blank');
+		shortcutCtx.set('Shift+E', {
+			description: $_('product.shortcuts.edit_new_window'),
+			action: () => {
+				if (product.code) {
+					window.open(resolve('/products/[barcode]/edit', { barcode: product.code }), '_blank');
+				}
 			}
-		}
-	});
+		});
 
-	onDestroy(() => {
-		shortcutCtx.delete('A');
-		shortcutCtx.delete('E');
-		shortcutCtx.delete('Shift+E');
-		shortcutCtx.delete('Shift+B');
+		return () => {
+			shortcutCtx.delete('A');
+			shortcutCtx.delete('E');
+			shortcutCtx.delete('Shift+E');
+			shortcutCtx.delete('Shift+B');
+		};
 	});
 
 	async function getProductAttributes(code: string): Promise<ProductGroupedAttributes[]> {

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -24,6 +24,9 @@
 	import { page } from '$app/state';
 	import { dev } from '$app/environment';
 	import IconMdiAlert from '@iconify-svelte/mdi/alert';
+	import type { Shortcut } from '../../../Shortcuts.svelte';
+	import { getContext } from 'svelte';
+	import { resolve } from '$app/paths';
 
 	interface Props {
 		data: PageData;
@@ -363,6 +366,22 @@
 
 	// Determine if we're in add mode (new product) or edit mode (existing product)
 	const isAddMode = $derived(productNotFound);
+
+	let shortcuts: Map<string, Shortcut> = getContext<() => Map<string, Shortcut>>('shortcuts')();
+	$effect(() => {
+		if (!isAddMode) {
+			shortcuts.set('V', {
+				description: $_('product.shortcuts.view_page'),
+				action: () => {
+					if (page.params.barcode) {
+						goto(resolve('/products/[barcode]', { barcode: page.params.barcode }));
+					}
+				}
+			});
+
+			return () => shortcuts.delete('V');
+		}
+	});
 </script>
 
 {#if dev}

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -377,9 +377,9 @@
 					}
 				}
 			});
-
-			return () => shortcutCtx.delete('V');
 		}
+
+		return () => shortcutCtx.delete('V');
 	});
 </script>
 

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -17,6 +17,7 @@
 	import EditProductForm from '$lib/ui/EditProductForm.svelte';
 	import AddProductForm from '$lib/ui/AddProductForm.svelte';
 	import { getToastCtx } from '$lib/stores/toasts';
+	import { getShortcutCtx } from '$lib/stores/shortcuts';
 
 	import type { PageData } from './$types';
 	import { PRODUCT_IMAGE_URL, PRODUCT_STATUS } from '$lib/const';
@@ -24,8 +25,6 @@
 	import { page } from '$app/state';
 	import { dev } from '$app/environment';
 	import IconMdiAlert from '@iconify-svelte/mdi/alert';
-	import type { Shortcut } from '../../../Shortcuts.svelte';
-	import { getContext } from 'svelte';
 	import { resolve } from '$app/paths';
 
 	interface Props {
@@ -35,6 +34,7 @@
 	let { data }: Props = $props();
 
 	const toastCtx = getToastCtx();
+	const shortcutCtx = getShortcutCtx();
 
 	function createEmptyImage(): SelectedImage | RawImage {
 		return {
@@ -367,10 +367,9 @@
 	// Determine if we're in add mode (new product) or edit mode (existing product)
 	const isAddMode = $derived(productNotFound);
 
-	let shortcuts: Map<string, Shortcut> = getContext<() => Map<string, Shortcut>>('shortcuts')();
 	$effect(() => {
 		if (!isAddMode) {
-			shortcuts.set('V', {
+			shortcutCtx.set('V', {
 				description: $_('product.shortcuts.view_page'),
 				action: () => {
 					if (page.params.barcode) {
@@ -379,7 +378,7 @@
 				}
 			});
 
-			return () => shortcuts.delete('V');
+			return () => shortcutCtx.delete('V');
 		}
 	});
 </script>


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

## Description
Part of #656 

- Added keyboard shortcuts for users on the product view and edit pages.
- Added English translations for shortcut descriptions.

### Shortcuts added

| Key | Page | Action |
|-----|------|--------|
| `A` | Product view | Open API product page in a new tab |
| `E` | Product view | Enter edit mode in the same tab |
| `Shift+E` | Product view | Enter edit mode in a new tab |
| `V` | Edit page | Go back to view mode |

### Working Video
[shortcuts-demo.webm](https://github.com/user-attachments/assets/a4a34eb2-8ca3-42ab-9734-268d199cd7a8)

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New product-page keyboard shortcuts: A (open product API page), E (edit in current window), Shift+E (edit in new window), V (return to product view while editing).
  * Updated shortcut label to "Show/hide product barcode" and added four new shortcut descriptions.

* **Bug Fixes**
  * Keyboard shortcuts are ignored while typing in inputs, textareas, selects, or editable content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->