### PR TITLE
fix: add missing rel="noopener noreferrer" to target="_blank" links

### DIFF
--- a/src/lib/ui/BarcodeInfo.svelte
+++ b/src/lib/ui/BarcodeInfo.svelte
@@ -39,7 +39,7 @@
 						class="text-xs text-blue-500 hover:underline"
 						href={`https://www.google.com/search?q=${code}`}
 						target="_blank"
-						rel="noopener"
+						rel="noopener noreferrer"
 						title="Search on Google"
 					>
 						Google
@@ -50,7 +50,7 @@
 						class="text-xs text-blue-500 hover:underline"
 						href={`https://duckduckgo.com/?q=${code}`}
 						target="_blank"
-						rel="noopener"
+						rel="noopener noreferrer"
 						title="Search on DuckDuckGo"
 					>
 						DuckDuckGo
@@ -61,7 +61,7 @@
 						class="text-xs text-green-600 hover:underline"
 						href={`https://prices.openfoodfacts.org/product/${code}`}
 						target="_blank"
-						rel="noopener"
+						rel="noopener noreferrer"
 						title="Open Prices"
 					>
 						Open Prices {openPricesStatus === null
@@ -76,7 +76,7 @@
 						class="text-xs text-green-600 hover:underline"
 						href={`https://pro.openfoodfacts.dev/products/${code}`}
 						target="_blank"
-						rel="noopener"
+						rel="noopener noreferrer"
 						title="Pro OFF"
 					>
 						Pro OFF{proOffStatus === null ? '…' : proOffStatus === 200 ? '' : ' (Not found)'}

--- a/src/lib/ui/ImageButton.svelte
+++ b/src/lib/ui/ImageButton.svelte
@@ -51,7 +51,7 @@
 				class="btn btn-circle btn-sm bg-base-100/80 hover:bg-base-100"
 				href={IMAGE_REPORT_URL(productCode, imageId)}
 				target="_blank"
-				rel="noopener"
+				rel="noopener noreferrer"
 				aria-label="Report to NutriPatrol"
 				title="Report to NutriPatrol"
 				onclick={(e) => e.stopPropagation()}

--- a/src/lib/ui/ImageModal.svelte
+++ b/src/lib/ui/ImageModal.svelte
@@ -175,7 +175,7 @@
 						class="btn btn-sm bg-base-100/80 hover:bg-base-100 gap-2"
 						href={IMAGE_REPORT_URL(image.productCode, image.imageid)}
 						target="_blank"
-						rel="noopener"
+						rel="noopener noreferrer"
 					>
 						<IconMdiFlagOutline class="h-5 w-5" />
 						<span>{$_('product.buttons.report_issue', { default: 'Report' })}</span>

--- a/src/lib/ui/NetworkError.svelte
+++ b/src/lib/ui/NetworkError.svelte
@@ -12,7 +12,12 @@
 
 	<p class="text-sm">
 		{$_('errors.network.instructions')}
-		<a href="https://status.openfoodfacts.org/" target="_blank" rel="noopener" class="link">
+		<a
+			href="https://status.openfoodfacts.org/"
+			target="_blank"
+			rel="noopener noreferrer"
+			class="link"
+		>
 			Open Food Facts Status Page
 		</a>
 	</p>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -382,7 +382,12 @@
 					})}
 				</p>
 				<div class="modal-action">
-					<a href="https://status.openfoodfacts.org" target="_blank" class="btn btn-primary">
+					<a
+						href="https://status.openfoodfacts.org"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="btn btn-primary"
+					>
 						{$_('slow_server.status_page', { default: 'View Status Page' })}
 					</a>
 				</div>

--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -253,7 +253,12 @@
 					<div class="mb-2">
 						<div class="text-secondary mb-2 text-sm font-bold">
 							<span>{$_('product.header.traceability_codes')}</span>
-							<a href={TRACEABILITY_CODES_URL} target="_blank" class="link link-secondary text-xs">
+							<a
+								href={TRACEABILITY_CODES_URL}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="link link-secondary text-xs"
+							>
 								({$_('product.header.traceability_codes_learn_more')})
 							</a>
 						</div>

--- a/src/routes/products/[barcode]/edit/TraceabilityCodes.svelte
+++ b/src/routes/products/[barcode]/edit/TraceabilityCodes.svelte
@@ -37,7 +37,12 @@
 	<div class="mt-1 text-xs">
 		<p>Format depends on country (e.g., FR XX.XXX.XXX CE for France)</p>
 		<p>
-			More info: <a href={TRACEABILITY_CODES_URL} target="_blank" class="link">
+			More info: <a
+				href={TRACEABILITY_CODES_URL}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="link"
+			>
 				Food Traceability Codes Wiki
 			</a>
 		</p>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -188,6 +188,7 @@
 			<a
 				href="https://world.openfoodfacts.org/cgi/search.pl?action=display&sort_by=unique_scans_n&page_size=20&graph=1&search_terms={mainSearchTerm}"
 				target="_blank"
+				rel="noopener noreferrer"
 				class="btn btn-soft btn-sm gap-2 max-sm:w-full"
 			>
 				{$_('search.generate_graphs_classic', { values: { term: mainSearchTerm } })}
@@ -196,6 +197,7 @@
 			<a
 				href="https://world.openfoodfacts.org/cgi/search.pl?action=display&sort_by=unique_scans_n&page_size=20&search_terms={mainSearchTerm}"
 				target="_blank"
+				rel="noopener noreferrer"
 				class="btn btn-soft btn-sm gap-2 max-sm:w-full"
 			>
 				{$_('search.advanced_search_classic', { values: { term: mainSearchTerm } })}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -164,6 +164,7 @@
 		class="btn btn-outline"
 		href={GITHUB_REPO_URL}
 		target="_blank"
+		rel="noopener noreferrer"
 		aria-label={$_('settings.github_link')}
 	>
 		<IconMdiGithub class="h-5 w-5" />


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Missing `rel="noopener noreferrer"` on `target="_blank"` links across the codebase.

### ⚠️ Risk: The potential impact if left unfixed
When a page links to another page using `target="_blank"`, the new page can potentially gain partial access to the original page's `window` object via `window.opener`. This could allow a malicious site to redirect the original tab to a fraudulent URL (Tabnabbing). Additionally, it prevents leaking the referrer URL to external sites.

### 🛡️ Solution: How the fix addresses the vulnerability
Added the `rel="noopener noreferrer"` attribute to all relevant `<a>` tags. `noopener` prevents the new page from accessing `window.opener`, and `noreferrer` prevents the browser from sending the original page's URL in the HTTP `Referer` header.

---
*PR created automatically by Jules for task [11595551875576394317](https://jules.google.com/task/11595551875576394317) started by @VaiTon*