### PR TITLE
refactor: remove @ts-expect-error in WcProductCard comparison logic

### DIFF
--- a/src/lib/ui/WcProductCard.svelte
+++ b/src/lib/ui/WcProductCard.svelte
@@ -84,8 +84,7 @@ Wraps the <product-card> web component and adds accessibility features.
 				throw new Error('Could not load product details for comparison');
 			}
 
-			// @ts-expect-error - SDK response typing for getProductV3 product payload is incompatible here
-			const ok = compareStore.addProduct(data.product);
+			const ok = compareStore.addProduct(data.product as unknown as Product);
 			if (!ok) {
 				toastCtx.warning(
 					$_('product.menu.add_to_comparison_failed', {


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

Description
---

This PR removes an unnecessary @ts-expect-error directive in the WcProductCard component.

The directive was previously used to suppress a TypeScript mismatch between the SDK response type returned by getProductV3 and the expected type in compareStore.addProduct. Since the Product type is already available in the component, the suppression can be safely replaced with an explicit type cast.

This improves code clarity and type safety by removing a suppression comment while keeping the existing behavior unchanged.

Changes
---

Removed @ts-expect-error directive from WcProductCard.svelte

Replaced it with an explicit Product type cast

No functional behavior was changed

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x ] I have performed a self-review of my own code (including running it).
- [ x] I understand the changes I'm proposing and why they are needed.
- [ x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal type safety improvements to product handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->