### PR TITLE
fix: improve typing for uploaded images API response

### DIFF
--- a/src/lib/ui/images/PhotoTypeSection.svelte
+++ b/src/lib/ui/images/PhotoTypeSection.svelte
@@ -84,14 +84,14 @@
 				toast.error($_('product.edit.images.toast.upload_failed_generic'));
 				return;
 			}
+			type UploadedImages = Record<string, { imgid: number }>;
 
 			if (uploadResult.data?.status === 'success') {
 				if (onImageUploaded) {
-					// FIXME: The API response typing is incorrect, so we need to cast here
+					// Temporary cast until the API response type is correctly defined in the SDK
 					// to access the uploaded images
-					const uploadedImages = uploadResult.data.product?.images?.uploaded as null | {
-						[key: string]: { imgid: number };
-					};
+					const uploadedImages = uploadResult.data.product?.images
+						?.uploaded as UploadedImages | null;
 
 					const firstImageKey = uploadedImages ? Object.keys(uploadedImages)[0] : null;
 					const imgid =


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description
Improves TypeScript typing for the uploaded images API response in PhotoTypeSection.svelte.

Previously the code relied on an inline cast due to incorrect API response typing. This change introduces a reusable UploadedImages type to make the intent clearer and improve type safety.

### Changes
- Introduced UploadedImages type
- Replaced inline cast with typed alias
- Updated FIXME comment

### Impact
No runtime changes. Improves code readability and type safety.
Fixes # (issue)

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements for better type safety and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->