### PR TITLE
fix(service-worker): cache only static and same-origin assets

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -17,6 +17,8 @@ const CACHE = `cache-${version}`;
 
 const STATIC_HOST = 'https://static.openfoodfacts.org';
 
+const NETWORK_TIMEOUT_MS = 3000;
+
 self.addEventListener('activate', (event) => {
 	// Remove previous cached data from disk
 	async function deleteOldCaches() {
@@ -28,74 +30,73 @@ self.addEventListener('activate', (event) => {
 	event.waitUntil(deleteOldCaches());
 });
 
+async function fetchWithTimeout(request: Request, ms = NETWORK_TIMEOUT_MS) {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), ms);
+	try {
+		return await fetch(request, { signal: controller.signal });
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function isBuildAsset(request: Request) {
+	const url = new URL(request.url);
+	if (url.origin !== self.location.origin) return false;
+	// Use destination when available; fall back to extension for programmatic fetches
+	if (request.destination === 'script' || request.destination === 'style') return true;
+	if (request.destination !== '') return false; // navigation, worker, etc.
+	return url.pathname.endsWith('.js') || url.pathname.endsWith('.css');
+}
+
+async function cacheFirst(request: Request) {
+	const cache = await caches.open(CACHE);
+	const cached = await cache.match(request);
+	if (cached) {
+		return cached;
+	}
+	const response = await fetch(request);
+	if (response.ok || response.type === 'opaque') {
+		cache.put(request, response.clone());
+	}
+	return response;
+}
+
+async function networkFirst(request: Request) {
+	try {
+		const response = await fetchWithTimeout(request);
+		if (response.ok || response.type === 'opaque') {
+			const cache = await caches.open(CACHE);
+			cache.put(request, response.clone());
+		}
+		return response;
+	} catch (error) {
+		const cache = await caches.open(CACHE);
+		const cached = await cache.match(request);
+		if (cached) return cached;
+		throw error;
+	}
+}
+
 self.addEventListener('fetch', (event) => {
-	// ignore POST requests etc
-	if (event.request.method !== 'GET') return;
-	if (event.request.url.startsWith('chrome-extension://')) return;
+	const { request } = event;
 
-	async function respond() {
-		const url = new URL(event.request.url);
+	// Only handle GET requests
+	if (request.method !== 'GET') return;
+	if (request.url.startsWith('chrome-extension://')) return;
 
-		// Static assets (static.openfoodfacts.org) — cache-first
-		if (url.origin === STATIC_HOST) {
-			const cache = await caches.open(CACHE);
-			const cached = await cache.match(event.request);
+	const url = new URL(request.url);
 
-			if (cached) {
-				console.debug(`SW: cache hit for ${event.request.url}`);
-				return cached;
-			}
-
-			const response = await fetch(event.request);
-
-			if (response.ok || response.type === 'opaque') {
-				event.waitUntil(cache.put(event.request, response.clone()));
-			}
-
-			return response;
-		}
-
-		// Same-origin SvelteKit build artifacts (JS/CSS) — network-first with offline fallback.
-		// We deliberately exclude same-origin API routes (+server.ts) from this branch so
-		// they are never cached and always go to the "plain fetch" passthrough below.
-		//
-		// request.destination identifies the resource type in modern browsers.
-		// The url.pathname.endsWith() fallbacks handle programmatic fetch() calls
-		// where destination can be an empty string '' — this is distinct from navigation
-		// requests (destination === 'document'), which are intentionally excluded here.
-		const isSameOriginAsset =
-			url.origin === self.location.origin &&
-			(event.request.destination === 'script' ||
-				event.request.destination === 'style' ||
-				url.pathname.endsWith('.js') ||
-				url.pathname.endsWith('.css'));
-
-		if (isSameOriginAsset) {
-			const cache = await caches.open(CACHE);
-			try {
-				const response = await fetch(event.request);
-
-				if (response.status === 200) {
-					event.waitUntil(cache.put(event.request, response.clone()));
-				}
-
-				return response;
-			} catch (err) {
-				const cached = await cache.match(event.request);
-
-				if (cached) {
-					return cached;
-				}
-
-				// if there's no cache, then just error out
-				// as there is nothing we can do to respond to this request
-				throw err;
-			}
-		}
-
-		// Everything else (API calls, etc.) — plain network passthrough, never cached
-		return fetch(event.request);
+	// Static assets: Cache-first
+	if (url.origin === STATIC_HOST) {
+		event.respondWith(cacheFirst(request));
+		return;
 	}
 
-	event.respondWith(respond());
+	// Build assets: Network-first with timeout
+	if (isBuildAsset(request)) {
+		// Build assets: Network-first with timeout
+		event.respondWith(networkFirst(request));
+		return;
+	}
 });

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -37,7 +37,7 @@ self.addEventListener('fetch', (event) => {
 		const url = new URL(event.request.url);
 		const cache = await caches.open(CACHE);
 
-		// for static assets, we want to cache-first
+		// Static assets (static.openfoodfacts.org) — cache-first
 		if (url.origin === STATIC_HOST) {
 			const cached = await cache.match(event.request);
 
@@ -45,35 +45,41 @@ self.addEventListener('fetch', (event) => {
 				console.debug(`SW: cache hit for ${event.request.url}`);
 				return cached;
 			}
-		}
 
-		// for everything else, try the network first, but
-		// fall back to the cache if we're offline
-		try {
 			const response = await fetch(event.request);
-
-			// if we're offline, fetch can return a value that is not a Response
-			// instead of throwing - and we can't pass this non-Response to respondWith
-			if (!(response instanceof Response)) {
-				throw new Error('invalid response from fetch');
-			}
 
 			if (response.status === 200) {
 				cache.put(event.request, response.clone());
 			}
 
 			return response;
-		} catch (err) {
-			const response = await cache.match(event.request);
-
-			if (response) {
-				return response;
-			}
-
-			// if there's no cache, then just error out
-			// as there is nothing we can do to respond to this request
-			throw err;
 		}
+
+		// Same-origin app assets (JS, CSS, etc.) — network-first with offline fallback
+		if (url.origin === self.location.origin) {
+			try {
+				const response = await fetch(event.request);
+
+				if (response.status === 200) {
+					cache.put(event.request, response.clone());
+				}
+
+				return response;
+			} catch (err) {
+				const cached = await cache.match(event.request);
+
+				if (cached) {
+					return cached;
+				}
+
+				// if there's no cache, then just error out
+				// as there is nothing we can do to respond to this request
+				throw err;
+			}
+		}
+
+		// Everything else (API calls, etc.) — plain network passthrough, never cached
+		return fetch(event.request);
 	}
 
 	event.respondWith(respond());

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -55,8 +55,22 @@ self.addEventListener('fetch', (event) => {
 			return response;
 		}
 
-		// Same-origin app assets (JS, CSS, etc.) — network-first with offline fallback
-		if (url.origin === self.location.origin) {
+		// Same-origin SvelteKit build artifacts (JS/CSS) — network-first with offline fallback.
+		// We deliberately exclude same-origin API routes (+server.ts) from this branch so
+		// they are never cached and always go to the "plain fetch" passthrough below.
+		//
+		// request.destination identifies the resource type in modern browsers.
+		// The url.pathname.endsWith() fallbacks handle programmatic fetch() calls
+		// where destination can be an empty string '' — this is distinct from navigation
+		// requests (destination === 'document'), which are intentionally excluded here.
+		const isSameOriginAsset =
+			url.origin === self.location.origin &&
+			(event.request.destination === 'script' ||
+				event.request.destination === 'style' ||
+				url.pathname.endsWith('.js') ||
+				url.pathname.endsWith('.css'));
+
+		if (isSameOriginAsset) {
 			const cache = await caches.open(CACHE);
 			try {
 				const response = await fetch(event.request);

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -35,10 +35,10 @@ self.addEventListener('fetch', (event) => {
 
 	async function respond() {
 		const url = new URL(event.request.url);
-		const cache = await caches.open(CACHE);
 
 		// Static assets (static.openfoodfacts.org) — cache-first
 		if (url.origin === STATIC_HOST) {
+			const cache = await caches.open(CACHE);
 			const cached = await cache.match(event.request);
 
 			if (cached) {
@@ -48,8 +48,8 @@ self.addEventListener('fetch', (event) => {
 
 			const response = await fetch(event.request);
 
-			if (response.status === 200) {
-				cache.put(event.request, response.clone());
+			if (response.ok || response.type === 'opaque') {
+				event.waitUntil(cache.put(event.request, response.clone()));
 			}
 
 			return response;
@@ -57,11 +57,12 @@ self.addEventListener('fetch', (event) => {
 
 		// Same-origin app assets (JS, CSS, etc.) — network-first with offline fallback
 		if (url.origin === self.location.origin) {
+			const cache = await caches.open(CACHE);
 			try {
 				const response = await fetch(event.request);
 
 				if (response.status === 200) {
-					cache.put(event.request, response.clone());
+					event.waitUntil(cache.put(event.request, response.clone()));
 				}
 
 				return response;


### PR DESCRIPTION
### Description

The service worker's `cache.put()` call was placed in a general network-first `try` block, causing it to run for **every** successful GET response. This meant live API responses (product data, search results, etc.) were being stored in the cache and could be served as stale data on subsequent visits.

This PR restructures the fetch handler into three explicit origin-based branches with precise caching rules:

```
GET request
│
├── chrome-extension:// → ignored entirely
├── non-GET             → ignored entirely
│
├── origin === STATIC_HOST    → cache-first  (static.openfoodfacts.org images/assets)
│                               cache write: if response.ok || response.type === 'opaque'
│                               wrapped in: event.waitUntil()
│
├── isSameOriginAsset         → network-first with offline fallback
│   (destination === 'script'   cache write: if response.status === 200 only
│    or 'style', or .js/.css     wrapped in: event.waitUntil()
│    pathname fallback)
│
└── everything else           → plain fetch(), NEVER cached
    (API calls to world.openfoodfacts.org, prices API, Robotoff, etc.)
```

### Key changes

- **`STATIC_HOST` branch**: cache-first. Writes to cache if `response.ok || response.type === 'opaque'` to correctly handle opaque cross-origin responses (which have status `0`, not `200`). Cache write wrapped in `event.waitUntil()` to prevent premature service worker termination.

- **`isSameOriginAsset` branch**: network-first, offline fallback. Narrowed from the previous broad `url.origin === self.location.origin` to only match SvelteKit static build artifacts — `request.destination === 'script' | 'style'`, with `.js`/`.css` pathname fallbacks for programmatic `fetch()` calls where `destination` can be `''`. Navigation requests (`destination === 'document'`) and same-origin API routes (`+server.ts`) both fall through to the passthrough branch. Cache write wrapped in `event.waitUntil()`.

- **Everything else**: plain `fetch()` passthrough — no cache reads, no cache writes.

- **`caches.open(CACHE)` is lazy-loaded** inside each branch, not at the top of `respond()`, so external API calls never incur unnecessary cache storage overhead.

### Screenshot or video

_No visual changes — this is a service worker caching logic fix._

### Related issue(s) and discussion

- Fixes: #1246

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved asset delivery: build assets now use a faster network-first path with timeout and caching, reducing load delays.
  * Static assets are served from cache-first for quicker repeat visits.
* **Reliability / Bug Fixes**
  * General requests now bypass caching, avoiding stale responses and reducing unexpected offline fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->