### PR TITLE
fix: remove unused eslint directives in settings

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -70,7 +70,6 @@
 			bind:value={$preferences.lang}
 			onchange={() => locale.set($preferences.lang)}
 		>
-			<!--eslint-disable-next-line @typescript-eslint/no-unused-vars -->
 			{#each Object.keys(data.languages).toSorted() as langKey (langKey)}
 				{@const lang = data.languages[langKey]}
 				<option
@@ -95,7 +94,6 @@
 				{$_('world_option')}
 			</option>
 
-			<!--eslint-disable-next-line @typescript-eslint/no-unused-vars -->
 			{#each Object.keys(data.countries).toSorted() as countryKey (countryKey)}
 				{@const country = data.countries[countryKey]}
 				{@const code2 = country.country_code_2.en}


### PR DESCRIPTION
🎯 **What:** Removed redundant `<!--eslint-disable-next-line @typescript-eslint/no-unused-vars -->` directives in `src/routes/settings/+page.svelte`.

💡 **Why:** The variables `langKey` and `countryKey` are explicitly used in the loop, making these directives unnecessary and cleaning up the code.

✅ **Verification:** Manually verified that the variables are in use. Code review confirmed the changes are correct and safe.

✨ **Result:** Improved code health by removing dead ESLint directives.

---
*PR created automatically by Jules for task [3988867254432665476](https://jules.google.com/task/3988867254432665476) started by @VaiTon*