### PR TITLE
refactor: overhaul iframe component for stability, routing, and loading states

### DIFF
--- a/src/lib/ui/StaticPageIframe.svelte
+++ b/src/lib/ui/StaticPageIframe.svelte
@@ -75,9 +75,9 @@
 	style="height: {frameHeight ? `${frameHeight}px` : '24rem'};"
 >
 	<div
-		class="pointer-events-none absolute inset-0 z-10 flex w-full flex-col items-center justify-center bg-gray-200 transition-opacity duration-300 {showContent
-			? 'opacity-0'
-			: 'opacity-100'}"
+		class="absolute inset-0 z-10 flex w-full flex-col items-center justify-center bg-gray-200 transition-opacity duration-300 {showContent
+			? 'pointer-events-none opacity-0'
+			: 'pointer-events-auto opacity-100'}"
 	>
 		{#if hasTimeoutError}
 			<span class="font-medium text-red-500">Failed to load content.</span>
@@ -93,10 +93,12 @@
 			onload={() => (isIframeLoaded = true)}
 			scrolling="no"
 			sandbox="allow-scripts allow-same-origin allow-popups"
+			tabindex={showContent && !hasTimeoutError ? 0 : -1}
+			aria-hidden={!(showContent && !hasTimeoutError)}
 			class="absolute top-0 left-0 w-full overflow-hidden border-0 transition-opacity duration-300 {showContent &&
 			!hasTimeoutError
-				? 'opacity-100'
-				: 'opacity-0'}"
+				? 'pointer-events-auto opacity-100'
+				: 'pointer-events-none opacity-0'}"
 			style="height: 100%;"
 		></iframe>
 	{/key}

--- a/src/lib/ui/StaticPageIframe.svelte
+++ b/src/lib/ui/StaticPageIframe.svelte
@@ -11,6 +11,8 @@
 	let isIframeLoaded = $state(false);
 	let hasTimeoutError = $state(false);
 
+	let iframeEl = $state<HTMLIFrameElement | null>(null);
+
 	let expectedOrigin = $derived.by(() => {
 		try {
 			return new URL(src).origin;
@@ -52,11 +54,19 @@
 		const abortController = new AbortController();
 
 		const handler = (event: MessageEvent) => {
-			if (!expectedOrigin || event.origin !== expectedOrigin || !event.data?.frameHeight) return;
+			if (
+				!expectedOrigin ||
+				event.origin !== expectedOrigin ||
+				event.source !== iframeEl?.contentWindow ||
+				!event.data?.frameHeight
+			) {
+				return;
+			}
 
 			const parsedHeight = parseInt(event.data.frameHeight, 10);
 			if (!isNaN(parsedHeight) && parsedHeight > 0) {
 				frameHeight = parsedHeight;
+				hasTimeoutError = false;
 				clearTimeout(timeoutId);
 			}
 		};
@@ -75,7 +85,8 @@
 	style:height={frameHeight ? `${frameHeight}px` : '24rem'}
 >
 	<div
-		aria-live="polite"
+		role="status"
+		aria-live={!showContent ? 'polite' : 'off'}
 		aria-hidden={showContent}
 		class="absolute inset-0 z-10 flex w-full flex-col items-center justify-center bg-gray-200 transition-opacity duration-300 {showContent
 			? 'pointer-events-none opacity-0'
@@ -90,6 +101,7 @@
 
 	{#key src}
 		<iframe
+			bind:this={iframeEl}
 			{src}
 			{title}
 			onload={() => (isIframeLoaded = true)}

--- a/src/lib/ui/StaticPageIframe.svelte
+++ b/src/lib/ui/StaticPageIframe.svelte
@@ -20,8 +20,8 @@
 		}
 	});
 
-	let previousSrc = $state(src);
-	let timeoutId: ReturnType<typeof setTimeout>;
+	let previousSrc: string | undefined;
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
 	const resetTimeout = () => {
 		clearTimeout(timeoutId);
@@ -34,7 +34,7 @@
 		}, 8000);
 	};
 
-	$effect(() => {
+	$effect.pre(() => {
 		if (src !== previousSrc) {
 			untrack(() => {
 				frameHeight = null;
@@ -71,10 +71,12 @@
 </script>
 
 <div
-	class="relative w-full overflow-hidden transition-all duration-300"
-	style="height: {frameHeight ? `${frameHeight}px` : '24rem'};"
+	class="relative w-full overflow-hidden"
+	style:height={frameHeight ? `${frameHeight}px` : '24rem'}
 >
 	<div
+		aria-live="polite"
+		aria-hidden={showContent}
 		class="absolute inset-0 z-10 flex w-full flex-col items-center justify-center bg-gray-200 transition-opacity duration-300 {showContent
 			? 'pointer-events-none opacity-0'
 			: 'pointer-events-auto opacity-100'}"
@@ -93,8 +95,7 @@
 			onload={() => (isIframeLoaded = true)}
 			scrolling="no"
 			sandbox="allow-scripts allow-same-origin allow-popups"
-			tabindex={showContent && !hasTimeoutError ? 0 : -1}
-			aria-hidden={!(showContent && !hasTimeoutError)}
+			inert={!(showContent && !hasTimeoutError)}
 			class="absolute top-0 left-0 w-full overflow-hidden border-0 transition-opacity duration-300 {showContent &&
 			!hasTimeoutError
 				? 'pointer-events-auto opacity-100'

--- a/src/lib/ui/StaticPageIframe.svelte
+++ b/src/lib/ui/StaticPageIframe.svelte
@@ -1,34 +1,103 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 
-	type Props = { src: string };
-	let { src }: Props = $props();
+	type Props = {
+		src: string;
+		title?: string;
+	};
+	let { src, title = 'External Content' }: Props = $props();
 
-	let frameHeight = $state('100vh'); // Default height, can be adjusted
+	let frameHeight = $state<number | null>(null);
+	let isIframeLoaded = $state(false);
+	let hasTimeoutError = $state(false);
+
+	let expectedOrigin = $derived.by(() => {
+		try {
+			return new URL(src).origin;
+		} catch {
+			console.warn(`[Iframe Component] Invalid URL provided: ${src}`);
+			return null;
+		}
+	});
+
+	let previousSrc = $state(src);
+	let timeoutId: ReturnType<typeof setTimeout>;
+
+	const resetTimeout = () => {
+		clearTimeout(timeoutId);
+		hasTimeoutError = false;
+		timeoutId = setTimeout(() => {
+			if (frameHeight === null) {
+				hasTimeoutError = true;
+				console.error(`[Iframe Component] Timeout waiting for frameHeight from ${src}`);
+			}
+		}, 8000);
+	};
+
+	$effect(() => {
+		if (src !== previousSrc) {
+			untrack(() => {
+				frameHeight = null;
+				isIframeLoaded = false;
+				previousSrc = src;
+				resetTimeout();
+			});
+		}
+	});
+
+	let showContent = $derived(frameHeight !== null && isIframeLoaded);
+
 	onMount(() => {
+		resetTimeout();
 		const abortController = new AbortController();
 
 		const handler = (event: MessageEvent) => {
-			if (!event.data?.frameHeight) return;
+			if (!expectedOrigin || event.origin !== expectedOrigin || !event.data?.frameHeight) return;
 
-			console.debug('Received frameHeight:', event.data.frameHeight);
-			frameHeight = event.data.frameHeight + 'px';
+			const parsedHeight = parseInt(event.data.frameHeight, 10);
+			if (!isNaN(parsedHeight) && parsedHeight > 0) {
+				frameHeight = parsedHeight;
+				clearTimeout(timeoutId);
+			}
 		};
 
-		window.addEventListener('message', handler, {
-			signal: abortController.signal
-		});
+		window.addEventListener('message', handler, { signal: abortController.signal });
 
 		return () => {
-			window.removeEventListener('message', handler);
 			abortController.abort();
+			clearTimeout(timeoutId);
 		};
 	});
 </script>
 
-<iframe
-	{src}
-	title="External Content"
-	class="w-full overflow-visible border-0"
-	style="height: {frameHeight};"
-></iframe>
+<div
+	class="relative w-full overflow-hidden transition-all duration-300"
+	style="height: {frameHeight ? `${frameHeight}px` : '24rem'};"
+>
+	<div
+		class="pointer-events-none absolute inset-0 z-10 flex w-full flex-col items-center justify-center bg-gray-200 transition-opacity duration-300 {showContent
+			? 'opacity-0'
+			: 'opacity-100'}"
+	>
+		{#if hasTimeoutError}
+			<span class="font-medium text-red-500">Failed to load content.</span>
+		{:else}
+			<span class="animate-pulse font-medium text-gray-500">Loading content...</span>
+		{/if}
+	</div>
+
+	{#key src}
+		<iframe
+			{src}
+			{title}
+			onload={() => (isIframeLoaded = true)}
+			scrolling="no"
+			sandbox="allow-scripts allow-same-origin allow-popups"
+			class="absolute top-0 left-0 w-full overflow-hidden border-0 transition-opacity duration-300 {showContent &&
+			!hasTimeoutError
+				? 'opacity-100'
+				: 'opacity-0'}"
+			style="height: 100%;"
+		></iframe>
+	{/key}
+</div>


### PR DESCRIPTION
**Resolves:** #1268 

### Overview
This PR resolves the ongoing layout and state management issues with the `StaticPageIframe` component. The previous implementation suffered from technical debt regarding SvelteKit's SPA lifecycle, lacking proper cleanup and error boundaries.

### Key Architectural & UI Changes:
* **Fixed SPA State Leaks:** Wrapped the `<iframe>` in a `{#key src}` block. This forces Svelte to destroy and recreate the DOM node on route changes, preventing the iframe's internal History API from hijacking the browser's "Back" button and ensuring a clean load state.
* **Resolved Dual Scroll & Footer Overlap:** Enforced `overflow-hidden` and `scrolling="no"` on the iframe. The container now strictly dictates the height based on the parsed `postMessage` payload, preventing the footer from floating over the content.
* **Added Error Boundaries (Timeout):** Implemented an 8-second timeout fallback. If the external source fails to send the `frameHeight` payload (e.g., external server crash, network drop), the UI now aborts the loading state and displays a graceful error message instead of an infinite loader.
* **Security & SSR Improvements:**
  * Made URL parsing SSR-safe with a `try-catch` block to prevent Server 500 crashes if a malformed `src` is provided.
  * Hardened the `message` event listener with strict `origin` validation and payload sanitization (`parseInt`).
* **UX Polish:** Replaced the abrupt conditional rendering (`{#if}`) with a CSS opacity crossfade. This eliminates the visual gap between the loader disappearing and the iframe rendering, mitigating Cumulative Layout Shift (CLS).

### Testing Notes
- Verify navigation between two different `/static` pages (height should recalculate, no cached height).
- Verify scroll behavior (only one main scrollbar should be visible, footer should respect the document flow).
- Simulate a network failure or point `src` to an invalid URL to verify the 8-second timeout fallback triggers correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional title for embedded content (defaults to "External Content")
  * Embedded content fully re-initializes when its source changes and shows a loading overlay until ready

* **Bug Fixes**
  * Height updates are validated before being applied to prevent invalid sizes
  * Visible loading timeout with an 8s error state if no size message arrives
  * Improved cleanup of listeners and timers on unmount or source change
<!-- end of auto-generated comment: release notes by coderabbit.ai -->