### PR TITLE
fix: debounce folksonomy key lookup to prevent API spam

### DIFF
--- a/src/routes/products/[barcode]/Folksonomy.svelte
+++ b/src/routes/products/[barcode]/Folksonomy.svelte
@@ -100,32 +100,37 @@
 
 	let possibleValues: { v: string; product_count: number }[] | null = $state(null);
 
-	$effect(() => {
-		// when newKey changes, fetch possible values
-		const key = newKey;
+	// Create a single debounced function that maintains state across calls
+	const debouncedFetchValues = createDebounce(100, () => {
+		if (newKey == '') {
+			possibleValues = null;
+			return;
+		}
+		console.debug('Fetching possible values for key:', newKey);
 
-		debounce(100, () => {
-			if (key == '') {
-				possibleValues = null;
-				return;
-			}
-			console.debug('Fetching possible values for key:', key);
-
-			getFolksonomyValues(fetch, key).then((values) => {
-				console.debug('Possible values for key', key, ':', values);
-				possibleValues = values;
-			});
+		getFolksonomyValues(fetch, newKey).then((values) => {
+			console.debug('Possible values for key', newKey, ':', values);
+			possibleValues = values;
 		});
 	});
 
-	function debounce(delay: number, fn: () => void) {
+	$effect(() => {
+		// when newKey changes, call the debounced fetch
+		// Reference newKey to make it a reactive dependency
+		void newKey;
+		debouncedFetchValues();
+	});
+
+	function createDebounce(delay: number, fn: () => void) {
 		let timeoutId: number | undefined;
-		(() => {
-			if (timeoutId) {
+
+		// Return a function that maintains timeoutId through closure
+		return () => {
+			if (timeoutId !== undefined) {
 				clearTimeout(timeoutId);
 			}
 			timeoutId = window.setTimeout(fn, delay);
-		})();
+		};
 	}
 
 	let isLoading: boolean = $state(false);


### PR DESCRIPTION
## Problem
Debounce in Folksonomy was broken—state didn't persist across calls, so every keystroke triggered an API call instead of deferring until typing stops.

## Solution  
Replaced IIFE implementation with closure-based debounce that:
- Maintains timeout state across invocations
- Clears previous timeout before setting new one
- Tracks reactive dependency on key changes

## Result
5 consecutive keystrokes now make 1 API call (100ms debounce) instead of 5—reduces server load and improves responsiveness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code efficiency for data fetching behavior in product details. Changes include optimized handling of debounced operations and reactive state management to enhance application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->