### PR TITLE
fix: resolve GeoJSON lint error

### DIFF
--- a/src/routes/facets/[facet]/CountriesMap.svelte
+++ b/src/routes/facets/[facet]/CountriesMap.svelte
@@ -10,7 +10,7 @@
 
 	import type { GeometryCollection, Topology } from 'topojson-specification';
 	import type { Country, FacetResponse, Taxonomy } from '@openfoodfacts/openfoodfacts-nodejs';
-	import type { Feature, Geometry } from 'geojson';
+	import type { Feature, Geometry, Position } from 'geojson';
 	import type * as Leaflet from 'leaflet';
 
 	type Props = { facet: FacetResponse };
@@ -59,8 +59,8 @@
 	 * This prevents Leaflet from drawing lines across the map for features that
 	 * cross the antimeridian (Russia, USA/Alaska, Fiji, etc.).
 	 */
-	function normalizeRing(ring: GeoJSON.Position[]): GeoJSON.Position[] {
-		const out: GeoJSON.Position[] = [ring[0].slice()];
+	function normalizeRing(ring: Position[]): Position[] {
+		const out: Position[] = [ring[0].slice()];
 		for (let i = 1; i < ring.length; i++) {
 			const prev = out[i - 1][0];
 			let lng = ring[i][0];


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description

The recent commit 63ae0fafd0b82611cb859f5d2911f7b196a655dd created a lint error which caused the CI to fail. 
It was caused by the use of the GeoJSON namespace i.e. GeoJSON.Position without it being explicitly imported. 

<img width="667" height="310" alt="image" src="https://github.com/user-attachments/assets/c62950ec-9db8-4794-aba6-6c548ccfd14d" />


I have fixed this by explicitly importing the `Position` type from the `geojson` package and using it directly. This way it now satisfies both TS's type checking and ESLint's variable definition checks.






### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->


---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal type annotation improvements to enhance code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->