### PR TITLE
🧪 test: add unit tests for `toLuceneString` in `facets.ts`

### DIFF
--- a/src/lib/facets.test.ts
+++ b/src/lib/facets.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { toLuceneString } from './facets';
+import type { FacetsSelection } from './facets';
+
+describe('toLuceneString', () => {
+	it('handles empty query and empty facets', () => {
+		const result = toLuceneString('', {});
+		expect(result).toBe('');
+	});
+
+	it('handles only a text query without facets', () => {
+		const result = toLuceneString('apple juice', {});
+		expect(result).toBe('apple juice');
+	});
+
+	it('handles a single include facet without a query', () => {
+		const facets: FacetsSelection = {
+			brands: { include: ['Coca-Cola'], exclude: [] }
+		};
+		const result = toLuceneString('', facets);
+		expect(result).toBe('brands:("Coca-Cola")');
+	});
+
+	it('handles a single exclude facet without a query', () => {
+		const facets: FacetsSelection = {
+			allergens: { include: [], exclude: ['en:peanuts'] }
+		};
+		const result = toLuceneString('', facets);
+		expect(result).toBe('-allergens:("en:peanuts")');
+	});
+
+	it('handles multiple include values for the same facet', () => {
+		const facets: FacetsSelection = {
+			brands: { include: ['Coca-Cola', 'Pepsi'], exclude: [] }
+		};
+		const result = toLuceneString('', facets);
+		expect(result).toBe('brands:("Coca-Cola" OR "Pepsi")');
+	});
+
+	it('handles multiple exclude values for the same facet', () => {
+		const facets: FacetsSelection = {
+			categories: { include: [], exclude: ['en:beverages', 'en:snacks'] }
+		};
+		const result = toLuceneString('', facets);
+		expect(result).toBe('-categories:("en:beverages" OR "en:snacks")');
+	});
+
+	it('handles both include and exclude values for the same facet', () => {
+		const facets: FacetsSelection = {
+			categories: { include: ['en:beverages'], exclude: ['en:alcoholic-beverages'] }
+		};
+		const result = toLuceneString('', facets);
+		expect(result).toBe('categories:("en:beverages") AND -categories:("en:alcoholic-beverages")');
+	});
+
+	it('handles multiple facet categories', () => {
+		const facets: FacetsSelection = {
+			brands: { include: ['Nestle'], exclude: [] },
+			categories: { include: ['en:chocolates'], exclude: [] }
+		};
+		const result = toLuceneString('', facets);
+		expect(result).toBe('brands:("Nestle") AND categories:("en:chocolates")');
+	});
+
+	it('handles a text query combined with facets', () => {
+		const facets: FacetsSelection = {
+			brands: { include: ['Lindt'], exclude: [] },
+			labels: { include: [], exclude: ['en:organic'] }
+		};
+		const result = toLuceneString('dark chocolate', facets);
+		expect(result).toBe('dark chocolate AND brands:("Lindt") AND -labels:("en:organic")');
+	});
+
+	it('handles empty include and exclude arrays gracefully', () => {
+		const facets: FacetsSelection = {
+			brands: { include: [], exclude: [] }
+		};
+		const result = toLuceneString('test', facets);
+		expect(result).toBe('test');
+	});
+});


### PR DESCRIPTION
🎯 **What:** The testing gap for the `toLuceneString` function in `src/lib/facets.ts` is now covered.
📊 **Coverage:** The test suite covers various scenarios:
- Empty queries and facets
- Pure text queries
- Single and multiple `include` facets
- Single and multiple `exclude` facets
- Mixed `include` and `exclude` values for the same facet
- Complex queries combining text and multiple facet categories
- Graceful handling of empty include/exclude arrays
✨ **Result:** Test coverage for this pure utility function is now effectively 100%, improving reliability when generating complex Lucene queries for API requests.

---
*PR created automatically by Jules for task [2823728220779470167](https://jules.google.com/task/2823728220779470167) started by @VaiTon*