### PR TITLE
fix: ensure baseUrl is always defined in PricesApi initialization

### DIFF
--- a/src/lib/api/prices.ts
+++ b/src/lib/api/prices.ts
@@ -12,7 +12,7 @@ export function isConfigured() {
 export const createPricesApi = (fetch: typeof window.fetch): PricesApi => {
 	const authToken = get(preferences)?.prices?.authToken ?? undefined;
 	const pricesApi = new PricesApi(fetch, {
-		baseUrl: BASE_URL,
+		baseUrl: BASE_URL ?? '',
 		authToken
 	});
 	return pricesApi;


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description
---

This PR improves type safety in the Prices API initialization.

The `BASE_URL` value may be `undefined`, while the `PricesApi` constructor expects `baseUrl` to be a `string`. This change ensures that a fallback value is provided when `BASE_URL` is undefined.

### Changes
---
- Added fallback to guarantee `baseUrl` is always a string
- Fixes TypeScript error: `string | undefined` not assignable to `string`

### Impact
---
Improves type safety without changing runtime behaviour.

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x ] I have performed a self-review of my own code (including running it).
- [x ] I understand the changes I'm proposing and why they are needed.
- [ x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API initialization robustness to gracefully handle missing configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->