### PR TITLE
🎨 Palette: Add aria-label and title to reset zoom button in ImageModal

### DIFF
--- a/src/lib/ui/ImageModal.svelte
+++ b/src/lib/ui/ImageModal.svelte
@@ -99,8 +99,10 @@
 			<button
 				class="btn bg-base-100/80 hover:bg-base-100 text-md text-base-content px-2 py-2 font-medium"
 				onclick={resetZoom}
-				title="Reset Zoom"
-				aria-label="Reset Zoom"
+				title={$_('product.edit.images.reset', { default: 'Reset' })}
+				aria-label="{$_('product.edit.images.reset', { default: 'Reset' })}, {zoomLevel.toFixed(
+					1
+				)} x"
 			>
 				{zoomLevel.toFixed(1)} x
 			</button>

--- a/src/lib/ui/ImageModal.svelte
+++ b/src/lib/ui/ImageModal.svelte
@@ -99,6 +99,8 @@
 			<button
 				class="btn bg-base-100/80 hover:bg-base-100 text-md text-base-content px-2 py-2 font-medium"
 				onclick={resetZoom}
+				title="Reset Zoom"
+				aria-label="Reset Zoom"
 			>
 				{zoomLevel.toFixed(1)} x
 			</button>


### PR DESCRIPTION
**💡 What**: Added `title="Reset Zoom"` and `aria-label="Reset Zoom"` to the reset zoom button within the `ImageModal.svelte` component.
**🎯 Why**: The reset zoom button displays the current zoom level as its text content (e.g., `1.5 x`), but its `onclick` action is `resetZoom`. Without an explicit `aria-label`, a screen reader would announce something like "1.5 x, button", which is not descriptive of the button's action. Additionally, adding a `title` provides a helpful tooltip for mouse users, improving overall usability and meeting accessibility standards.
**♿ Accessibility**: Improved screen reader context for the reset zoom button in the image modal.

---
*PR created automatically by Jules for task [10695175482138155254](https://jules.google.com/task/10695175482138155254) started by @VaiTon*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility for image controls by adding screen reader labels and descriptive tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->