### PR TITLE
fix: correct Robotoff insights API endpoint

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -13,7 +13,8 @@ export * from './api/knowledgepanels';
 
 export function createRobotoffApi(fetch: typeof window.fetch) {
 	const { fetch: wrappedFetch, url } = wrapFetchWithCredentials(fetch, new URL(ROBOTOFF_URL));
-	return new Robotoff(wrappedFetch, { baseUrl: url.toString() });
+	const baseUrl = new URL('/api/v1', url).toString();
+	return new Robotoff(wrappedFetch, { baseUrl });
 }
 
 export function createKeycloakApi(fetch: typeof window.fetch, url: URL) {


### PR DESCRIPTION
### Description

The homepage now displays products from the Robotoff Insights API correctly.

### Changes include
- Updated the `createRobotoffApi` function in `api.ts` to include `/api/v1` in the base URL.
- Ensured all calls to the Robotoff SDK now use the correct endpoint.

### Screenshot
After fixing the API:

<img width="1920" height="1020" alt="Open Food Facts Explorer homepage showing products" src="https://github.com/user-attachments/assets/a3cc1c2f-d6f6-4ed9-a0d4-f5f2c09f18d7" />

### Related Issue
Fixes #1218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced API endpoint initialization for improved URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->