### PR TITLE
feat: add /health endpoint for Docker health checks (#1120)

### DIFF
--- a/src/routes/health/+server.ts
+++ b/src/routes/health/+server.ts
@@ -1,12 +1,16 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import pkg from '../../../package.json';
 
 export const GET: RequestHandler = () => {
 	return json(
-		{ status: 'up' },
+		{
+			status: 'ok',
+			version: pkg.version
+		},
 		{
 			status: 200,
-			headers: { 'Cache-Control': 'no-cache' }
+			headers: { 'Cache-Control': 'no-store, no-cache, must-revalidate' }
 		}
 	);
 };


### PR DESCRIPTION
Fixes #1120.

This Pull Request adds a dedicated `/health` endpoint to the explorer to facilitate Docker health checks and infrastructure monitoring.

### Changes:
- **`src/routes/health/+server.ts`**: Implemented a JSON endpoint returning `{ "status": "ok", "version": "..." }`.
- **Metadata**: Included the application version from `package.json` for better deployment tracking.
- **Caching**: Disabled caching for the health check to ensure real-time status reporting.

Verification:
- Confirmed the endpoint returns 200 OK.
- Verified JSON structure matches requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health check endpoint now returns service version information.

* **Bug Fixes**
  * Health check response status label changed from "up" to "ok" for consistency.
  * Cache-Control header tightened to prevent caching of health responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->