### PR TITLE
fix: add error fallback for product loading

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -198,7 +198,7 @@
 		      {attributes}
 		      sortByScore={$personalizedSearch.classifyProductsEnabled}
 	      />
-    {:catch error}
+    {:catch}
 	      <p class="text-center text-red-500">
 		      {$_('errors.load_products')}
 	      </p>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -193,12 +193,16 @@
 				{/each}
 			</div>
 		{:then [resolvedProducts, attributes]}
-			<ProductGrid
-				products={resolvedProducts.map((state) => state.product)}
-				{attributes}
-				sortByScore={$personalizedSearch.classifyProductsEnabled}
-			/>
-		{/await}
+	      <ProductGrid
+		      products={resolvedProducts.map((state) => state.product)}
+		      {attributes}
+		      sortByScore={$personalizedSearch.classifyProductsEnabled}
+	      />
+    {:catch error}
+	      <p class="text-center text-red-500">
+		      Failed to load products. Please try again later.
+	      </p>
+    {/await}
 	</div>
 </section>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -200,7 +200,7 @@
 	      />
     {:catch error}
 	      <p class="text-center text-red-500">
-		      Failed to load products. Please try again later.
+		      {$_('errors.load_products')}
 	      </p>
     {/await}
 	</div>


### PR DESCRIPTION
### Description

Added error handling to the product loading section using a `{:catch}` block in the `#await` statement.

This ensures that users see a fallback message when product data fails to load, improving overall user experience and preventing empty or broken UI states.

### Screenshot or video

Not applicable (UI fallback for error state)

### Related issue(s) and discussion

* Fixes: N/A

---

### Checklist: Author Self-Review

* [x] I have performed a self-review of my own code (including running it).
* [x] I understand the changes I'm proposing and why they are needed.
* [x] My changes generate no new warnings or errors (linting, console).
* [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

* [ ] Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When product data fails to load, the app now shows a centered, localized error message in red instead of a blank area, preventing the product grid from rendering and giving clear feedback to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->