### PR TITLE
🎨 Palette: Add `aria-current="page"` to active pagination item

### DIFF
--- a/src/lib/Pagination.svelte
+++ b/src/lib/Pagination.svelte
@@ -18,7 +18,7 @@
 		</a>
 	{/if}
 
-	<span class="btn join-item btn-active">{page}</span>
+	<span class="btn join-item btn-active" aria-current="page">{page}</span>
 
 	{#if totalPages > page + 1}
 		<a href={pageUrl(page + 1)} class="btn join-item"> {page + 1}</a>


### PR DESCRIPTION
🎨 Palette: Add `aria-current="page"` to active pagination item

💡 **What**: Added `aria-current="page"` to the active page number in the Pagination component.
🎯 **Why**: Improves accessibility for screen reader users by properly identifying the currently active page among a list of pagination links, providing better context and orientation.
📸 **Before/After**: 
* Before: `<span class="btn join-item btn-active">{page}</span>`
* After: `<span class="btn join-item btn-active" aria-current="page">{page}</span>`
♿ **Accessibility**: Significant improvement for screen reader announcements in paginated views.

---
*PR created automatically by Jules for task [3107333739442231892](https://jules.google.com/task/3107333739442231892) started by @VaiTon*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility for pagination controls to provide improved screen reader support, enabling users of assistive technologies to better identify the current page indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->