### PR TITLE
docs: Add feature parity list link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ By building a new frontend, we want to be able to iterate faster on the user exp
 - Using more openfoodfacts-webcomponents
 - Support for [Open Prices](https://prices.openfoodfacts.org/)
 - Support for Nutri-Patrol
+- [Feature parity list](https://docs.google.com/spreadsheets/d/1JE6prbafDeArI5GKzoxcEJRJDTFkakynBo-NltcPJx8/edit?usp=sharing)
 
 ## Get in touch
 


### PR DESCRIPTION
docs: Add feature parity list link to README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
  * Added a new roadmap reference link to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->