### PR TITLE
refactor: improve skeleton list rendering clarity

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -188,9 +188,9 @@
 			<div
 				class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-2 xl:grid-cols-3"
 			>
-				 {#each Array.from({ length: SKELETON_COUNT }) as _, i (i)}
-	         <div class="skeleton h-36 w-full rounded-lg"></div>
-         {/each}
+				{#each Array.from({ length: SKELETON_COUNT }) as _, i (i)}
+	          <div class="skeleton h-36 w-full rounded-lg"></div>
+        {/each}
 			</div>
 		{:then [resolvedProducts, attributes]}
 			<ProductGrid


### PR DESCRIPTION
### Description

Refactored the skeleton list rendering by replacing the use of `Array(SKELETON_COUNT)` with `Array.from({ length: SKELETON_COUNT })`.

This improves code readability and makes the intent of generating a fixed-length list clearer, while maintaining the same behavior.

### Screenshot or video

Not applicable (internal refactor with no visual change)

### Related issue(s) and discussion

* Fixes: N/A

---

### Checklist: Author Self-Review

* [x] I have performed a self-review of my own code (including running it).
* [x] I understand the changes I'm proposing and why they are needed.
* [x] My changes generate no new warnings or errors (linting, console).
* [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

* [ ] Generic LLM v0.0.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated how loading skeletons are generated and iterated internally. This is an implementation detail only; there are no visual or behavioral changes visible to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->