### PR TITLE
feat: add serving size validation using units taxonomy

### DIFF
--- a/src/lib/api/taxonomy/types.ts
+++ b/src/lib/api/taxonomy/types.ts
@@ -1,4 +1,4 @@
-import type { TaxoNode } from '@openfoodfacts/openfoodfacts-nodejs';
+import type { LocalizedString, TaxoNode } from '@openfoodfacts/openfoodfacts-nodejs';
 
 export type {
 	LocalizedString,
@@ -24,6 +24,9 @@ export function getOrDefault<T>(localized: Record<string, T>, lang: string = 'en
 
 export type Origin = TaxoNode & object;
 
+export type Unit = TaxoNode & {
+	symbol?: LocalizedString;
+};
 export const TAXONOMIES_NAMES: Record<string, string> = {
 	labels: 'Label',
 	categories: 'Category',

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -336,6 +336,22 @@
 			"nutritional_information": "Nutritional Information",
 			"no_nutrition_image": "No nutrition image for language {language}",
 			"serving_size": "Serving Size",
+			"serving_size_examples": "40 g, 250 ml, 1 serving (30 g)",
+			"serving_size_placeholder": "e.g., {examples}",
+			"serving_size_issues": {
+				"missing_number": {
+					"title": "Serving size is missing a number",
+					"desc": "Serving size should include a numeric value. Examples: {examples}"
+				},
+				"missing_unit": {
+					"title": "Serving size is missing a unit",
+					"desc": "Serving size should include a unit. Examples: {examples}"
+				},
+				"unknown_unit": {
+					"title": "Serving size unit may be incorrect",
+					"desc": "Serving size should include a common unit. Examples: {examples}"
+				}
+			},
 			"no_nutrition_data": "No nutrition information on the product",
 			"no_nutrition_specified": "No nutrition data specified",
 			"remove_all_nutrient_values": "Remove all nutrient values",

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -153,7 +153,23 @@
 			"ingredients_list": "Ingredients list",
 			"no_ingredients_image": "No ingredients image",
 			"nutritional_information": "Nutritional Information",
-			"serving_size": "Serving Size",
+			"serving_size": "Porzione",
+			"serving_size_examples": "40 g, 250 ml, 1 porzione (30 g)",
+			"serving_size_placeholder": "es. {examples}",
+			"serving_size_issues": {
+				"missing_number": {
+					"title": "La porzione non contiene un numero",
+					"desc": "La porzione dovrebbe includere un valore numerico. Esempi: {examples}"
+				},
+				"missing_unit": {
+					"title": "La porzione non contiene un'unità di misura",
+					"desc": "La porzione dovrebbe includere un'unità di misura. Esempi: {examples}"
+				},
+				"unknown_unit": {
+					"title": "L'unità di misura della porzione potrebbe non essere corretta",
+					"desc": "La porzione dovrebbe includere un'unità di misura comune. Esempi: {examples}"
+				}
+			},
 			"no_nutrition_data": "No nutrition information on the product",
 			"no_nutrition_specified": "No nutrition data specified",
 			"comment": "Comment",

--- a/src/lib/ui/AddProductForm.svelte
+++ b/src/lib/ui/AddProductForm.svelte
@@ -70,6 +70,7 @@
 		storeNames: string[];
 		originNames: string[];
 		countriesNames: string[];
+		units: string[];
 	};
 
 	let {
@@ -87,6 +88,7 @@
 		storeNames,
 		originNames,
 		countriesNames,
+		units,
 		isSubmitting,
 		submit
 	}: Props = $props();
@@ -154,7 +156,7 @@
 {:else if currentStep === 3}
 	<IngredientsStep bind:product {getIngredientsImage} />
 {:else if currentStep === 4}
-	<NutritionStep bind:product {getNutritionImage} {handleNutrimentInput} />
+	<NutritionStep bind:product {units} {getNutritionImage} {handleNutrimentInput} />
 {:else if currentStep === 5}
 	<PackagingStep bind:product {getPackagingImage} />
 {:else if currentStep === 6}

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -48,6 +48,7 @@
 		storeNames: string[];
 		originNames: string[];
 		countriesNames: string[];
+		units: string[];
 	};
 
 	let {
@@ -65,6 +66,7 @@
 		storeNames,
 		originNames,
 		countriesNames,
+		units,
 		isSubmitting,
 		submit
 	}: Props = $props();
@@ -141,7 +143,7 @@
 			{$_('product.edit.sections.nutrition')}
 		</div>
 		<div class="collapse-content">
-			<NutritionStep bind:product {getNutritionImage} {handleNutrimentInput} />
+			<NutritionStep bind:product {units} {getNutritionImage} {handleNutrimentInput} />
 		</div>
 	</div>
 

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -369,8 +369,9 @@
 			</fieldset>
 			<fieldset class="fieldset">
 				{#each DEFAULT_SHOWN as nutrient (nutrient)}
-					{@const issue = issuesByField(nutrient)[0] ?? issuesByField('all')[0]}
-					<label class={['input w-full', fieldInputClasses([nutrient, 'all'])]}>
+					{@const issueKeys = [nutrient, 'all']}
+					{@const issue = issuesByField(issueKeys)[0]}
+					<label class={['input w-full', fieldInputClasses(issueKeys)]}>
 						<span class="label w-60">
 							<span class="flex grow items-center gap-2">
 								{$_(`product.edit.nutrient.${nutrient}`)}

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -17,8 +17,8 @@
 
 	import ImageButton from '../ImageButton.svelte';
 	import {
+		getServingSizeValidationResult,
 		getNutritionIssues,
-		getServingSizeIssue,
 		type Issue,
 		type IssueSeverity
 	} from './nutrition';
@@ -116,6 +116,23 @@
 		warning: 'input-warning'
 	};
 	const SEVERITY_PRECEDENCE: IssueSeverity[] = ['error', 'warning'];
+	const SERVING_SIZE_VALIDATION_ISSUES = {
+		'missing-number': {
+			severity: 'error',
+			title: 'product.edit.serving_size_issues.missing_number.title',
+			desc: 'product.edit.serving_size_issues.missing_number.desc'
+		},
+		'missing-unit': {
+			severity: 'error',
+			title: 'product.edit.serving_size_issues.missing_unit.title',
+			desc: 'product.edit.serving_size_issues.missing_unit.desc'
+		},
+		'unknown-unit': {
+			severity: 'warning',
+			title: 'product.edit.serving_size_issues.unknown_unit.title',
+			desc: 'product.edit.serving_size_issues.unknown_unit.desc'
+		}
+	} as const;
 
 	function inputClassForSeverity(severity: IssueSeverity | undefined): string {
 		return severity == null ? '' : INPUT_CLASS_BY_SEVERITY[severity];
@@ -131,7 +148,29 @@
 		return undefined;
 	}
 
-	let servingSizeIssue = $derived(getServingSizeIssue(product.serving_size, units));
+	let servingSizeExamples = $derived($_('product.edit.serving_size_examples'));
+	let servingSizeValidationResult = $derived(
+		getServingSizeValidationResult(product.serving_size, units)
+	);
+	let servingSizeIssue = $derived.by((): Issue | null => {
+		if (servingSizeValidationResult === 'valid') {
+			return null;
+		}
+
+		const validationIssue = SERVING_SIZE_VALIDATION_ISSUES[servingSizeValidationResult];
+
+		return {
+			severity: validationIssue.severity,
+			field: 'serving_size',
+			title: $_(validationIssue.title),
+			desc: $_(validationIssue.desc, { values: { examples: servingSizeExamples } })
+		};
+	});
+	let servingSizePlaceholder = $derived(
+		$_('product.edit.serving_size_placeholder', {
+			values: { examples: servingSizeExamples }
+		})
+	);
 	let nutritionIssues = $derived(getNutritionIssues(product));
 
 	let issuesByField = $derived((keys: string | string[]) => {
@@ -229,7 +268,7 @@
 						class={['input input-bordered w-full text-sm sm:text-base', servingSizeInputClass]}
 						value={product.serving_size ?? ''}
 						oninput={handleServingSize}
-						placeholder="e.g., 40 g, 250 ml, 1 serving (30 g)"
+						placeholder={servingSizePlaceholder}
 					/>
 				</label>
 				{#if servingSizeIssue}

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -16,15 +16,16 @@
 	import IconMdiDeleteSweep from '@iconify-svelte/mdi/delete-sweep';
 
 	import ImageButton from '../ImageButton.svelte';
-	import { analyzeNutrition } from './nutrition';
+	import { getNutritionIssues, getServingSizeIssue } from './nutrition';
 
 	type Props = {
 		product: Product;
+		units: string[];
 		getNutritionImage: (language: string) => string | null;
 		handleNutrimentInput: (e: Event, key: string) => void;
 	};
 
-	let { product = $bindable(), getNutritionImage, handleNutrimentInput }: Props = $props();
+	let { product = $bindable(), units, getNutritionImage, handleNutrimentInput }: Props = $props();
 
 	const IGNORE_NUTRIENTS: NutrientKey[] = ['energy-kj', 'energy-kcal', 'energy'];
 	const DEFAULT_SHOWN: NutrientKey[] = [
@@ -81,7 +82,23 @@
 		};
 	}
 
-	let analysisResults = $derived(analyzeNutrition(product));
+	function handleServingSize(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+
+		product = {
+			...product,
+			serving_size: input.value
+		};
+	}
+
+	function handleNoNutritionData(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+
+		product = {
+			...product,
+			no_nutrition_data: input.checked
+		};
+	}
 
 	const bySeverity = (a: { severity: string }, b: { severity: string }) => {
 		if (a.severity === b.severity) return 0;
@@ -89,21 +106,34 @@
 		return 1;
 	};
 
+	function inputClassForSeverity(severity: 'warning' | 'error' | undefined): string {
+		if (severity === 'error') return 'input-error';
+		if (severity === 'warning') return 'input-warning';
+		return '';
+	}
+
+	function highestSeverity(
+		issues: Array<{ severity: 'warning' | 'error' }>
+	): 'warning' | 'error' | undefined {
+		if (issues.some((r) => r.severity === 'error')) return 'error';
+		if (issues.some((r) => r.severity === 'warning')) return 'warning';
+		return undefined;
+	}
+
+	let servingSizeIssue = $derived(getServingSizeIssue(product.serving_size, units));
+	let nutritionIssues = $derived(getNutritionIssues(product));
+
 	let issuesByField = $derived((keys: string | string[]) => {
 		const keysArray = Array.isArray(keys) ? keys : [keys];
 
-		return analysisResults
+		return nutritionIssues
 			.filter((r) => r.field && keysArray.includes(r.field))
 			.toSorted(bySeverity);
 	});
-
-	let fieldInputClasses = $derived((field: string | string[]) => {
-		const results = issuesByField(field);
-		if (results.length === 0) return '';
-		if (results.some((r) => r.severity === 'error')) return 'input-error';
-		if (results.some((r) => r.severity === 'warning')) return 'input-warning';
-		return '';
-	});
+	let servingSizeInputClass = $derived(inputClassForSeverity(servingSizeIssue?.severity));
+	let fieldInputClasses = $derived((field: string | string[]) =>
+		inputClassForSeverity(highestSeverity(issuesByField(field)))
+	);
 
 	function wipeAllNutrientValues() {
 		product = {
@@ -113,6 +143,33 @@
 		additionalNutrients = [];
 	}
 </script>
+
+{#snippet issueTooltip(issue: { severity: 'warning' | 'error'; title: string })}
+	{@const isError = issue.severity === 'error'}
+	{@const Icon = isError ? IconMdiAlertCircle : IconMdiAlert}
+	{@const iconColorClass = isError ? 'text-error' : 'text-warning'}
+	<div
+		class={['tooltip cursor-default', isError ? 'tooltip-error' : 'tooltip-warning']}
+		data-tip={issue.title}
+	>
+		<Icon class={[iconColorClass, 'ml-2 h-5 w-5 text-lg']} />
+	</div>
+{/snippet}
+
+{#snippet issueAlert(issue: { severity: 'warning' | 'error'; title: string; desc?: string })}
+	{@const isError = issue.severity === 'error'}
+	{@const Icon = isError ? IconMdiAlertCircle : IconMdiAlert}
+	{@const alertColorClass = isError ? 'alert-error' : 'alert-warning'}
+	<div class={[alertColorClass, 'alert mt-4']}>
+		<Icon class="h-5 w-5" />
+		<div>
+			<p class="text-sm font-bold sm:text-base">{issue.title}</p>
+			{#if issue.desc}
+				<p class="mt-2 text-sm sm:text-base">{issue.desc}</p>
+			{/if}
+		</div>
+	</div>
+{/snippet}
 
 <h2
 	class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
@@ -151,20 +208,32 @@
 					<span class="label mb-2 flex items-center gap-2 leading-0">
 						{$_('product.edit.serving_size')}
 						<InfoTooltip text={$_('product.edit.tooltips.serving_size')} />
-					</span>title
+						{#if servingSizeIssue}
+							{@render issueTooltip(servingSizeIssue)}
+						{/if}
+					</span>
 					<input
 						id="serving-size-input"
 						type="text"
-						class="input input-bordered w-full text-sm sm:text-base"
-						bind:value={product.serving_size}
-						placeholder="e.g., 100g, 1 serving (30g)"
+						class={['input input-bordered w-full text-sm sm:text-base', servingSizeInputClass]}
+						value={product.serving_size ?? ''}
+						oninput={handleServingSize}
+						placeholder="e.g., 40 g, 250 ml, 1 serving (30 g)"
 					/>
 				</label>
+				{#if servingSizeIssue}
+					{@render issueAlert(servingSizeIssue)}
+				{/if}
 			</div>
 
 			<div>
 				<label class="label">
-					<input type="checkbox" class="checkbox" bind:checked={product.no_nutrition_data} />
+					<input
+						type="checkbox"
+						class="checkbox"
+						checked={product.no_nutrition_data ?? false}
+						onchange={handleNoNutritionData}
+					/>
 					<span>
 						{$_('product.edit.no_nutrition_data')}
 					</span>
@@ -213,23 +282,7 @@
 							{$_('product.edit.si_kilojoules')}
 						</span>
 						{#if issuesByField('energy').length > 0}
-							{@const issue = issuesByField('energy')[0]}
-							<div
-								class={[
-									'tooltip',
-									issue?.severity === 'error' && 'tooltip-error',
-									issue?.severity === 'warning' && 'tooltip-warning'
-								]}
-								data-tip={issue?.title}
-							>
-								<div class="ml-2 h-5 w-5">
-									{#if issue.severity === 'warning'}
-										<IconMdiAlert class="text-warning h-5 w-5" />
-									{:else if issue.severity === 'error'}
-										<IconMdiAlertCircle class="text-error h-5 w-5" />
-									{/if}
-								</div>
-							</div>
+							{@render issueTooltip(issuesByField('energy')[0])}
 						{/if}
 					</label>
 
@@ -259,20 +312,14 @@
 							{$_('product.edit.si_kilocalories')}
 						</span>
 						{#if issuesByField('energy').length > 0}
-							{@const issue = issuesByField('energy')[0]}
-							<div class="tooltip tooltip-warning" data-tip={issue?.title}>
-								{#if issue.severity === 'warning'}
-									<IconMdiAlert class="text-warning ml-2 h-5 w-5" />
-								{:else if issue.severity === 'error'}
-									<IconMdiAlertCircle class="text-error ml-2 h-5 w-5" />
-								{/if}
-							</div>
+							{@render issueTooltip(issuesByField('energy')[0])}
 						{/if}
 					</label>
 				</div>
 			</fieldset>
 			<fieldset class="fieldset">
 				{#each DEFAULT_SHOWN as nutrient (nutrient)}
+					{@const issue = issuesByField(nutrient)[0] ?? issuesByField('all')[0]}
 					<label class={['input w-full', fieldInputClasses([nutrient, 'all'])]}>
 						<span class="label w-60">
 							<span class="flex grow items-center gap-2">
@@ -282,22 +329,8 @@
 									<InfoTooltip text={$_(EMPTY_NUTRIENT_TOOLTIPS[nutrient])} />
 								{/if}
 							</span>
-							{#if issuesByField([nutrient, 'all']).length > 0}
-								{@const issue = issuesByField(nutrient)[0] ?? issuesByField('all')[0]}
-								<div
-									class={[
-										'tooltip cursor-default',
-										issue?.severity === 'error' && 'tooltip-error',
-										issue?.severity === 'warning' && 'tooltip-warning'
-									]}
-									data-tip={issue?.title}
-								>
-									{#if issue.severity === 'warning'}
-										<IconMdiAlert class="text-warning ml-2 h-5 w-5 text-lg" />
-									{:else if issue.severity === 'error'}
-										<IconMdiAlertCircle class="text-error ml-2 h-5 w-5 text-lg" />
-									{/if}
-								</div>
+							{#if issue}
+								{@render issueTooltip(issue)}
 							{/if}
 						</span>
 
@@ -393,34 +426,14 @@
 				{/if}
 			</fieldset>
 
-			{#if analysisResults.length > 0}
+			{#if nutritionIssues.length > 0}
 				<div class="divider"></div>
 				<h3 class="text-lg font-bold">{$_('product.edit.nutrition_issues')}</h3>
 				<p class="text-base-content/80 text-sm">
 					{$_('product.edit.nutrition_issues_description')}
 				</p>
-				{#each analysisResults.toSorted(bySeverity) as result (result.title)}
-					{#if result.severity === 'error'}
-						<div class="alert alert-error mt-4">
-							<IconMdiAlertCircle class="h-5 w-5" />
-							<div>
-								<p class="text-sm font-bold sm:text-base">{result.title}</p>
-								{#if result.desc}
-									<p class="mt-2 text-sm sm:text-base">{result.desc}</p>
-								{/if}
-							</div>
-						</div>
-					{:else if result.severity === 'warning'}
-						<div class="alert alert-warning mt-4">
-							<IconMdiAlertCircle class="h-5 w-5" />
-							<div>
-								<p class="text-sm font-bold sm:text-base">{result.title}</p>
-								{#if result.desc}
-									<p class="mt-2 text-sm sm:text-base">{result.desc}</p>
-								{/if}
-							</div>
-						</div>
-					{/if}
+				{#each nutritionIssues.toSorted(bySeverity) as result (result.title)}
+					{@render issueAlert(result)}
 				{/each}
 			{/if}
 		{:else}

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -16,7 +16,12 @@
 	import IconMdiDeleteSweep from '@iconify-svelte/mdi/delete-sweep';
 
 	import ImageButton from '../ImageButton.svelte';
-	import { getNutritionIssues, getServingSizeIssue } from './nutrition';
+	import {
+		getNutritionIssues,
+		getServingSizeIssue,
+		type Issue,
+		type IssueSeverity
+	} from './nutrition';
 
 	type Props = {
 		product: Product;
@@ -100,23 +105,29 @@
 		};
 	}
 
-	const bySeverity = (a: { severity: string }, b: { severity: string }) => {
+	const bySeverity = (a: Issue, b: Issue) => {
 		if (a.severity === b.severity) return 0;
 		if (a.severity === 'error') return -1;
 		return 1;
 	};
 
-	function inputClassForSeverity(severity: 'warning' | 'error' | undefined): string {
-		if (severity === 'error') return 'input-error';
-		if (severity === 'warning') return 'input-warning';
-		return '';
+	const INPUT_CLASS_BY_SEVERITY: Record<IssueSeverity, string> = {
+		error: 'input-error',
+		warning: 'input-warning'
+	};
+	const SEVERITY_PRECEDENCE: IssueSeverity[] = ['error', 'warning'];
+
+	function inputClassForSeverity(severity: IssueSeverity | undefined): string {
+		return severity == null ? '' : INPUT_CLASS_BY_SEVERITY[severity];
 	}
 
-	function highestSeverity(
-		issues: Array<{ severity: 'warning' | 'error' }>
-	): 'warning' | 'error' | undefined {
-		if (issues.some((r) => r.severity === 'error')) return 'error';
-		if (issues.some((r) => r.severity === 'warning')) return 'warning';
+	function highestSeverity(issues: Issue[]): IssueSeverity | undefined {
+		for (const severity of SEVERITY_PRECEDENCE) {
+			if (issues.some((issue) => issue.severity === severity)) {
+				return severity;
+			}
+		}
+
 		return undefined;
 	}
 
@@ -144,7 +155,7 @@
 	}
 </script>
 
-{#snippet issueTooltip(issue: { severity: 'warning' | 'error'; title: string })}
+{#snippet issueTooltip(issue: Issue)}
 	{@const isError = issue.severity === 'error'}
 	{@const Icon = isError ? IconMdiAlertCircle : IconMdiAlert}
 	{@const iconColorClass = isError ? 'text-error' : 'text-warning'}
@@ -156,7 +167,7 @@
 	</div>
 {/snippet}
 
-{#snippet issueAlert(issue: { severity: 'warning' | 'error'; title: string; desc?: string })}
+{#snippet issueAlert(issue: Issue)}
 	{@const isError = issue.severity === 'error'}
 	{@const Icon = isError ? IconMdiAlertCircle : IconMdiAlert}
 	{@const alertColorClass = isError ? 'alert-error' : 'alert-warning'}

--- a/src/lib/ui/edit-product-steps/nutrition.test.ts
+++ b/src/lib/ui/edit-product-steps/nutrition.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { getServingSizeIssue } from './nutrition';
+
+const units = [
+	'g',
+	'grammo',
+	'克',
+	'ml',
+	'millilitro',
+	'mcg',
+	'microgrammo',
+	'µg',
+	'percent',
+	'percento',
+	'%'
+];
+
+describe('getServingSizeIssue', () => {
+	it('shows an error when the input has no number at all', () => {
+		const issue = getServingSizeIssue('large portion', units);
+
+		expect(issue).toMatchObject({
+			field: 'serving_size',
+			severity: 'error'
+		});
+	});
+
+	it('shows an error when the input is only a number', () => {
+		const issue = getServingSizeIssue('100', units);
+
+		expect(issue).toMatchObject({
+			field: 'serving_size',
+			severity: 'error'
+		});
+	});
+
+	it('shows a warning when the number is there but the unit is unknown', () => {
+		const issue = getServingSizeIssue('1 pcs', units);
+
+		expect(issue).toMatchObject({
+			field: 'serving_size',
+			severity: 'warning'
+		});
+	});
+
+	it('does not let punctuation contribute to identifying an unknown unit', () => {
+		const issue = getServingSizeIssue('100)', units);
+
+		expect(issue).toMatchObject({
+			field: 'serving_size',
+			severity: 'error'
+		});
+	});
+
+	it('accepts units exposed by the taxonomy regardless of position', () => {
+		expect(getServingSizeIssue('1 serving (30 g)', units)).toBeNull();
+		expect(getServingSizeIssue('1 serving (30 克)', units)).toBeNull();
+		expect(getServingSizeIssue('50 µg', units)).toBeNull();
+		expect(getServingSizeIssue('250ml', units)).toBeNull();
+		expect(getServingSizeIssue('1.5 ml', units)).toBeNull();
+		expect(getServingSizeIssue('1,5 ml', units)).toBeNull();
+		expect(getServingSizeIssue('10 %', units)).toBeNull();
+		expect(getServingSizeIssue('ml 250', units)).toBeNull();
+	});
+
+	it('shows a warning when text does not contain a standalone unit token', () => {
+		const issue = getServingSizeIssue('1 ggg', units);
+
+		expect(issue).toMatchObject({
+			field: 'serving_size',
+			severity: 'warning'
+		});
+	});
+
+	it('shows no issue for an empty serving size', () => {
+		const issue = getServingSizeIssue('', units);
+
+		expect(issue).toBeNull();
+	});
+});

--- a/src/lib/ui/edit-product-steps/nutrition.test.ts
+++ b/src/lib/ui/edit-product-steps/nutrition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getServingSizeIssue } from './nutrition';
+import { getServingSizeValidationResult } from './nutrition';
 
 const units = [
 	'g',
@@ -16,66 +16,51 @@ const units = [
 	'%'
 ];
 
-describe('getServingSizeIssue', () => {
+describe('getServingSizeValidationResult', () => {
 	it('shows an error when the input has no number at all', () => {
-		const issue = getServingSizeIssue('large portion', units);
+		const issue = getServingSizeValidationResult('large portion', units);
 
-		expect(issue).toMatchObject({
-			field: 'serving_size',
-			severity: 'error'
-		});
+		expect(issue).toBe('missing-number');
 	});
 
 	it('shows an error when the input is only a number', () => {
-		const issue = getServingSizeIssue('100', units);
+		const issue = getServingSizeValidationResult('100', units);
 
-		expect(issue).toMatchObject({
-			field: 'serving_size',
-			severity: 'error'
-		});
+		expect(issue).toBe('missing-unit');
 	});
 
 	it('shows a warning when the number is there but the unit is unknown', () => {
-		const issue = getServingSizeIssue('1 pcs', units);
+		const issue = getServingSizeValidationResult('1 pcs', units);
 
-		expect(issue).toMatchObject({
-			field: 'serving_size',
-			severity: 'warning'
-		});
+		expect(issue).toBe('unknown-unit');
 	});
 
 	it('does not let punctuation contribute to identifying an unknown unit', () => {
-		const issue = getServingSizeIssue('100)', units);
+		const issue = getServingSizeValidationResult('100)', units);
 
-		expect(issue).toMatchObject({
-			field: 'serving_size',
-			severity: 'error'
-		});
+		expect(issue).toBe('missing-unit');
 	});
 
 	it('accepts units exposed by the taxonomy regardless of position', () => {
-		expect(getServingSizeIssue('1 serving (30 g)', units)).toBeNull();
-		expect(getServingSizeIssue('1 serving (30 克)', units)).toBeNull();
-		expect(getServingSizeIssue('50 µg', units)).toBeNull();
-		expect(getServingSizeIssue('250ml', units)).toBeNull();
-		expect(getServingSizeIssue('1.5 ml', units)).toBeNull();
-		expect(getServingSizeIssue('1,5 ml', units)).toBeNull();
-		expect(getServingSizeIssue('10 %', units)).toBeNull();
-		expect(getServingSizeIssue('ml 250', units)).toBeNull();
+		expect(getServingSizeValidationResult('1 serving (30 g)', units)).toBe('valid');
+		expect(getServingSizeValidationResult('1 serving (30 克)', units)).toBe('valid');
+		expect(getServingSizeValidationResult('50 µg', units)).toBe('valid');
+		expect(getServingSizeValidationResult('250ml', units)).toBe('valid');
+		expect(getServingSizeValidationResult('1.5 ml', units)).toBe('valid');
+		expect(getServingSizeValidationResult('1,5 ml', units)).toBe('valid');
+		expect(getServingSizeValidationResult('10 %', units)).toBe('valid');
+		expect(getServingSizeValidationResult('ml 250', units)).toBe('valid');
 	});
 
 	it('shows a warning when text does not contain a standalone unit token', () => {
-		const issue = getServingSizeIssue('1 ggg', units);
+		const issue = getServingSizeValidationResult('1 ggg', units);
 
-		expect(issue).toMatchObject({
-			field: 'serving_size',
-			severity: 'warning'
-		});
+		expect(issue).toBe('unknown-unit');
 	});
 
 	it('shows no issue for an empty serving size', () => {
-		const issue = getServingSizeIssue('', units);
+		const issue = getServingSizeValidationResult('', units);
 
-		expect(issue).toBeNull();
+		expect(issue).toBe('valid');
 	});
 });

--- a/src/lib/ui/edit-product-steps/nutrition.ts
+++ b/src/lib/ui/edit-product-steps/nutrition.ts
@@ -1,7 +1,9 @@
 import type { Product } from '$lib/api';
 
-type Issue = {
-	severity: 'warning' | 'error';
+export type IssueSeverity = 'warning' | 'error';
+
+export type Issue = {
+	severity: IssueSeverity;
 	field?: string; // e.g., 'energy', 'proteins', 'all', etc.
 	title: string;
 	desc?: string;

--- a/src/lib/ui/edit-product-steps/nutrition.ts
+++ b/src/lib/ui/edit-product-steps/nutrition.ts
@@ -14,7 +14,7 @@ type ServingSizeValidationResult = 'valid' | 'missing-number' | 'missing-unit' |
 type AnalysisFunc = (product: Product) => Issue[];
 
 // Match numeric tokens so we can inspect the surrounding text for units.
-const NUMBER_PATTERN = /\.\d+|\d+(?:(?:,|\.)\d+)?/g;
+const NUMBER_PATTERN = /\.\d+|\d+(?:[,.]\d+)?/g;
 // Match characters that are letters in any language.
 const LETTER_PATTERN = /\p{L}/u;
 
@@ -45,7 +45,7 @@ function containsKnownUnit(token: string, units: readonly string[]): boolean {
 	return false;
 }
 
-function validateServingSize(
+export function getServingSizeValidationResult(
 	servingSize: string | null | undefined,
 	units: readonly string[]
 ): ServingSizeValidationResult {
@@ -81,40 +81,6 @@ function validateServingSize(
 	}
 
 	return 'missing-unit';
-}
-
-export function getServingSizeIssue(
-	servingSize: string | null | undefined,
-	units: readonly string[]
-): Issue | null {
-	const validationResult = validateServingSize(servingSize, units);
-	const servingSizeExamples = 'Examples: 40 g, 250 ml, or 1 serving (30 g).';
-
-	switch (validationResult) {
-		case 'valid':
-			return null;
-		case 'missing-number':
-			return {
-				severity: 'error',
-				field: 'serving_size',
-				title: 'Serving size is missing a number',
-				desc: `Serving size should include a numeric value. ${servingSizeExamples}`
-			};
-		case 'missing-unit':
-			return {
-				severity: 'error',
-				field: 'serving_size',
-				title: 'Serving size is missing a unit',
-				desc: `Serving size should include a unit. ${servingSizeExamples}`
-			};
-		case 'unknown-unit':
-			return {
-				severity: 'warning',
-				field: 'serving_size',
-				title: 'Serving size unit may be incorrect',
-				desc: `Serving size should include a common unit. ${servingSizeExamples}`
-			};
-	}
 }
 
 const energyMismatchAnalysis: AnalysisFunc = (product) => {

--- a/src/lib/ui/edit-product-steps/nutrition.ts
+++ b/src/lib/ui/edit-product-steps/nutrition.ts
@@ -1,13 +1,115 @@
 import type { Product } from '$lib/api';
 
-type AnalysisResult = {
+type Issue = {
 	severity: 'warning' | 'error';
 	field?: string; // e.g., 'energy', 'proteins', 'all', etc.
 	title: string;
 	desc?: string;
 };
 
-type AnalysisFunc = (product: Product) => AnalysisResult[];
+type ServingSizeValidationResult = 'valid' | 'missing-number' | 'missing-unit' | 'unknown-unit';
+
+type AnalysisFunc = (product: Product) => Issue[];
+
+// Match numeric tokens so we can inspect the surrounding text for units.
+const NUMBER_PATTERN = /\.\d+|\d+(?:(?:,|\.)\d+)?/g;
+// Match characters that are letters in any language.
+const LETTER_PATTERN = /\p{L}/u;
+
+function isLetter(character: string | undefined): boolean {
+	return character != null && LETTER_PATTERN.test(character);
+}
+
+function containsKnownUnit(token: string, units: readonly string[]): boolean {
+	// Return true when the token contains a known unit as a standalone token.
+	for (const unit of units) {
+		let currentIndex = token.indexOf(unit);
+
+		while (currentIndex !== -1) {
+			const previousChar = token[currentIndex - 1];
+			const nextChar = token[currentIndex + unit.length];
+			if (!isLetter(previousChar) && !isLetter(nextChar)) {
+				return true;
+			}
+
+			currentIndex = token.indexOf(unit, currentIndex + unit.length);
+		}
+	}
+
+	return false;
+}
+
+function validateServingSize(
+	servingSize: string | null | undefined,
+	units: readonly string[]
+): ServingSizeValidationResult {
+	const normalizedServingSize = (servingSize ?? '').toLowerCase().trim();
+
+	if (normalizedServingSize === '') {
+		return 'valid';
+	}
+
+	if (normalizedServingSize.match(NUMBER_PATTERN) == null) {
+		return 'missing-number';
+	}
+
+	const tokens = normalizedServingSize.split(NUMBER_PATTERN);
+	let containsUnknownUnit = false;
+
+	for (const token of tokens) {
+		if (token.trim() === '') {
+			continue;
+		}
+
+		if (containsKnownUnit(token, units)) {
+			return 'valid';
+		}
+
+		if (LETTER_PATTERN.test(token)) {
+			containsUnknownUnit = true;
+		}
+	}
+
+	if (containsUnknownUnit) {
+		return 'unknown-unit';
+	}
+
+	return 'missing-unit';
+}
+
+export function getServingSizeIssue(
+	servingSize: string | null | undefined,
+	units: readonly string[]
+): Issue | null {
+	const validationResult = validateServingSize(servingSize, units);
+	const servingSizeExamples = 'Examples: 40 g, 250 ml, or 1 serving (30 g).';
+
+	switch (validationResult) {
+		case 'valid':
+			return null;
+		case 'missing-number':
+			return {
+				severity: 'error',
+				field: 'serving_size',
+				title: 'Serving size is missing a number',
+				desc: `Serving size should include a numeric value. ${servingSizeExamples}`
+			};
+		case 'missing-unit':
+			return {
+				severity: 'error',
+				field: 'serving_size',
+				title: 'Serving size is missing a unit',
+				desc: `Serving size should include a unit. ${servingSizeExamples}`
+			};
+		case 'unknown-unit':
+			return {
+				severity: 'warning',
+				field: 'serving_size',
+				title: 'Serving size unit may be incorrect',
+				desc: `Serving size should include a common unit. ${servingSizeExamples}`
+			};
+	}
+}
 
 const energyMismatchAnalysis: AnalysisFunc = (product) => {
 	const kcalToKjFactor = 4.184;
@@ -106,7 +208,7 @@ const sumOfMacroLessThan100g: AnalysisFunc = (product) => {
 };
 
 const singleFieldLessThan100g: AnalysisFunc = (product) => {
-	const results: AnalysisResult[] = [];
+	const issues: Issue[] = [];
 	const fields = [
 		'proteins',
 		'carbohydrates',
@@ -119,7 +221,7 @@ const singleFieldLessThan100g: AnalysisFunc = (product) => {
 	for (const field of fields) {
 		const value = product.nutriments?.[field] ?? 0;
 		if (value > 100) {
-			results.push({
+			issues.push({
 				severity: 'error',
 				title: `The value of ${field} exceeds 100g`,
 				desc: `The amount of ${field} is ${value.toFixed(2)}g per 100g of product, which exceeds the maximum of 100g.`,
@@ -127,10 +229,10 @@ const singleFieldLessThan100g: AnalysisFunc = (product) => {
 			});
 		}
 	}
-	return results;
+	return issues;
 };
 
-function sugarsLessThanCarbs(product: Product): AnalysisResult[] {
+function sugarsLessThanCarbs(product: Product): Issue[] {
 	const sugars = product.nutriments?.['sugars'] ?? 0;
 	const carbs = product.nutriments?.['carbohydrates'] ?? 0;
 	if (sugars > carbs) {
@@ -159,10 +261,10 @@ const analysisFunctions: AnalysisFunc[] = [
 	sugarsLessThanCarbs
 ];
 
-export function analyzeNutrition(product: Product): AnalysisResult[] {
-	let results: AnalysisResult[] = [];
+export function getNutritionIssues(product: Product): Issue[] {
+	let issues: Issue[] = [];
 	for (const func of analysisFunctions) {
-		results = results.concat(func(product));
+		issues = issues.concat(func(product));
 	}
-	return results;
+	return issues;
 }

--- a/src/lib/ui/edit-product-steps/nutrition.ts
+++ b/src/lib/ui/edit-product-steps/nutrition.ts
@@ -23,6 +23,10 @@ function isLetter(character: string | undefined): boolean {
 function containsKnownUnit(token: string, units: readonly string[]): boolean {
 	// Return true when the token contains a known unit as a standalone token.
 	for (const unit of units) {
+		if (unit === '') {
+			continue;
+		}
+
 		let currentIndex = token.indexOf(unit);
 
 		while (currentIndex !== -1) {

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -144,8 +144,7 @@
 	}
 
 	function getUnits(taxo: Taxonomy<Unit>) {
-		const units: string[] = [];
-		const seenUnits: Record<string, true> = {};
+		const units = new Set<string>();
 
 		for (const taxoNode of Object.values(taxo)) {
 			const localizedUnits = [
@@ -155,14 +154,13 @@
 
 			for (const unit of localizedUnits) {
 				const normalizedUnit = unit.toLowerCase().trim();
-				if (normalizedUnit !== '' && seenUnits[normalizedUnit] !== true) {
-					seenUnits[normalizedUnit] = true;
-					units.push(normalizedUnit);
+				if (normalizedUnit !== '') {
+					units.add(normalizedUnit);
 				}
 			}
 		}
 
-		return units;
+		return [...units];
 	}
 
 	let categoryNames = $derived(getNames(data.categories));

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -7,6 +7,7 @@
 		getOrDefault,
 		type SelectedImage,
 		type Taxonomy,
+		type Unit,
 		type Product,
 		type Nutriments,
 		type RawImage,
@@ -142,12 +143,35 @@
 			.filter((t): t is string => t !== undefined);
 	}
 
+	function getUnits(taxo: Taxonomy<Unit>) {
+		const units: string[] = [];
+		const seenUnits: Record<string, true> = {};
+
+		for (const taxoNode of Object.values(taxo)) {
+			const localizedUnits = [
+				...Object.values(taxoNode.name),
+				...Object.values(taxoNode.symbol ?? {})
+			];
+
+			for (const unit of localizedUnits) {
+				const normalizedUnit = unit.toLowerCase().trim();
+				if (normalizedUnit !== '' && seenUnits[normalizedUnit] !== true) {
+					seenUnits[normalizedUnit] = true;
+					units.push(normalizedUnit);
+				}
+			}
+		}
+
+		return units;
+	}
+
 	let categoryNames = $derived(getNames(data.categories));
 	let labelNames = $derived(getNames(data.labels));
 	let brandNames = $derived(getNames(data.brands));
 	let storeNames = $derived(getNames(data.stores));
 	let originNames = $derived(getNames(data.origins));
 	let countriesNames = $derived(getNames(data.countries));
+	let units = $derived(getUnits(data.units));
 
 	function createProductStore(data: PageData): Product {
 		return data.state.status === PRODUCT_STATUS.EMPTY ||
@@ -385,7 +409,7 @@
 
 {#if dev}
 	<div class="alert alert-warning my-8 text-lg" role="alert">
-		<IconMdiAlert class="mr-2" />
+		<IconMdiAlert class="mr-2 h-6 w-6 shrink-0" />
 		<div>
 			<p>
 				<strong> You are not logged in! </strong>
@@ -438,6 +462,7 @@
 			{originNames}
 			{submit}
 			{storeNames}
+			{units}
 			{handleNutrimentInput}
 		/>
 	{:else}
@@ -457,6 +482,7 @@
 			{labelNames}
 			{originNames}
 			{storeNames}
+			{units}
 			languages={filteredLanguages}
 		/>
 	{/if}

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import ISO6391 from 'iso-639-1';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { _ } from '$lib/i18n';
 
 	import {
@@ -144,7 +145,7 @@
 	}
 
 	function getUnits(taxo: Taxonomy<Unit>) {
-		const units = new Set<string>();
+		const units = new SvelteSet<string>();
 
 		for (const taxoNode of Object.values(taxo)) {
 			const localizedUnits = [

--- a/src/routes/products/[barcode]/edit/+page.ts
+++ b/src/routes/products/[barcode]/edit/+page.ts
@@ -9,6 +9,7 @@ import {
 	type Brand,
 	type Store,
 	type Country,
+	type Unit,
 	createProductsApi
 } from '$lib/api';
 import { userInfo } from '$lib/stores/user';
@@ -63,13 +64,14 @@ export const load: PageLoad = async ({ fetch, params }) => {
 	const productType =
 		productState.status !== 'failure' ? productState.product.product_type : undefined;
 
-	const [categories, labels, brands, stores, origins, countries] = await Promise.all([
+	const [categories, labels, brands, stores, origins, countries, units] = await Promise.all([
 		getTaxo<Category>('categories', fetch, productType),
 		getTaxo<Label>('labels', fetch, productType),
 		getTaxo<Brand>('brands', fetch, productType),
 		getTaxo<Store>('stores', fetch, productType),
 		getTaxo<Origin>('origins', fetch, productType),
-		getTaxo<Country>('countries', fetch, productType)
+		getTaxo<Country>('countries', fetch, productType),
+		getTaxo<Unit>('units', fetch, productType)
 	]);
 
 	console.debug(`Product state for barcode ${params.barcode}:`, productState.status);
@@ -86,7 +88,8 @@ export const load: PageLoad = async ({ fetch, params }) => {
 			brands,
 			stores,
 			origins,
-			countries
+			countries,
+			units
 		};
 	}
 
@@ -97,6 +100,7 @@ export const load: PageLoad = async ({ fetch, params }) => {
 		brands,
 		stores,
 		origins,
-		countries
+		countries,
+		units
 	};
 };


### PR DESCRIPTION
## Description

This PR adds serving size validation using the `units` taxonomy as the source of truth.

The validation is non-blocking and provides feedback according to the following logic:
<table>
  <tr>
    <th align="center">Validation</th>
    <th align="center">Cases</th>
  </tr>
  <tr>
    <td valign="middle" align="center"><strong>No issue</strong></td>
    <td valign="top">
      <ul>
        <li>Input is empty</li>
        <li>Input contains a number and a recognized unit</li>
      </ul>
    </td>
  </tr>
  <tr>
    <td valign="middle" align="center"><strong>Error</strong></td>
    <td valign="top">
      <ul>
        <li>Input is not empty but missing a number</li>
        <li>Input contains a number but missing a unit</li>
      </ul>
    </td>
  </tr>
  <tr>
    <td valign="middle" align="center"><strong>Warning</strong></td>
    <td valign="top">
      <ul>
        <li>Input contains a number and text that could be a unit, but the unit is not recognized</li>
      </ul>
    </td>
  </tr>
</table>

As a conservative approach, inputs are considered valid whether the unit appears before or after the number, to avoid confusing users when they provide imperfect but still useful inputs like `ml 250`.

## Changes
<table>
  <tr>
    <th align="center">File</th>
    <th align="center">Changes</th>
  </tr>
  <tr>
    <td valign="middle" align="center">
      <a href="https://github.com/openfoodfacts/openfoodfacts-explorer/pull/1209/changes#diff-7020a6bab670b4f20815023475f0a0436f9092968813d5e62e81d4be919c3d62"><code>types.ts</code></a>
    </td>
    <td valign="top">
      <ul>
        <li>Added <code>Unit</code> taxonomy type</li>
      </ul>
    </td>
  </tr>
  <tr>
    <td valign="middle" align="center">
      <a href="https://github.com/openfoodfacts/openfoodfacts-explorer/pull/1209/changes#diff-2ed210d24f6b0e53042fff18a33fac0d46b6634718cdb54982c391712c8e7ecc"><code>+page.ts</code></a>
    </td>
    <td valign="top">
      <ul>
        <li>Added <code>units</code> taxonomy to page load data</li>
      </ul>
    </td>
  </tr>
  <tr>
    <td valign="middle" align="center">
      <a href="https://github.com/openfoodfacts/openfoodfacts-explorer/pull/1209/changes#diff-4fa0132850ff7bb5564a3d2d9c412093d3d20e4e49debd9f2f9c09909fa7ebb2"><code>AddProductForm.svelte</code></a><br/>
      <a href="https://github.com/openfoodfacts/openfoodfacts-explorer/pull/1209/changes#diff-0ef0b341f6c7940ea4c0f823dc1661eacb7d9c1817812512fce53b1576901dbd"><code>EditProductForm.svelte</code></a>
    </td>
    <td valign="top">
      <ul>
        <li>Passed units data to the nutrition step</li>
      </ul>
    </td>
  </tr>
  <tr>
    <td valign="middle" align="center">
      <a href="https://github.com/openfoodfacts/openfoodfacts-explorer/pull/1209/changes#diff-d6e1b392c45cf62bae7e52eae7199d171234593fb94832141acf5ade3c74cb80"><code>+page.svelte</code></a>
    </td>
    <td valign="top">
      <ul>
        <li>Unpacked <code>units</code> taxonomy as a list of strings</li>
        <li>Passed units to the edit form flow</li>
        <li>Added sizing class to warning icon in dev alert banner as it was showing super big (this was not in the scope of the PR, but was a very small fix so I thought reasonable to include it)</li>
      </ul>
    </td>
  </tr>
  <tr>
    <td valign="middle" align="center">
      <a href="https://github.com/openfoodfacts/openfoodfacts-explorer/pull/1209/changes#diff-a67da16d0bd68853f5e4a4d2db00b5dc0ea9c2830ea9ea948f830fea8ecef2a1"><code>nutrition.ts</code></a>
    </td>
    <td valign="top">
      <ul>
        <li>Added serving size validation logic</li>
        <li>Reused same issue model already used by nutrition step</li>
        <li>Renamed some shared types and functions so they are now consistent with both serving size validation and nutrition analysis</li>
      </ul>
    </td>
  </tr>
  <tr>
    <td valign="middle" align="center">
      <a href="https://github.com/openfoodfacts/openfoodfacts-explorer/pull/1209/changes#diff-c7036034ed803ec596aecf37b3e201e12bb7be0ff040f4703051a35a60588757"><code>NutritionStep.svelte</code></a>
    </td>
    <td valign="top">
      <ul>
        <li>Added serving size validation in nutrition step UI</li>
        <li>Reused shared tooltip and alert rendering for both serving size and existing nutrition issues</li>
        <li>Kept serving size feedback independent from <code>no_nutrition_data</code></li>
      </ul>
    </td>
  </tr>
  <tr>
    <td valign="middle" align="center">
      <a href="https://github.com/openfoodfacts/openfoodfacts-explorer/pull/1209/changes#diff-38b445b65396e04aa4d1f617391a87751acc427fe493df0996a56b41a3cf77b7"><code>nutrition.test.ts</code></a>
    </td>
    <td valign="top">
      <ul>
        <li>Added unit tests for serving size validation</li>
      </ul>
    </td>
  </tr>
</table>

## Related issue
Fixes #807

## Notes
- As discussed in the related issue, I initially considered lazy-loading the units taxonomy on field focus, but ultimately I realized it was more consistent to align it with the existing taxonomy loading flow used by the edit page.

## Screenshots
<table>
  <tr>
    <td colspan="6" align="center">
      <strong>Serving size validation</strong>
    </td>
  </tr>
  <tr>
    <td colspan="2" align="center" valign="top">
      <strong>No input</strong><br/>
      <a href="https://github.com/user-attachments/assets/2ee309f2-0276-4580-9f6c-db221599f886" target="_blank">
        <img src="https://github.com/user-attachments/assets/2ee309f2-0276-4580-9f6c-db221599f886" width="220" />
      </a>
    </td>
    <td colspan="2" align="center" valign="top">
      <strong>Valid input</strong><br/>
      <a href="https://github.com/user-attachments/assets/646dcaba-83ff-4c66-aca6-53b0b743babb" target="_blank">
        <img src="https://github.com/user-attachments/assets/646dcaba-83ff-4c66-aca6-53b0b743babb" width="220" />
      </a>
    </td>
    <td colspan="2" align="center" valign="top">
      <strong>Missing number</strong><br/>
      <a href="https://github.com/user-attachments/assets/7233d08e-c85d-4f59-b3dd-03be13d6f7a7" target="_blank">
        <img src="https://github.com/user-attachments/assets/7233d08e-c85d-4f59-b3dd-03be13d6f7a7" width="220" />
      </a>
    </td>
  </tr>
  <tr>
    <td colspan="2" align="center" valign="top">
      <strong>Missing unit</strong><br/>
      <a href="https://github.com/user-attachments/assets/18287ee9-d98e-471e-bfdb-ba1776f9beed" target="_blank">
        <img src="https://github.com/user-attachments/assets/18287ee9-d98e-471e-bfdb-ba1776f9beed" width="220" />
      </a>
    </td>
    <td colspan="2" align="center" valign="top">
      <strong>Unrecognized unit</strong><br/>
      <a href="https://github.com/user-attachments/assets/0c2ce146-00ee-4189-a627-986e2078ee74" target="_blank">
        <img src="https://github.com/user-attachments/assets/0c2ce146-00ee-4189-a627-986e2078ee74" width="220" />
      </a>
    </td>
    <td colspan="2" align="center" valign="top">
      <strong>No nutrition data</strong><br/>
      <a href="https://github.com/user-attachments/assets/02387e8a-7442-4ff0-9666-b0e459cdd081" target="_blank">
        <img src="https://github.com/user-attachments/assets/02387e8a-7442-4ff0-9666-b0e459cdd081" width="220" />
      </a>
    </td>
  </tr>

  <tr>
    <td colspan="6" align="center">
      <strong>Warning icon bug</strong>
    </td>
  </tr>
  <tr>
    <td colspan="3" align="center" valign="top">
      <strong>Before</strong><br/>
      <a href="https://github.com/user-attachments/assets/f45ce574-469a-470c-988e-df243434ff17" target="_blank">
        <img src="https://github.com/user-attachments/assets/f45ce574-469a-470c-988e-df243434ff17" width="450" />
      </a>
    </td>
    <td colspan="3" align="center" valign="top">
      <strong>After</strong><br/>
      <a href="https://github.com/user-attachments/assets/d05a3178-1e74-4434-909e-96f9b75abe2d" target="_blank">
        <img src="https://github.com/user-attachments/assets/d05a3178-1e74-4434-909e-96f9b75abe2d" width="450" />
      </a>
    </td>
  </tr>
</table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product forms now receive unit data so serving-size fields recognize unit names and symbols.
  * Pages now load and pass unit lists to forms.

* **Improvements**
  * Serving-size validation added with clearer severity-aware alerts/tooltips and refined input styling.
  * Nutrition issue reporting consolidated and more consistent.

* **Localization**
  * New localized strings for serving-size examples, placeholders, and validation messages (en/it).

* **Tests**
  * Added tests covering serving-size parsing and unit-recognition edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->