### PR TITLE
refactor(settings): parallelize API calls on settings page

### DIFF
--- a/src/routes/settings/+page.ts
+++ b/src/routes/settings/+page.ts
@@ -8,14 +8,16 @@ import type { PageLoad } from './$types';
 export const ssr = false;
 
 export const load: PageLoad = async ({ fetch }) => {
-	const languages = await getTaxo<Language>('languages', fetch);
-	let countries = await getTaxo<Country>('countries', fetch);
+	const [languages, countriesRaw] = await Promise.all([
+		getTaxo<Language>('languages', fetch),
+		getTaxo<Country>('countries', fetch)
+	]);
 
 	// Not every country has a language_code_2, so we need to filter them out
 	// as they are used to store the language preference and to query the API
 	// TODO: fix the taxonomy to add missing codes
-	countries = Object.fromEntries(
-		Object.entries(countries).filter(([, country]) => country.country_code_2 != null)
+	const countries = Object.fromEntries(
+		Object.entries(countriesRaw).filter(([, country]) => country.country_code_2 != null)
 	);
 
 	const off = createProductsApi(fetch);


### PR DESCRIPTION
###Description
This PR improves the loading performance of the settings page (src/routes/settings/+page.ts) by parallelizing taxonomy API calls.

Previously, the getTaxo calls for languages and countries were executed sequentially, increasing the total data fetching time. This change updates the implementation to use Promise.all, allowing both requests to run concurrently and reducing overall page load latency.

###Changes
-Refactored taxonomy fetching to use Promise.all
-Reduced sequential network calls
-Improved initial page load performance

Checklist: Author Self-Review
 ✅I have performed a self-review of my own code (including running it).
✅ I understand the changes I'm proposing and why they are needed.
 ✅My changes generate no new warnings or errors (linting, console).
 ✅I have made corresponding changes to the documentation (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Settings page now loads with improved efficiency.

* **Bug Fixes**
  * Resolved issue where invalid country entries appeared in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->