### PR TITLE
refactor(BarcodeInfo): replace status codes with promises and #await blocks

### DIFF
--- a/src/lib/ui/BarcodeInfo.svelte
+++ b/src/lib/ui/BarcodeInfo.svelte
@@ -1,101 +1,146 @@
 <script lang="ts">
 	import JsBarcode from 'jsbarcode';
-	import Card from './Card.svelte';
+	import OpenFoodFacts from '@openfoodfacts/openfoodfacts-nodejs';
+
 	import { createPricesApi } from '$lib/api/prices';
+
+	import Card from './Card.svelte';
 
 	let { code }: { code: string } = $props();
 
-	let openPricesPromise = $derived(
-		createPricesApi(fetch)
-			.getPrices({ product_code: code, size: 1 })
-			.then((r) => {
-				if (!(r.data && r.data.items && r.data.items.length > 0)) {
-					throw new Error('Not found');
-				}
-			})
-	);
+	const SEARCH_ENTRIES = [
+		{
+			name: 'Google',
+			url: (code: string) => `https://www.google.com/search?q=${code}`
+		},
+		{
+			name: 'DuckDuckGo',
+			url: (code: string) => `https://duckduckgo.com/?q=${code}`
+		}
+	];
 
-	let proOffPromise = $derived(
-		fetch(`https://pro.openfoodfacts.dev/products/${code}`).then((r) => {
-			if (!r.ok) throw new Error('Not found');
-		})
-	);
+	const OFF_ENTRIES = [
+		{
+			name: 'Open Prices',
+			url: (code: string) => `https://prices.openfoodfacts.org/product/${code}`,
+			fetchData: async (code: string) => {
+				const api = createPricesApi(fetch);
+
+				const { data, error } = await api.getPrices({ product_code: code, size: 1 });
+				if (error) throw new Error('API error: ' + error);
+				else if (!data) throw new Error('No data received');
+				else if (data.items.length === 0) throw new Error('Not found');
+
+				return data;
+			}
+		},
+		{
+			name: 'Pro OFF',
+			url: (code: string) => `https://pro.openfoodfacts.dev/products/${code}`,
+			fetchData: async (code: string) => {
+				const proClient = new OpenFoodFacts(fetch, {
+					host: 'https://pro.openfoodfacts.org'
+				});
+
+				const { data, error } = await proClient.getProductV3(code);
+				if (error) throw new Error('API error: ' + error);
+				else if (!data) throw new Error('No data received');
+				else if (data.status == 'failure') throw new Error('Not found');
+
+				return data;
+			}
+		}
+	];
+
+	let barcodeElement: SVGSVGElement;
 
 	$effect(() => {
-		JsBarcode('#barcode', code, { format: 'ean13' });
+		if (!code || code.length === 0) {
+			return;
+		} else if (barcodeElement == null) {
+			console.warn('Barcode element not found');
+			return;
+		}
+		try {
+			JsBarcode(barcodeElement, code, { format: 'ean13' });
+		} catch (e) {
+			console.error('Failed to generate barcode:', e);
+		}
 	});
 </script>
 
 <Card>
-	<h1 class="card-title my-4 grow text-2xl font-bold md:text-4xl">Barcode Information</h1>
-	<div class="card-body flex flex-row-reverse">
-		<svg id="barcode" class="mb-2 block"></svg>
-
+	<h1 class="mb-4 text-2xl font-bold md:text-4xl">Barcode Information</h1>
+	<div class="flex flex-col gap-6 sm:flex-row sm:items-start sm:gap-8">
 		<div class="grow">
 			<label class="input w-full">
 				<span class="label">Barcode</span>
-				<input type="text" readonly value={code} />
+				<input type="text" readonly value={code} class="font-mono tracking-widest" />
 			</label>
 
-			<ul class="list mt-4 list-inside list-disc">
-				<li>
-					<a
-						class="text-xs text-blue-500 hover:underline"
-						href={`https://www.google.com/search?q=${code}`}
-						target="_blank"
-						rel="noopener noreferrer"
-						title="Search on Google"
-					>
-						Google
-					</a>
-				</li>
-				<li>
-					<a
-						class="text-xs text-blue-500 hover:underline"
-						href={`https://duckduckgo.com/?q=${code}`}
-						target="_blank"
-						rel="noopener noreferrer"
-						title="Search on DuckDuckGo"
-					>
-						DuckDuckGo
-					</a>
-				</li>
-				<li>
-					<a
-						class="text-xs text-green-600 hover:underline"
-						href={`https://prices.openfoodfacts.org/product/${code}`}
-						target="_blank"
-						rel="noopener noreferrer"
-						title="Open Prices"
-					>
-						Open Prices{#await openPricesPromise}…{:catch e}
-							({e.message === 'Not found' ? 'Not found' : 'Error'}){/await}
-					</a>
-				</li>
-				<li>
-					<a
-						class="text-xs text-green-600 hover:underline"
-						href={`https://pro.openfoodfacts.dev/products/${code}`}
-						target="_blank"
-						rel="noopener noreferrer"
-						title="Pro OFF"
-					>
-						Pro OFF{#await proOffPromise}…{:catch e}
-							({e.message === 'Not found' ? 'Not found' : 'Error'}){/await}
-					</a>
-				</li>
-				{#if code && code.length >= 3}
-					<li>
-						<a
-							class="text-xs text-purple-500 hover:underline"
-							href={`/search?barcode_prefix=${code.slice(0, 3)}`}
-							title="Find similar products"
-						>
-							Similar prefix
-						</a>
-					</li>
-				{/if}
-			</ul>
+			<div class="mt-4 space-y-3">
+				<div>
+					<p class="text-base-content/50 mb-1.5 text-xs font-semibold tracking-wide uppercase">
+						Search
+					</p>
+					<div class="flex flex-wrap gap-2">
+						{#each SEARCH_ENTRIES as entry (entry.name)}
+							<a
+								class="btn btn-sm btn-outline"
+								href={entry.url(code)}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{entry.name}
+							</a>
+						{/each}
+					</div>
+				</div>
+
+				<div>
+					<p class="text-base-content/50 mb-1.5 text-xs font-semibold tracking-wide uppercase">
+						Product availability
+					</p>
+					<div class="flex flex-wrap gap-2">
+						{#each OFF_ENTRIES as entry (entry.name)}
+							<a
+								class="btn btn-sm btn-outline"
+								href={entry.url(code)}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{entry.name}
+								{#await entry.fetchData(code)}
+									<span class="loading loading-xs loading-spinner opacity-50"></span>
+								{:then}
+									<span class="bg-success size-2 rounded-full" title="Found"></span>
+								{:catch e}
+									<span
+										class="size-2 rounded-full {e.message === 'Not found'
+											? 'bg-base-content/30'
+											: 'bg-error'}"
+										title={e.message === 'Not found' ? 'Not found' : 'Error'}
+									></span>
+								{/await}
+							</a>
+						{/each}
+
+						{#if code && code.length >= 3}
+							<a
+								class="btn btn-sm btn-outline btn-secondary"
+								href={`/search?barcode_prefix=${code.slice(0, 3)}`}
+								title="Find similar products"
+							>
+								Similar prefix
+							</a>
+						{/if}
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<div class="shrink-0 self-start rounded-lg bg-white p-3 shadow-sm">
+			<svg bind:this={barcodeElement}></svg>
 		</div>
 	</div>
 </Card>

--- a/src/lib/ui/BarcodeInfo.svelte
+++ b/src/lib/ui/BarcodeInfo.svelte
@@ -5,20 +5,24 @@
 
 	let { code }: { code: string } = $props();
 
-	let openPricesStatus: number | null = $state(null);
-	let proOffStatus: number | null = $state(null);
+	let openPricesPromise = $derived(
+		createPricesApi(fetch)
+			.getPrices({ product_code: code, size: 1 })
+			.then((r) => {
+				if (!(r.data && r.data.items && r.data.items.length > 0)) {
+					throw new Error('Not found');
+				}
+			})
+	);
+
+	let proOffPromise = $derived(
+		fetch(`https://pro.openfoodfacts.dev/products/${code}`).then((r) => {
+			if (!r.ok) throw new Error('Not found');
+		})
+	);
 
 	$effect(() => {
 		JsBarcode('#barcode', code, { format: 'ean13' });
-		createPricesApi(window.fetch)
-			.getPrices({ product_code: code, size: 1 })
-			.then((r) => {
-				openPricesStatus = r.data && r.data.items && r.data.items.length > 0 ? 200 : 404;
-			})
-			.catch(() => (openPricesStatus = 0));
-		fetch(`https://pro.openfoodfacts.dev/products/${code}`)
-			.then((r) => (proOffStatus = r.status))
-			.catch(() => (proOffStatus = 0));
 	});
 </script>
 
@@ -64,11 +68,8 @@
 						rel="noopener noreferrer"
 						title="Open Prices"
 					>
-						Open Prices {openPricesStatus === null
-							? '…'
-							: openPricesStatus === 200
-								? ''
-								: ' (Not found)'}
+						Open Prices{#await openPricesPromise}…{:catch e}
+							({e.message === 'Not found' ? 'Not found' : 'Error'}){/await}
 					</a>
 				</li>
 				<li>
@@ -79,7 +80,8 @@
 						rel="noopener noreferrer"
 						title="Pro OFF"
 					>
-						Pro OFF{proOffStatus === null ? '…' : proOffStatus === 200 ? '' : ' (Not found)'}
+						Pro OFF{#await proOffPromise}…{:catch e}
+							({e.message === 'Not found' ? 'Not found' : 'Error'}){/await}
 					</a>
 				</li>
 				{#if code && code.length >= 3}


### PR DESCRIPTION
## Description

Refactors the `BarcodeInfo.svelte` component to use Svelte 5 `$derived` Promises and `{#await}` blocks as a cleaner alternative to storing numeric HTTP status codes in component state.

This is a follow-up to #1195 (which fixed the bug of using `0` for error states). That PR's reviewer (@VaiTon) suggested exploring a promise-based approach, so this PR implements that idea.

## Changes

- **Removed magic numbers**: Dropped the `openPricesStatus` and `proOffStatus` integer state variables (`-1`, `200`, `404`, etc.).
- **Promises in state**: Replaced them with `$derived` promises — `openPricesPromise` and `proOffPromise`.
- **`{#await}` in layout**: Uses Svelte's native `{#await}…{:then}…{:catch}` blocks directly in the template for clear, declarative loading/success/error rendering.
- **Improved reactivity**: Because the promises are `$derived` from the `code` prop, they automatically re-run if the barcode changes — unlike the previous `$effect`-based approach.
- **SSR safe**: Uses `fetch` (SvelteKit's global) instead of `window.fetch`.

## Motivation

Addresses the reviewer suggestion in #1195:
> "Maybe keep the promises in the state and then use `#await` inside the layout?"

## Verification

- `svelte-check` passes with 0 errors
- `npm run format` applied cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-link async loading with individual loading spinners and explicit "Found" success indicators
  * Search links driven from a shared entry list for a more consistent experience

* **Bug Fixes**
  * Clearer "Not found" vs. generic error messaging for barcode lookups
  * Prevents barcode rendering when no code is available to avoid empty/error displays
<!-- end of auto-generated comment: release notes by coderabbit.ai -->