### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in CountriesMap tooltip

### DIFF
--- a/src/routes/facets/[facet]/CountriesMap.svelte
+++ b/src/routes/facets/[facet]/CountriesMap.svelte
@@ -260,7 +260,7 @@
 				// Tooltip shown on hover for every country
 				const tooltipContent = data
 					? `<strong>${DOMPurify.sanitize(data.name)}</strong><br>${numberFormat.format(data.products)} products`
-					: (feature.properties?.name ?? numericId);
+					: DOMPurify.sanitize(feature.properties?.name ?? numericId);
 
 				pathLayer.bindTooltip(tooltipContent, { sticky: true });
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Un-sanitized string `feature.properties?.name` (which could contain malicious HTML via GeoJSON properties) was being directly bound to a Leaflet tooltip `pathLayer.bindTooltip` in `src/routes/facets/[facet]/CountriesMap.svelte`.
🎯 **Impact:** XSS execution. An attacker who controls the GeoJSON properties or taxonomy names could execute arbitrary JavaScript when a user hovers over a country segment on the map.
🔧 **Fix:** Sanitized the dynamic value by passing it to `DOMPurify.sanitize()` prior to displaying it on the tooltip. Note: `DOMPurify` was already being used for another string right above this.
✅ **Verification:** Ran tests (`pnpm test`) and linters (`pnpm lint`), no regressions introduced. Code reviewed.

---
*PR created automatically by Jules for task [14613653712867490196](https://jules.google.com/task/14613653712867490196) started by @VaiTon*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sanitization of text displayed in countries map tooltips to ensure proper text processing before rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->