### PR TITLE
fix: add aria-label to nutrition calculator clear button

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -506,6 +506,10 @@
 		"learn_more": "Learn More",
 		"learn_more_desc": "Find out how Open Food Facts works and how you can help."
 	},
+	"calculator": {
+		"clear_all": "Clear All",
+		"clear_all_aria": "Clear all items from calculator"
+	},
 	"compare": {
 		"page_title": "Compare Products",
 		"page_description": "Compare nutritional information of food products",

--- a/src/lib/ui/NutritionCalculator.svelte
+++ b/src/lib/ui/NutritionCalculator.svelte
@@ -8,7 +8,6 @@
 		toggleCalculator,
 		totalNutrition
 	} from '$lib/stores/calculatorStore';
-	import { _ as t } from '$lib/i18n';
 	import { onMount } from 'svelte';
 	import { _ } from 'svelte-i18n';
 
@@ -123,11 +122,11 @@
 				<button
 					class="btn btn-sm btn-error"
 					onclick={clearCalculator}
-					aria-label={$t('calculator.clear_all_aria', {
+					aria-label={$_('calculator.clear_all_aria', {
 						default: 'Clear all items from calculator'
 					})}
 				>
-					{$t('calculator.clear_all', { default: 'Clear All' })}
+					{$_('calculator.clear_all', { default: 'Clear All' })}
 				</button>
 			</div>
 		{/if}

--- a/src/lib/ui/NutritionCalculator.svelte
+++ b/src/lib/ui/NutritionCalculator.svelte
@@ -8,6 +8,7 @@
 		toggleCalculator,
 		totalNutrition
 	} from '$lib/stores/calculatorStore';
+	import { _ as t } from '$lib/i18n';
 	import { onMount } from 'svelte';
 	import { _ } from 'svelte-i18n';
 
@@ -122,11 +123,11 @@
 				<button
 					class="btn btn-sm btn-error"
 					onclick={clearCalculator}
-					aria-label={$_('calculator.clear_all_aria', {
+					aria-label={$t('calculator.clear_all_aria', {
 						default: 'Clear all items from calculator'
 					})}
 				>
-					{$_('calculator.clear_all', { default: 'Clear All' })}
+					{$t('calculator.clear_all', { default: 'Clear All' })}
 				</button>
 			</div>
 		{/if}


### PR DESCRIPTION
### Description

This PR is a clean replacement for #1100 with minimal, focused scope.

It improves accessibility for the Nutrition Calculator clear button by:
- adding a translatable aria-label to the clear button
- making the clear button text translatable
- adding the required source keys in en-US only:
  - calculator.clear_all
  - calculator.clear_all_aria

It also keeps compatibility with the current codebase by using an aliased i18n helper in the component, avoiding merge-time symbol collisions.

### Screenshot or video

N/A (text/accessibility change only; no visual layout change).

### Related issue(s) and discussion

- Fixes: #1098

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).