### PR TITLE
fix: add breathing space to mobile search and menu dropdowns

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -303,7 +303,7 @@
 	</div>
 
 	{#if searchActive}
-		<div class="flex justify-center">
+		<div class="flex justify-center pb-4">
 			<SearchBar bind:searchQuery onSearch={gotoProductsSearch} loading={isSearching} />
 		</div>
 	{/if}
@@ -312,7 +312,7 @@
 		role="region"
 		aria-label={$_('menu.mobile_nav', { default: 'Mobile navigation menu' })}
 		class:hidden={!accordionOpen}
-		class="mt-3 flex flex-col gap-2 md:flex-row md:flex-wrap md:justify-center"
+		class="mt-3 flex flex-col gap-2 pb-4 md:flex-row md:flex-wrap md:justify-center"
 	>
 		<a class="btn btn-outline link" href="/static/discover">
 			{$_('discover_link')}


### PR DESCRIPTION
## Description

This PR adds bottom padding (`pb-4`) to the mobile search bar container and the mobile hamburger menu dropdown in `src/routes/+layout.svelte`.

Previously, when opening either the search or the hamburger menu in the mobile view, the containers lacked breathing space and sat flush against the content directly below them. Adding this padding improves visual spacing and provides a cleaner, more readable UI when these menus are expanded.

Fixes #1134

---

## Checklist

### Author Self-Review
- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

---

<img width="690" height="758" alt="image" src="https://github.com/user-attachments/assets/af736351-3bcb-41e5-b2cc-988565f916fe" />

---

<img width="688" height="757" alt="image" src="https://github.com/user-attachments/assets/dcee6cb8-4f95-4a5a-8edb-e7645b0a21b2" />

---
@VaiTon You were right, sir. After going through the codebase more carefully, I now understand it much better. 

Could you please review this PR and let me know if any improvements are needed? I’d really appreciate your feedback.
