### PR TITLE
fix(ui): add translation for labels search, warning,language

### DIFF
--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -13,7 +13,7 @@
 		"placeholder": "Query or barcode",
 		"go": "Go",
 		"scan": "Scan a barcode",
-		"button": "Search"
+		"button": "Ricerca"
 	},
 	"auth": {
 		"username": "Username",
@@ -30,11 +30,11 @@
 		"actions": "Actions"
 	},
 	"general": {
-		"language": "Language",
+		"language": "lingua",
 		"country": "Paese",
 		"currency": "Valuta",
 		"loading": "Loading...",
-		"warning": "Warning",
+		"warning": "Avvertimento",
 		"notes": "Notes",
 		"summary": "Summary",
 		"product_not_found": "Product not found",


### PR DESCRIPTION
**Description**
Missing translations for Italian characters on some labels 
**Expected Behavior**
The label should display text in Italian.
**Actual Behavior**
The label displays information in English.
**GSoC 2026**
I am Apurva and I am a candidate for GSoC 2026, and I would like to work on this! I have already identified the fix and would like to be assigned to this issue.
