### PR TITLE
fix(a11y): add role and tabindex to crop resize handles

### DIFF
--- a/src/lib/ui/images/PhotoEditDialog.svelte
+++ b/src/lib/ui/images/PhotoEditDialog.svelte
@@ -561,6 +561,8 @@
 								{action}
 								class="absolute z-10 h-[10px] w-[10px] rounded-sm border border-gray-300 bg-white"
 								onpointerdown={enableCropping}
+								role="button"
+								tabindex="0"
 								aria-label="Resize crop selection"
 							></cropper-handle>
 						{/each}


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

### Screenshot or video

<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- Fixes: <!-- #1 -->

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enhanced keyboard accessibility for the photo editor's crop handles, enabling keyboard navigation and control of the cropping interface alongside mouse interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->