### PR TITLE
fix(search): guard against undefined env var and null autocomplete response

### DIFF
--- a/src/lib/api/search.test.ts
+++ b/src/lib/api/search.test.ts
@@ -27,6 +27,16 @@ describe('getSearchBaseUrl', () => {
 		);
 	});
 
+	it('should throw error if PUBLIC_SEARCH_BASE_URL is whitespace-only', async () => {
+		mockEnv.PUBLIC_SEARCH_BASE_URL = '   ';
+
+		const { getSearchBaseUrl } = await import('./search');
+
+		expect(() => getSearchBaseUrl()).toThrow(
+			'PUBLIC_SEARCH_BASE_URL is not set. Please set it in your environment variables.'
+		);
+	});
+
 	it('should return base URL if PUBLIC_SEARCH_BASE_URL is set', async () => {
 		mockEnv.PUBLIC_SEARCH_BASE_URL = 'https://example.com';
 

--- a/src/lib/api/search.ts
+++ b/src/lib/api/search.ts
@@ -13,7 +13,7 @@ import { env } from '$env/dynamic/public';
  * @returns The search API base URL string.
  */
 export function getSearchBaseUrl() {
-	if (env.PUBLIC_SEARCH_BASE_URL == null || env.PUBLIC_SEARCH_BASE_URL == '') {
+	if (env.PUBLIC_SEARCH_BASE_URL == null || env.PUBLIC_SEARCH_BASE_URL.trim() === '') {
 		throw new Error(
 			'PUBLIC_SEARCH_BASE_URL is not set. Please set it in your environment variables.'
 		);

--- a/src/lib/api/search.ts
+++ b/src/lib/api/search.ts
@@ -7,8 +7,13 @@ import type { ProductReduced } from './product';
 import { wrapFetchWithCredentials } from './utils';
 import { env } from '$env/dynamic/public';
 
+/**
+ * Returns the base URL for the search API from the PUBLIC_SEARCH_BASE_URL env variable.
+ * @throws {Error} If PUBLIC_SEARCH_BASE_URL is not set or empty.
+ * @returns The search API base URL string.
+ */
 export function getSearchBaseUrl() {
-	if (env.PUBLIC_SEARCH_BASE_URL == '') {
+	if (env.PUBLIC_SEARCH_BASE_URL == null || env.PUBLIC_SEARCH_BASE_URL == '') {
 		throw new Error(
 			'PUBLIC_SEARCH_BASE_URL is not set. Please set it in your environment variables.'
 		);
@@ -22,13 +27,27 @@ export function createSearchApi(fetch: typeof window.fetch): SearchApi {
 	return new SearchApi(wrappedFetch, { baseUrl: url.toString() });
 }
 
+/**
+ * Fetches autocomplete suggestions for a given query from the search API.
+ * @param query - The autocomplete query parameters.
+ * @param fetch - The fetch function to use for the request.
+ * @returns A `{ data, error }` object — `data` contains the AutocompleteResponse on success, `error` contains a message string on failure.
+ */
 export const autocomplete = async (
 	query: AutocompleteQuery,
 	fetch: typeof window.fetch
-): Promise<AutocompleteResponse> => {
-	const api = createSearchApi(fetch);
-	const response = await api.autocomplete(query);
-	return response.data as AutocompleteResponse;
+): Promise<{ data?: AutocompleteResponse; error?: string }> => {
+	try {
+		const api = createSearchApi(fetch);
+		const response = await api.autocomplete(query);
+		if (response.data) {
+			return { data: response.data as AutocompleteResponse };
+		}
+		return { error: 'No data returned from autocomplete API' };
+	} catch (e: unknown) {
+		const message = e instanceof Error ? e.message : String(e);
+		return { error: message };
+	}
 };
 
 export type AutocompleteOption = {

--- a/src/lib/ui/SearchBar.svelte
+++ b/src/lib/ui/SearchBar.svelte
@@ -51,9 +51,13 @@
 
 		try {
 			autocompleteLoading = true;
-			const response = await autocomplete(autocompleteQuery, fetch);
-			if (response && Array.isArray(response.options)) {
-				autocompleteList = response.options;
+			const { data, error } = await autocomplete(autocompleteQuery, fetch);
+
+			if (error) {
+				console.error('Autocomplete API error:', error);
+				autocompleteList = [];
+			} else if (data && Array.isArray(data.options)) {
+				autocompleteList = data.options;
 			} else {
 				autocompleteList = [];
 			}


### PR DESCRIPTION
### Description

Two related null-safety improvements in `src/lib/api/search.ts`.

**Bug 1 — `getSearchBaseUrl()` doesn't guard against `undefined`**

SvelteKit types `env.PUBLIC_SEARCH_BASE_URL` as `string | undefined`. The previous guard only caught the `''` case. If the env var is missing from `.env`, the function returns `undefined`, and the immediate caller (`createSearchApi`) does `new URL(undefined)` — throwing a cryptic `TypeError` instead of the clear error message already written in the `throw`.

```diff
-    if (env.PUBLIC_SEARCH_BASE_URL == '') {
+    if (env.PUBLIC_SEARCH_BASE_URL == null || env.PUBLIC_SEARCH_BASE_URL == '') {
```

**Bug 2 — `autocomplete()` casts `undefined` to `AutocompleteResponse`**

When the search API returns an error or non-200, `response.data` is `undefined`. The previous `as AutocompleteResponse` cast silenced TypeScript, but any caller doing `.options.map(...)` would crash with `TypeError: Cannot read properties of undefined`.

Per maintainer feedback, the fix is to return the same `{ data, error }` object shape used by other API calls in this codebase, keeping the data layer honest and leaving UI fallback decisions to the caller.

```diff
- ): Promise<AutocompleteResponse> => {
-     const api = createSearchApi(fetch);
-     const response = await api.autocomplete(query);
-     return response.data as AutocompleteResponse;
+ ): Promise<{ data?: AutocompleteResponse; error?: string }> => {
+     try {
+         const api = createSearchApi(fetch);
+         const response = await api.autocomplete(query);
+         if (response.data) return { data: response.data as AutocompleteResponse };
+         return { error: 'No data returned from autocomplete API' };
+     } catch (e: unknown) {
+         const message = e instanceof Error ? e.message : String(e);
+         return { error: message };
+     }
```

`SearchBar.svelte` was updated to unpack `{ data, error }` and handle the error path explicitly.

### Screenshot or video

_No visual changes — both are logic/type-safety fixes._

### Related issue(s) and discussion

- Fixes: #1248

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have addressed maintainer feedback regarding architectural concerns.

## Large Language Models usage disclosure

- [ ]  Generic LLM v0.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Autocomplete errors and exceptions are now surfaced and result in empty suggestion lists instead of breaking the UI.
  * Added safe handling when autocomplete returns no data so suggestions gracefully show as empty.
  * Strengthened search base URL validation to catch missing or whitespace-only values earlier.

* **Tests**
  * Added a unit test to ensure whitespace-only search base URLs are treated as not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->