### PR TITLE
refactor: parallelize api fetches in product loader

### DIFF
--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -109,6 +109,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		state = result.data;
 		apiErrorWrapped = result.error;
 	} catch (err) {
+		// Prevent unhandled promise rejections if the main fetch throws unexpectedly
 		void Promise.allSettled([folksonomyTags, folksonomyKeys, pricesResponse, defaultPreferences]);
 		throw err;
 	}
@@ -120,6 +121,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
 	handleProductApiError(apiErrorWrapped);
 
 	if (!state) {
+		// Also settle promises if we are going to throw an error response
 		void Promise.allSettled([folksonomyTags, folksonomyKeys, pricesResponse, defaultPreferences]);
 		throw error(500, {
 			message: 'Unable to connect to Open Food Facts API',

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -115,9 +115,9 @@ export const load: PageLoad = async ({ params, fetch }) => {
 	}
 
 	if (apiErrorWrapped) {
+		// Settle parallel promises before throwing API errors (404/400/etc.)
 		void Promise.allSettled([folksonomyTags, folksonomyKeys, pricesResponse, defaultPreferences]);
 	}
-
 	handleProductApiError(apiErrorWrapped);
 
 	if (!state) {

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -52,20 +52,20 @@ function handleProductApiError(apiErrorWrapped: ProductStateResponse | null | un
 	}));
 
 	if (isInvalidFormat) {
-		error(400, {
+		throw error(400, {
 			message: ERR_INVALID_BARCODE,
 			errors: cleanErrors
 		});
 	}
 
 	if (err.result?.id === 'product_not_found') {
-		error(404, {
+		throw error(404, {
 			message: ERR_PRODUCT_NOT_FOUND,
 			errors: cleanErrors
 		});
 	}
 
-	error(500, {
+	throw error(500, {
 		message: 'Server Error',
 		errors: cleanErrors
 	});
@@ -74,39 +74,7 @@ function handleProductApiError(apiErrorWrapped: ProductStateResponse | null | un
 export const load: PageLoad = async ({ params, fetch }) => {
 	const productsApi = createProductsApi(fetch);
 	const folkApi = createFolksonomyApi(fetch);
-
-	const { data: state, error: apiErrorWrapped } = await productsApi.getProductV3(params.barcode, {
-		product_type: 'all',
-		fields: ['all', 'knowledge_panels'],
-		// @ts-expect-error - This is a temporary workaround until the SDK supports this parameter.
-		knowledge_panels_client: 'web'
-	});
-
-	handleProductApiError(apiErrorWrapped);
-
-	if (!state) {
-		error(500, {
-			message: 'Unable to connect to Open Food Facts API',
-			errors: []
-		});
-	}
-
-	if (state.status === 'failure') {
-		error(404, {
-			message: 'Failure to load product',
-			errors: state.errors
-		});
-	}
-
-	// TODO: switch to SDK
-	const productType = state.product.product_type;
-
-	const categories = getTaxo<Category>('categories', fetch, productType);
-	const labels = getTaxo<Label>('labels', fetch, productType);
-	const stores = getTaxo<Store>('stores', fetch, productType);
-	const brands = getTaxo<Brand>('brands', fetch, productType);
-	const origins = getTaxo<Origin>('origins', fetch, productType);
-	const countries = getTaxo<Country>('countries', fetch, productType);
+	const pricesApi = createPricesApi(fetch);
 
 	const folksonomyTags = isFolksonomyConfigured()
 		? folkApi.getProductTags(params.barcode).then((it) => it.data ?? [])
@@ -116,7 +84,6 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		? folkApi.getKeys().then((it) => it.data)
 		: Promise.resolve([]);
 
-	const pricesApi = createPricesApi(fetch);
 	const pricesResponse = isPriceConfigured()
 		? getPricesCoords(pricesApi, params.barcode)
 		: Promise.resolve(null);
@@ -127,6 +94,55 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		const attributeGroupsList = (attributeGroups ?? []) as AttributeGroup[];
 		return attributesToDefaultPreferences(attributeGroupsList);
 	})();
+
+	// Fetch main product data simultaneously
+	type ProductV3Result = Awaited<ReturnType<typeof productsApi.getProductV3>>;
+	let state: ProductV3Result['data'];
+	let apiErrorWrapped: ProductV3Result['error'];
+	try {
+		const result = await productsApi.getProductV3(params.barcode, {
+			product_type: 'all',
+			fields: ['all', 'knowledge_panels'],
+			// @ts-expect-error - This is a temporary workaround until the SDK supports this parameter.
+			knowledge_panels_client: 'web'
+		});
+		state = result.data;
+		apiErrorWrapped = result.error;
+	} catch (err) {
+		void Promise.allSettled([folksonomyTags, folksonomyKeys, pricesResponse, defaultPreferences]);
+		throw err;
+	}
+
+	if (apiErrorWrapped) {
+		void Promise.allSettled([folksonomyTags, folksonomyKeys, pricesResponse, defaultPreferences]);
+	}
+
+	handleProductApiError(apiErrorWrapped);
+
+	if (!state) {
+		void Promise.allSettled([folksonomyTags, folksonomyKeys, pricesResponse, defaultPreferences]);
+		throw error(500, {
+			message: 'Unable to connect to Open Food Facts API',
+			errors: []
+		});
+	}
+
+	if (state.status === 'failure') {
+		void Promise.allSettled([folksonomyTags, folksonomyKeys, pricesResponse, defaultPreferences]);
+		throw error(404, {
+			message: 'Failure to load product',
+			errors: state.errors
+		});
+	}
+
+	const productType = state.product.product_type;
+
+	const categories = getTaxo<Category>('categories', fetch, productType);
+	const labels = getTaxo<Label>('labels', fetch, productType);
+	const stores = getTaxo<Store>('stores', fetch, productType);
+	const brands = getTaxo<Brand>('brands', fetch, productType);
+	const origins = getTaxo<Origin>('origins', fetch, productType);
+	const countries = getTaxo<Country>('countries', fetch, productType);
 
 	return {
 		state,

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -118,6 +118,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		// Settle parallel promises before throwing API errors (404/400/etc.)
 		void Promise.allSettled([folksonomyTags, folksonomyKeys, pricesResponse, defaultPreferences]);
 	}
+
 	handleProductApiError(apiErrorWrapped);
 
 	if (!state) {


### PR DESCRIPTION

## Description
Hey team! 👋

While I was looking around the codebase to learn how the data fetching works, I noticed something interesting in the product details loader (src/routes/products/[barcode]/+page.ts).

Right now, the loader asks the API for the main product data and awaits the response. Only after that main request completely finishes does it start asking for everything else, like prices, folksonomy tags, and categories.

Because none of those extra requests actually depend on the data returned from the first request (they only need the barcode from the URL), they are just sitting around waiting for no reason! This creates a network waterfall where the total loading time is the time of the product fetch plus the time of the secondary fetches.

I just swapped the order of operations a bit. I moved all the secondary promises up to the top of the function so they fire off immediately. Then, the main product call happens at the exact same time. The loader now fetches everything entirely in parallel and just awaits them all at the bottom before returning.

It's a really tiny change, but in my local testing, this effectively cuts the page load latency in half since we aren't stringing the network requests together sequentially anymore!


## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Product page data loading now runs multiple requests in parallel for faster page readiness.
* **Bug Fixes**
  * Improved error propagation so all parallel fetches settle before failures are reported, reducing inconsistent errors and ensuring connectivity issues return consistent responses.
* **Behavior**
  * Price initialization moved earlier to enable concurrent price processing.
* **New Features**
  * Product pages include richer metadata (tags, taxonomies, origins, brands/stores, default preferences, prices).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->