### PR TITLE
fix: reduce sentry tracing sample rate

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,10 +1,11 @@
+import { dev } from '$app/environment';
 import { handleErrorWithSentry } from '@sentry/sveltekit';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
 	dsn: 'https://6a3e1451763425bd80a12c9548969f22@o241488.ingest.us.sentry.io/4509950733320194',
 
-	tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1
+	tracesSampleRate: dev ? 1.0 : 0.1
 });
 
 // If you have a custom error handler, pass it to `handleErrorWithSentry`


### PR DESCRIPTION
### Description

Updated the Sentry `tracesSampleRate` to be environment-based instead of always set to `1.0`.

Previously, tracing was enabled at 100% for all environments, which can introduce unnecessary performance overhead and increase data volume in production.

### Changes

* Set `tracesSampleRate` to `1.0` in development
* Reduced it to `0.1` in production using an environment check

### Result

* Maintains full visibility during development
* Improves performance and efficiency in production

### Screenshot or video

Not applicable (configuration change)

### Related issue(s) and discussion

* Fixes: N/A

---

### Checklist: Author Self-Review

* [x] I have performed a self-review of my own code (including running it).
* [x] I understand the changes I'm proposing and why they are needed.
* [x] My changes generate no new warnings or errors (linting, console).
* [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

* [ ] Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted performance monitoring to collect full tracing data during development while reducing sampling in production, lowering data collection overhead without impacting developer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->