### PR TITLE
fix: add missing 'help.button' translation key (#1132)

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -445,6 +445,9 @@
 		"button": "Menu",
 		"mobile_nav": "Mobile navigation menu"
 	},
+	"help": {
+		"button": "Show help shortcuts"
+	},
 	"facets": {
 		"facet_website_title": "Exploring {facet} - Open Food Facts Explorer",
 		"facet_website_description": "Discover the {facet} category on Open Food Facts Explorer.",

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -157,6 +157,9 @@
 			"instructions": "Se il problema persiste, visita la pagina di stato di Open Food Facts."
 		}
 	},
+	"help": {
+		"button": "Mostra le scorciatoie della guida"
+	},
 	"landing": {
 		"title": "Open Food Facts Explorer",
 		"subtitle": "Un database collaborativo, gratuito e aperto di prodotti alimentari da tutto il mondo. Scopri, cerca e contribuisci alla trasparenza alimentare per tutti.",


### PR DESCRIPTION
Fixes #1132.

Added the missing `help.button` translation key to `en-US.json` and `it-IT.json`. This key is used in `src/routes/+layout.svelte` for the help shortcuts button tooltip and aria-label.

### Changes:
- **`src/lib/i18n/messages/en-US.json`**: Added `"help": { "button": "Show help shortcuts" }`.
- **`src/lib/i18n/messages/it-IT.json`**: Added `"help": { "button": "Mostra le scorciatoie della guida" }`.

### Verification:
- Verified the key usage in `src/routes/+layout.svelte`.
- Manually confirmed the translation structure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added help shortcuts feature to guide users through the interface.

* **Improvements**
  * Refined and standardized UI terminology and wording across the application.
  * Enhanced nutrition information display with improved chart-related labels and tooltips.
  * Improved translations in English and Italian for better localization.
  * Updated various labels, descriptions, and messaging for increased clarity and consistency.
  * Streamlined navigation and facet-related text for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->