### PR TITLE
fix: debounce folksonomy value lookup and prevent stale updates

### DIFF
--- a/src/routes/products/[barcode]/Folksonomy.svelte
+++ b/src/routes/products/[barcode]/Folksonomy.svelte
@@ -100,32 +100,67 @@
 
 	let possibleValues: { v: string; product_count: number }[] | null = $state(null);
 
-	$effect(() => {
-		// when newKey changes, fetch possible values
-		const key = newKey;
+	type DebouncedFn = (() => void) & {
+		cancel: () => void;
+	};
 
-		debounce(100, () => {
-			if (key == '') {
-				possibleValues = null;
-				return;
-			}
-			console.debug('Fetching possible values for key:', key);
+	// Create a single debounced function that maintains state across calls
+	const debouncedFetchValues = createDebounce(100, () => {
+		if (newKey == '') {
+			possibleValues = null;
+			return;
+		}
+		const requestedKey = newKey;
+		console.debug('Fetching possible values for key:', requestedKey);
 
-			getFolksonomyValues(fetch, key).then((values) => {
-				console.debug('Possible values for key', key, ':', values);
+		getFolksonomyValues(fetch, requestedKey)
+			.then((values) => {
+				if (requestedKey !== newKey) {
+					return;
+				}
+
+				console.debug('Possible values for key', requestedKey, ':', values);
 				possibleValues = values;
+			})
+			.catch((error) => {
+				if (requestedKey !== newKey) {
+					return;
+				}
+
+				console.error('Failed to fetch possible values for key', requestedKey, error);
 			});
-		});
 	});
 
-	function debounce(delay: number, fn: () => void) {
+	$effect(() => {
+		// when newKey changes, call the debounced fetch
+		// Reference newKey to make it a reactive dependency
+		void newKey;
+		debouncedFetchValues();
+
+		return () => {
+			debouncedFetchValues.cancel();
+		};
+	});
+
+	function createDebounce(delay: number, fn: () => void): DebouncedFn {
 		let timeoutId: number | undefined;
-		(() => {
-			if (timeoutId) {
+
+		// Return a function that maintains timeoutId through closure
+		const debounced = () => {
+			if (timeoutId !== undefined) {
 				clearTimeout(timeoutId);
 			}
 			timeoutId = window.setTimeout(fn, delay);
-		})();
+		};
+
+		debounced.cancel = () => {
+			if (timeoutId !== undefined) {
+				clearTimeout(timeoutId);
+				timeoutId = undefined;
+			}
+		};
+
+		return debounced;
 	}
 
 	let isLoading: boolean = $state(false);


### PR DESCRIPTION
This PR fixes a critical bug in the Folksonomy component where the debounce mechanism was broken, causing an API call for every keystroke instead of debouncing input.

## Problem
- The debounce IIFE was not maintaining timeout state across calls
- Result: Each keystroke triggered an immediate (un-debounced) API call
- Additionally: Stale API responses could overwrite newer results
- Memory leak: debounce timer never cleared on component unmount

## Solution
1. **Fixed debounce closure**: Proper timeout persistence with cancel() method
2. **Stale response guard**: Snapshot requested key before fetch, validate on response
3. **Memory leak fix**: Added cleanup function in effect to call cancel() on unmount
4. **Error handling**: Added .catch() with same stale response guard

## Testing
- ✅ TypeScript: pnpm check passes
- ✅ Linting: pnpm lint passes  
- ✅ Build: pnpm build succeeds
- ✅ Dev server: Component tested on product detail page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal improvements to enhance application performance and reliability in the folksonomy feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->