### PR TITLE
test: add folksonomy unit tests

### DIFF
--- a/src/lib/api/folksonomy.test.ts
+++ b/src/lib/api/folksonomy.test.ts
@@ -33,6 +33,7 @@ describe('folksonomy.ts utilities', () => {
 		vi.clearAllMocks();
 		mockGetValues.mockReset();
 		mockFetch = vi.fn();
+		mockedEnv.PUBLIC_FOLKSONOMY_API_URL = 'https://api.folksonomy.openfoodfacts.org';
 	});
 
 	describe('isConfigured', () => {

--- a/src/lib/api/folksonomy.test.ts
+++ b/src/lib/api/folksonomy.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isConfigured, createFolksonomyApi, getFolksonomyValues } from './folksonomy';
+import { Folksonomy } from '@openfoodfacts/openfoodfacts-nodejs';
+import { wrapFetchWithAuth } from '$lib/stores/auth';
+
+const { mockGetValues, mockedEnv } = vi.hoisted(() => ({
+	mockGetValues: vi.fn(),
+	mockedEnv: {
+		PUBLIC_FOLKSONOMY_API_URL: 'https://api.folksonomy.openfoodfacts.org' as string | undefined
+	}
+}));
+
+vi.mock('$env/dynamic/public', () => ({
+	env: mockedEnv
+}));
+
+vi.mock('$lib/stores/auth', () => ({
+	wrapFetchWithAuth: vi.fn((fetch) => fetch)
+}));
+
+vi.mock('@openfoodfacts/openfoodfacts-nodejs', () => {
+	return {
+		Folksonomy: vi.fn().mockImplementation(function (fetch, options) {
+			return { fetch, options, getValues: mockGetValues };
+		})
+	};
+});
+
+describe('folksonomy.ts utilities', () => {
+	let mockFetch: typeof window.fetch;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetValues.mockReset();
+		mockFetch = vi.fn();
+	});
+
+	describe('isConfigured', () => {
+		it('should return true if PUBLIC_FOLKSONOMY_API_URL is defined', () => {
+			expect(isConfigured()).toBe(true);
+		});
+
+		it('should return false if PUBLIC_FOLKSONOMY_API_URL is not defined', async () => {
+			mockedEnv.PUBLIC_FOLKSONOMY_API_URL = undefined;
+			vi.resetModules();
+
+			const { isConfigured } = await import('./folksonomy');
+
+			expect(isConfigured()).toBe(false);
+
+			// Restore for other tests
+			mockedEnv.PUBLIC_FOLKSONOMY_API_URL = 'https://api.folksonomy.openfoodfacts.org';
+		});
+	});
+
+	describe('createFolksonomyApi', () => {
+		it('should create Folksonomy instance with wrapped fetch and base URL', () => {
+			const api = createFolksonomyApi(mockFetch);
+
+			expect(wrapFetchWithAuth).toHaveBeenCalledWith(mockFetch);
+
+			const wrappedFetch = vi.mocked(wrapFetchWithAuth).mock.results[0].value;
+			expect(Folksonomy).toHaveBeenCalledWith(wrappedFetch, {
+				baseUrl: 'https://api.folksonomy.openfoodfacts.org'
+			});
+			expect(Folksonomy).toHaveBeenCalledTimes(1);
+			expect(api).toEqual({
+				fetch: wrappedFetch,
+				options: {
+					baseUrl: 'https://api.folksonomy.openfoodfacts.org'
+				},
+				getValues: mockGetValues
+			});
+		});
+	});
+
+	describe('getFolksonomyValues', () => {
+		it('should return empty array and log error when response has an error', async () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			mockGetValues.mockResolvedValueOnce({ error: 'Some error' });
+
+			const result = await getFolksonomyValues(mockFetch, 'test-key');
+
+			expect(mockGetValues).toHaveBeenCalledWith('test-key');
+			expect(result).toEqual([]);
+			expect(consoleSpy).toHaveBeenCalledWith(expect.anything());
+
+			consoleSpy.mockRestore();
+		});
+
+		it('should return data when response is successful', async () => {
+			const mockData = [{ id: '1', name: 'value1' }];
+
+			mockGetValues.mockResolvedValueOnce({ data: mockData });
+
+			const result = await getFolksonomyValues(mockFetch, 'test-key');
+
+			expect(mockGetValues).toHaveBeenCalledWith('test-key');
+			expect(result).toEqual(mockData);
+		});
+	});
+});


### PR DESCRIPTION
Description

This PR adds unit tests for the Folksonomy API utilities to improve reliability and ensure correct behavior when interacting with the Folksonomy SDK.

Changes:

Added tests for isConfigured to cover both configured and unconfigured states.
Added tests for createFolksonomyApi to verify correct initialization with wrapped fetch and base URL.
Added tests for getFolksonomyValues covering:
   Successful API response
   Error handling (returns empty array and logs error)
Mocked:
  @openfoodfacts/openfoodfacts-nodejs (Folksonomy SDK)
   $lib/stores/auth (auth wrapper)
   $env/dynamic/public (environment configuration)

Motivation:

Even though this is a thin wrapper, it contains important logic for configuration handling and error safety. These tests ensure stability and prevent silent failures when the SDK or API behavior changes.


Checklist: Author Self-Review
 ✅I have performed a self-review of my own code (including running it).
✅ I understand the changes I'm proposing and why they are needed.
✅ My changes generate no new warnings or errors (linting, console).

Large Language Models usage disclosure
ChatGPT (GPT-5.3) — used for guidance, code review, and test improvement suggestions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for folksonomy API utilities covering configuration detection, API client creation with wrapped fetch, successful value retrieval, and error handling (returns empty list and logs errors). Includes isolation setup to reset environment and mocks between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->