### PR TITLE
fix: localize product card aria-label and handle missing product name

### DIFF
--- a/src/lib/ui/WcProductCard.svelte
+++ b/src/lib/ui/WcProductCard.svelte
@@ -123,7 +123,13 @@ Wraps the <product-card> web component and adds accessibility features.
 	{product}
 	onclick={navigateToProduct}
 	onkeyup={(e: KeyboardEvent) => e.key === 'Enter' && navigateToProduct()}
-	aria-label={`Go to product ${product.product_name} with code ${product.code}`}
+	aria-label={$_('product.card.go_to_product_with_code', {
+	default: 'Go to product {name} with code {code}',
+	values: {
+		name: product.product_name || $_('product.card.this_product', { default: 'this product' }),
+		code: product.code
+	}
+})}
 	showMatchTag={personalScore != undefined}
 	navigating={{
 		to: navigating ? { params: { barcode: product.code } } : null


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description

<Fixes accessibility and localization issue in WcProductCard.

- Replaced hardcoded aria-label with svelte-i18n translation
- Added fallback for missing product_name to avoid "undefined">

### Screenshot or video

<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

### Related issue(s) and discussion

<- Fixes: #<issue-number>>

- Fixes: <!-- #1 -->

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- - [x] ChatGPT (GPT-5.3) used for guidance and code suggestion <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0
