### PR TITLE
🛡️ Sentinel: Update security recommendation in UX_GUIDE

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Incorrect Regex Parsing for Svelte
+**Vulnerability:** N/A (Tooling Issue)
+**Learning:** Svelte files and standard HTML parsing using regular expressions can be deceiving. Our custom python script attempting to find `<a target="_blank">` tags failed because Svelte syntax can span multiple lines natively, and simple regex heuristics failed to accurately map the `rel="noopener noreferrer"` present on subsequent lines.
+**Prevention:** Rely on robust HTML/Svelte parsers or AST tools instead of quick regex searches when refactoring security-critical components in Svelte files to prevent accidental data duplication and false positives.

--- a/UX_GUIDE.md
+++ b/UX_GUIDE.md
@@ -201,7 +201,7 @@ We aim to make Open Food Facts accessible to everyone. Before submitting a PR, r
   - `<a>` for navigation (changing the URL, linking to external pages).
 - **Dynamic notifications** (Toasts) use `role="alert"` and `aria-live="polite"`.
 - **Interactive elements** are keyboard-accessible (focusable and operable via `Enter`/`Space`).
-- **External links** use `target="_blank"` with `rel="noopener"` for security.
+- **External links** use `target="_blank"` with `rel="noopener noreferrer"` for security.
 
 ### Good Examples from the Codebase
 

--- a/UX_GUIDE.md
+++ b/UX_GUIDE.md
@@ -207,7 +207,7 @@ We aim to make Open Food Facts accessible to everyone. Before submitting a PR, r
 
 ```svelte
 <!-- Footer: social link with aria-label -->
-<a href="https://github.com/openfoodfacts" target="_blank" aria-label="GitHub">
+<a href="https://github.com/openfoodfacts" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
 	<IconMdiGithub class="h-6 w-6" />
 </a>
 


### PR DESCRIPTION
🛡️ Sentinel: Security enhancement

🚨 Severity: ENHANCEMENT
💡 Vulnerability: The `UX_GUIDE.md` only specified using `rel="noopener"`. For broad coverage of older browser reverse-tabnabbing vulnerabilities, it should recommend `rel="noopener noreferrer"`. The actual codebase's elements already correctly include both.
🎯 Impact: Helps enforce better development practices by explicitly suggesting the full `noopener noreferrer` pair.
🔧 Fix: Updated the guide document.
✅ Verification: Ran `pnpm lint` and `pnpm test` successfully.

---
*PR created automatically by Jules for task [7349117660592257554](https://jules.google.com/task/7349117660592257554) started by @VaiTon*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated external-link accessibility/security guidance: require rel="noopener noreferrer" when using target="_blank", and updated example anchor tags accordingly.
  * Added a dated documentation note describing a regex-based parsing issue with framework-specific multiline templates, documenting the parsing failure, lessons learned, and prevention guidance for future tooling and reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->