### PR TITLE
docs: clarify setup instructions for Corepack / pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,46 +42,23 @@ The Open Food Facts community uses Slack for communication. You can join the `#o
 
 ## Developing
 
-This project uses **pnpm**.
+This project uses pnpm. If you have corepack enabled, you should be able to directly use `pnpm` commands. Otherwise, you can install pnpm with `npm install -g pnpm`.
 
-### Prerequisites
-
-Make sure you have **Corepack enabled** so that `pnpm` is available in all environments (including dependency build steps):
-
-```bash
-corepack enable
-```
-
-> [!IMPORTANT]
-> Some dependencies are fetched directly from Git repositories and require `pnpm` during their build (`prepare`) phase.
-> If `pnpm` is not globally available, installation may fail.
-
----
-
-Install dependencies:
+First, install dependencies:
 
 ```bash
 pnpm install
 ```
 
-If you encounter issues during installation, ensure that:
-
-- `corepack enable` has been run
-- your Node.js version supports Corepack (>=16.10)
-
----
-
-Set up environment variables:
+Before running the project, set up the environment variables:
 
 ```bash
 cp .env.example .env
 ```
 
-Edit the `.env` file as needed.
+Edit the `.env` file as needed to configure your development environment.
 
----
-
-Start the development server:
+Then start the development server:
 
 ```bash
 pnpm run dev

--- a/README.md
+++ b/README.md
@@ -42,23 +42,46 @@ The Open Food Facts community uses Slack for communication. You can join the `#o
 
 ## Developing
 
-This project uses pnpm. If you have corepack enabled, you should be able to directly use `pnpm` commands. Otherwise, you can install pnpm with `npm install -g pnpm`.
+This project uses **pnpm**.
 
-First, install dependencies:
+### Prerequisites
+
+Make sure you have **Corepack enabled** so that `pnpm` is available in all environments (including dependency build steps):
+
+```bash
+corepack enable
+```
+
+> [!IMPORTANT]
+> Some dependencies are fetched directly from Git repositories and require `pnpm` during their build (`prepare`) phase.
+> If `pnpm` is not globally available, installation may fail.
+
+---
+
+Install dependencies:
 
 ```bash
 pnpm install
 ```
 
-Before running the project, set up the environment variables:
+If you encounter issues during installation, ensure that:
+
+- `corepack enable` has been run
+- your Node.js version supports Corepack (>=16.10)
+
+---
+
+Set up environment variables:
 
 ```bash
 cp .env.example .env
 ```
 
-Edit the `.env` file as needed to configure your development environment.
+Edit the `.env` file as needed.
 
-Then start the development server:
+---
+
+Start the development server:
 
 ```bash
 pnpm run dev

--- a/README.md
+++ b/README.md
@@ -42,15 +42,42 @@ The Open Food Facts community uses Slack for communication. You can join the `#o
 
 ## Developing
 
-This project uses pnpm. If you have corepack enabled, you should be able to directly use `pnpm` commands. Otherwise, you can install pnpm with `npm install -g pnpm`.
+This project uses **pnpm** as the package manager.
 
-First, install dependencies:
+### Prerequisites
+
+Ensure `pnpm` is globally available before installing dependencies. You have two options to set this up:
+
+**Option 1: Corepack (Recommended)**
+
+```bash
+corepack enable
+```
+
+Corepack is currently bundled with Node.js ≥16.10. It automatically reads the `"packageManager"` field in `package.json` to download the exact version of `pnpm` required, preventing lockfile conflicts.
+
+**Option 2: Global installation**
+
+If you prefer not to use Corepack, you can install `pnpm` globally via npm:
+
+```bash
+npm install -g pnpm
+```
+
+_(Note: If using this method, please ensure your installed version matches the one specified in our `package.json`, i.e. 10.24.0, to avoid unintended modifications to `pnpm-lock.yaml`)_.
+
+> [!IMPORTANT]
+> **Why global availability matters:** We use dependencies fetched directly from Git repositories (e.g., `@sinnwerkstatt/sveltekit-matomo`). The package manager must compile them during their `prepare` phase. If `pnpm` is not globally accessible on your PATH, the installation will fail with `ERR_PNPM_PREPARE_PACKAGE`.
+
+---
+
+### Installation
 
 ```bash
 pnpm install
 ```
 
-Before running the project, set up the environment variables:
+### Environment Setup
 
 ```bash
 cp .env.example .env
@@ -58,7 +85,9 @@ cp .env.example .env
 
 Edit the `.env` file as needed to configure your development environment.
 
-Then start the development server:
+---
+
+### Development Server
 
 ```bash
 pnpm run dev


### PR DESCRIPTION
### Summary

This PR improves the onboarding experience by clarifying a common source of setup failures: the requirement for `pnpm` to be globally accessible on the PATH during the installation of Git-fetched dependencies.

---

### Context

While observing discussions in Slack, multiple contributors reported issues during local setup (e.g., dependency install failures, unresolved modules such as `@sinnwerkstatt/sveltekit-matomo`, and `ERR_PNPM_PREPARE_PACKAGE` errors).

It showed that:
- The project fetches certain dependencies directly from Git repositories.
- These dependencies require a global `pnpm` installation during their `prepare` build phase.
- If contributors lack a global `pnpm` setup (either via `corepack enable` or `npm install -g pnpm`), the installation fails silently or throws confusing resolution errors.

---

### Changes

- Added an `[!IMPORTANT]` warning block in the **Developing** section of the README.
- Clarified that `pnpm` must be globally available on the PATH to successfully execute the build scripts of Git-referenced dependencies.
- Kept the original, flexible installation instructions (Corepack or npm global install) intact.

---

### Impact

- Reduces friction for new contributors.
- Prevents recurring `prepare` phase setup issues.
- Provides immediate troubleshooting context for failing Git dependencies.
- Reduces repeated support questions in Slack.

---

### Scope

This is a **documentation-only change** (non-invasive, no runtime impact).

---

### Related issue

Closes #1261 

---

### Notes

*This PR was updated to accurately reflect that any global installation of pnpm resolves the issue, rather than enforcing Corepack as a strict prerequisite.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote development setup to add a Prerequisites section and recommend enabling Corepack (with an optional fallback global installer).
  * Added an IMPORTANT note: global package manager availability is required for building Git-sourced dependencies (prepare step may fail otherwise).
  * Reorganized setup into Installation, Environment Setup, and Development Server; clarified .env editing and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->