### PR TITLE
fix: move husky to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"geojson": "^0.5.0",
 		"globals": "^16.5.0",
 		"html5-qrcode": "^2.3.8",
+		"husky": "^9.1.7",
 		"iso-3166-1": "^2.1.1",
 		"iso-639-1": "^3.1.5",
 		"isomorphic-dompurify": "^3.1.0",
@@ -125,7 +126,6 @@
 	"dependencies": {
 		"@openfoodfacts/openfoodfacts-webcomponents": "^1.15.1",
 		"@sentry/sveltekit": "^10.29.0",
-		"@webcomponents/webcomponentsjs": "^2.8.0",
-		"husky": "^9.1.7"
+		"@webcomponents/webcomponentsjs": "^2.8.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
       '@webcomponents/webcomponentsjs':
         specifier: ^2.8.0
         version: 2.8.0
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
     devDependencies:
       '@crowdin/cli':
         specifier: ^4.12.0
@@ -136,6 +133,9 @@ importers:
       html5-qrcode:
         specifier: ^2.3.8
         version: 2.3.8
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       iso-3166-1:
         specifier: ^2.1.1
         version: 2.1.1


### PR DESCRIPTION
### Description

This PR moves `husky` from `dependencies` to `devDependencies` in `package.json`.

Husky is used only during development for managing Git hooks and is not required in production. Keeping it under `dependencies` causes it to be unnecessarily installed in production environments.

### Changes

* Moved `husky` from `dependencies` to `devDependencies` in `package.json`

### Motivation

This follows best practices for dependency classification in Node.js projects. It reduces unnecessary package installation in production and keeps the dependency tree clean.

### Checklist

- My code follows the code style of this project
- I have performed a self-review of my own code
- I have tested my changes locally
- This change does not break existing functionality
-No additional tests were required for this change

### Large Language Models usage disclosure

* ChatGPT (GPT-5.3) – used for PR formatting assistance
