### PR TITLE
fix: Wire mobile Filter button to facets modal

### DIFF
--- a/src/lib/ui/SearchOptionsFooter.svelte
+++ b/src/lib/ui/SearchOptionsFooter.svelte
@@ -1,20 +1,31 @@
 <script lang="ts">
 	import { SORT_OPTIONS } from '$lib/const';
+	import { _ } from '$lib/i18n';
 
 	import IconMdiSort from '@iconify-svelte/mdi/sort';
 	import IconMdiFilter from '@iconify-svelte/mdi/filter';
 
+	import type { SearchResult } from '$lib/api/search';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		onSortOptionSelect?: (value: string) => void;
+		sortBy?: string;
+		onFilterClick?: () => void;
+		searchResult?: SearchResult;
+		children?: Snippet<[{ facets: Record<string, any>; close: () => void }]>;
+	}
+
 	let {
 		onSortOptionSelect = () => {},
 		sortBy = '',
-		onFilterClick = () => {}
-	}: {
-		onSortOptionSelect: (value: string) => void;
-		sortBy: string;
-		onFilterClick: () => void;
-	} = $props();
+		onFilterClick = () => {},
+		searchResult,
+		children
+	}: Props = $props();
 
 	let sortDropdownOpen = $state(false);
+	let showFacetsModal = $state(false);
 </script>
 
 <footer class="search-options-footer">
@@ -57,7 +68,13 @@
 			class="flex h-full w-1/2 flex-col items-center justify-center py-1 focus:outline-none"
 			aria-label="Filter"
 			aria-controls="facets"
-			onclick={() => onFilterClick()}
+			onclick={() => {
+				if (searchResult?.facets && Object.keys(searchResult.facets).length > 0) {
+					showFacetsModal = true;
+				} else {
+					onFilterClick();
+				}
+			}}
 		>
 			<span class="flex items-center text-sm leading-tight font-semibold tracking-wide">
 				Filter <IconMdiFilter class="ml-2 text-lg" />
@@ -65,6 +82,32 @@
 		</button>
 	</div>
 </footer>
+
+{#if showFacetsModal && searchResult?.facets}
+	<div class="fixed inset-0 z-50 flex items-end lg:hidden" role="dialog" aria-modal="true">
+		<div
+			class="fixed inset-0 bg-black/50"
+			onclick={() => (showFacetsModal = false)}
+			aria-hidden="true"
+		></div>
+		<div class="bg-base-100 max-h-[80%] w-full overflow-auto rounded-t-lg p-4">
+			<div class="mb-2 flex items-center justify-between">
+				<h3 class="text-lg font-semibold">{$_('search.filters_title', { default: 'Filters' })}</h3>
+				<button
+					class="btn btn-ghost"
+					onclick={() => (showFacetsModal = false)}
+					aria-label="Close filters">✕</button
+				>
+			</div>
+			<div class="space-y-2">
+				{@render children?.({
+					facets: searchResult.facets,
+					close: () => (showFacetsModal = false)
+				})}
+			</div>
+		</div>
+	</div>
+{/if}
 
 <style lang="postcss">
 	@reference './../../app.css';

--- a/src/lib/ui/SearchOptionsFooter.svelte
+++ b/src/lib/ui/SearchOptionsFooter.svelte
@@ -6,10 +6,12 @@
 
 	let {
 		onSortOptionSelect = () => {},
-		sortBy = ''
+		sortBy = '',
+		onFilterClick = () => {}
 	}: {
 		onSortOptionSelect: (value: string) => void;
 		sortBy: string;
+		onFilterClick: () => void;
 	} = $props();
 
 	let sortDropdownOpen = $state(false);
@@ -54,6 +56,8 @@
 		<button
 			class="flex h-full w-1/2 flex-col items-center justify-center py-1 focus:outline-none"
 			aria-label="Filter"
+			aria-controls="facets"
+			onclick={() => onFilterClick()}
 		>
 			<span class="flex items-center text-sm leading-tight font-semibold tracking-wide">
 				Filter <IconMdiFilter class="ml-2 text-lg" />

--- a/src/lib/ui/SearchOptionsFooter.svelte
+++ b/src/lib/ui/SearchOptionsFooter.svelte
@@ -5,15 +5,16 @@
 	import IconMdiSort from '@iconify-svelte/mdi/sort';
 	import IconMdiFilter from '@iconify-svelte/mdi/filter';
 
-	import type { SearchResult, FacetResult } from '$lib/api/search';
-	import type { Snippet } from 'svelte';
+	import FacetBar from '../../routes/search/FacetBar.svelte';
+	import type { SearchResult } from '$lib/api/search';
 
 	interface Props {
 		onSortOptionSelect?: (value: string) => void;
 		sortBy?: string;
 		onFilterClick?: () => void;
 		searchResult?: SearchResult;
-		children?: Snippet<[{ facets: FacetResult; close: () => void }]>;
+		onAddFacet?: (key: string, val: string) => void;
+		onRemoveFacet?: (key: string, val: string) => void;
 	}
 
 	let {
@@ -21,7 +22,8 @@
 		sortBy = '',
 		onFilterClick = () => {},
 		searchResult,
-		children
+		onAddFacet = () => {},
+		onRemoveFacet = () => {}
 	}: Props = $props();
 
 	let sortDropdownOpen = $state(false);
@@ -108,10 +110,7 @@
 				>
 			</div>
 			<div class="space-y-2">
-				{@render children?.({
-					facets: searchResult.facets,
-					close: () => (showFacetsModal = false)
-				})}
+				<FacetBar facets={searchResult.facets} {onAddFacet} {onRemoveFacet} />
 			</div>
 		</div>
 	</div>

--- a/src/lib/ui/SearchOptionsFooter.svelte
+++ b/src/lib/ui/SearchOptionsFooter.svelte
@@ -5,7 +5,7 @@
 	import IconMdiSort from '@iconify-svelte/mdi/sort';
 	import IconMdiFilter from '@iconify-svelte/mdi/filter';
 
-	import type { SearchResult } from '$lib/api/search';
+	import type { SearchResult, FacetResult } from '$lib/api/search';
 	import type { Snippet } from 'svelte';
 
 	interface Props {
@@ -13,7 +13,7 @@
 		sortBy?: string;
 		onFilterClick?: () => void;
 		searchResult?: SearchResult;
-		children?: Snippet<[{ facets: Record<string, any>; close: () => void }]>;
+		children?: Snippet<[{ facets: FacetResult; close: () => void }]>;
 	}
 
 	let {
@@ -26,7 +26,15 @@
 
 	let sortDropdownOpen = $state(false);
 	let showFacetsModal = $state(false);
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && showFacetsModal) {
+			showFacetsModal = false;
+		}
+	}
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <footer class="search-options-footer">
 	{#if sortDropdownOpen}

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -301,18 +301,12 @@
 		goto('/facets');
 	}}
 	{searchResult}
->
-	{#snippet children({ facets })}
-		<FacetBar
-			{facets}
-			onAddFacet={(key, val) => {
-				selectedFacets = addIncludeFacet(selectedFacets, key, val);
-				refreshQuery();
-			}}
-			onRemoveFacet={(key, val) => {
-				selectedFacets = removeIncludeFacet(selectedFacets, key, val);
-				refreshQuery();
-			}}
-		/>
-	{/snippet}
-</SearchOptionsFooter>
+	onAddFacet={(key, val) => {
+		selectedFacets = addIncludeFacet(selectedFacets, key, val);
+		refreshQuery();
+	}}
+	onRemoveFacet={(key, val) => {
+		selectedFacets = removeIncludeFacet(selectedFacets, key, val);
+		refreshQuery();
+	}}
+/>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -37,8 +37,6 @@
 	let { data }: PageProps = $props();
 	let { search: searchResult } = $derived(data);
 
-	let showFacetsModal = $state(false);
-
 	let sortedProducts = $derived.by(() => {
 		if (!searchResult?.hits || searchResult.hits.length === 0 || !data.attributesByCode) return [];
 
@@ -300,43 +298,21 @@
 	onSortOptionSelect={(value) => handleSortChange(value)}
 	sortBy={selectedSort.value}
 	onFilterClick={() => {
-		if (searchResult.facets && Object.keys(searchResult.facets).length > 0) {
-			showFacetsModal = true;
-		} else {
-			goto('/facets');
-		}
+		goto('/facets');
 	}}
-/>
-
-{#if showFacetsModal}
-	<div class="fixed inset-0 z-50 flex items-end lg:hidden" role="dialog" aria-modal="true">
-		<div
-			class="fixed inset-0 bg-black/50"
-			onclick={() => (showFacetsModal = false)}
-			aria-hidden="true"
-		></div>
-		<div class="bg-base-100 max-h-[80%] w-full overflow-auto rounded-t-lg p-4">
-			<div class="mb-2 flex items-center justify-between">
-				<h3 class="text-lg font-semibold">{$_('search.filters_title', { default: 'Filters' })}</h3>
-				<button
-					class="btn btn-ghost"
-					onclick={() => (showFacetsModal = false)}
-					aria-label="Close filters">✕</button
-				>
-			</div>
-			<div class="space-y-2">
-				<FacetBar
-					facets={searchResult.facets}
-					onAddFacet={(key, val) => {
-						selectedFacets = addIncludeFacet(selectedFacets, key, val);
-						refreshQuery();
-					}}
-					onRemoveFacet={(key, val) => {
-						selectedFacets = removeIncludeFacet(selectedFacets, key, val);
-						refreshQuery();
-					}}
-				/>
-			</div>
-		</div>
-	</div>
-{/if}
+	{searchResult}
+>
+	{#snippet children({ facets })}
+		<FacetBar
+			{facets}
+			onAddFacet={(key, val) => {
+				selectedFacets = addIncludeFacet(selectedFacets, key, val);
+				refreshQuery();
+			}}
+			onRemoveFacet={(key, val) => {
+				selectedFacets = removeIncludeFacet(selectedFacets, key, val);
+				refreshQuery();
+			}}
+		/>
+	{/snippet}
+</SearchOptionsFooter>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -37,6 +37,8 @@
 	let { data }: PageProps = $props();
 	let { search: searchResult } = $derived(data);
 
+	let showFacetsModal = $state(false);
+
 	let sortedProducts = $derived.by(() => {
 		if (!searchResult?.hits || searchResult.hits.length === 0 || !data.attributesByCode) return [];
 
@@ -164,7 +166,7 @@
 
 <!-- Facet Bar -->
 {#if searchResult.facets && Object.keys(searchResult.facets).length > 0}
-	<div class="my-4">
+	<div class="my-4" id="facets">
 		<FacetBar
 			facets={searchResult.facets}
 			onAddFacet={(key, val) => {
@@ -297,4 +299,44 @@
 <SearchOptionsFooter
 	onSortOptionSelect={(value) => handleSortChange(value)}
 	sortBy={selectedSort.value}
+	onFilterClick={() => {
+		if (searchResult.facets && Object.keys(searchResult.facets).length > 0) {
+			showFacetsModal = true;
+		} else {
+			goto('/facets');
+		}
+	}}
 />
+
+{#if showFacetsModal}
+	<div class="fixed inset-0 z-50 flex items-end lg:hidden" role="dialog" aria-modal="true">
+		<div
+			class="fixed inset-0 bg-black/50"
+			onclick={() => (showFacetsModal = false)}
+			aria-hidden="true"
+		></div>
+		<div class="bg-base-100 max-h-[80%] w-full overflow-auto rounded-t-lg p-4">
+			<div class="mb-2 flex items-center justify-between">
+				<h3 class="text-lg font-semibold">{$_('search.filters_title', { default: 'Filters' })}</h3>
+				<button
+					class="btn btn-ghost"
+					onclick={() => (showFacetsModal = false)}
+					aria-label="Close filters">✕</button
+				>
+			</div>
+			<div class="space-y-2">
+				<FacetBar
+					facets={searchResult.facets}
+					onAddFacet={(key, val) => {
+						selectedFacets = addIncludeFacet(selectedFacets, key, val);
+						refreshQuery();
+					}}
+					onRemoveFacet={(key, val) => {
+						selectedFacets = removeIncludeFacet(selectedFacets, key, val);
+						refreshQuery();
+					}}
+				/>
+			</div>
+		</div>
+	</div>
+{/if}


### PR DESCRIPTION
## Description

Make the mobile **Filter** button functional. The button now opens a modal displaying the existing facets UI, allowing users to filter search results on mobile. Falls back to navigating to `/facets` page when no facets are available.

---

## Changes

- Added `showFacetsModal` state and modal UI to the search page.
- Wired `onFilterClick` handler to open the modal or navigate to `/facets`.
- Added i18n support for the modal title.
- Fixed event handler syntax for consistency.

---

## Working Demo--->>

https://github.com/user-attachments/assets/6239cf94-e90e-4bce-99f6-a5881723ea9d

---

## Closes #1089 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-friendly filters modal: tapping Filter opens a dismissible facets modal with in-modal facet editing; desktop retains the persistent facets bar and footer-triggered navigation to the facets view.
  * Facet edits apply immediately and refresh the search results/navigation.

* **Accessibility**
  * Filter button exposes ARIA control mapping and the modal can be closed with the Escape key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->