### PR TITLE
fix: implement graceful degradation for API failures in homepage load

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -141,7 +141,13 @@
 	>
 		<IconMdiDatabase class="text-primary mb-4 h-12 w-12" />
 		<h2 class="text-xl font-bold">
-			<CountUp value={data.productCount} />
+			{#await data.productCount}
+				<div class="skeleton h-8 w-24"></div>
+			{:then count}
+				<CountUp value={count} />
+			{:catch}
+				<div>0</div>
+			{/await}
 		</h2>
 		<p class="text-base-content/70">{$_('landing.products_count')}</p>
 	</a>
@@ -151,7 +157,13 @@
 	>
 		<IconMdiAccountGroup class="text-primary mb-4 h-12 w-12" />
 		<h2 class="text-xl font-bold">
-			<CountUp value={data.contributorCount} />
+			{#await data.contributorCount}
+				<div class="skeleton h-8 w-24"></div>
+			{:then count}
+				<CountUp value={count} />
+			{:catch}
+				<div>0</div>
+			{/await}
 		</h2>
 		<p class="text-base-content/70">{$_('landing.contributors_count')}</p>
 	</a>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -2,7 +2,9 @@ import { wrapFetchWithCredentials } from '$lib/api/utils';
 import { API_HOST } from '$lib/const';
 import type { PageLoad } from './$types';
 
-async function getNumberOfProducts(fetch: typeof window.fetch): Promise<number> {
+async function getNumberOfProducts(
+	fetch: (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+): Promise<number> {
 	const { fetch: wrappedFetch, url } = wrapFetchWithCredentials(fetch, new URL(API_HOST));
 	const res = await wrappedFetch(`${url}.json`);
 	if (!res.ok) {
@@ -12,7 +14,9 @@ async function getNumberOfProducts(fetch: typeof window.fetch): Promise<number> 
 	return data?.count || 0;
 }
 
-async function getNumberOfContributors(fetch: typeof window.fetch): Promise<number> {
+async function getNumberOfContributors(
+	fetch: (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+): Promise<number> {
 	const { fetch: wrappedFetch, url } = wrapFetchWithCredentials(fetch, new URL(API_HOST));
 	const res = await wrappedFetch(`${url}facets/contributors.json`);
 	if (!res.ok) {
@@ -23,10 +27,8 @@ async function getNumberOfContributors(fetch: typeof window.fetch): Promise<numb
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	const productCount = getNumberOfProducts(fetch);
-	const contributorCount = getNumberOfContributors(fetch);
 	return {
-		productCount: await productCount,
-		contributorCount: await contributorCount
+		productCount: getNumberOfProducts(fetch),
+		contributorCount: getNumberOfContributors(fetch)
 	};
 };


### PR DESCRIPTION
## Related issue(s)
Fixes #1263

## The Situation
When external APIs fail (like the current 403 error on the contributors endpoint), the homepage crashes with a 500 Internal Server Error due to unhandled exceptions in the load function.

## The Fix
Implemented graceful error handling at the UI level using Svelte's '{#await}' pattern instead of trying to handle errors in the backend.

**Key Changes:**
- Removed try/catch blocks from 'getNumberOfProducts' and 'getNumberOfContributors'
- Functions now throw errors naturally, which Svelte catches at the template level
- Implemented '{#await}' blocks in '+page.svelte' for both product and contributor counts
- Each async value now has three states:
  - **Pending**: Shows loading skeleton while fetching
  - **Then**: Displays the actual count value
  - **Catch**: Shows fallback value of 0 if API fails
- Maintained parallel fetching pattern for optimal performance

## How It Works
When an API fails:
1. Loading skeleton appears briefly
2. Promise rejects and is caught by '{#await}' catch block
3. Fallback value (0) is displayed gracefully
4. Homepage stays functional instead of showing 500 error

## Why This Approach
- More idiomatic Svelte - follows framework best practices
- Better separation of concerns - UI handles presentation errors
- Better UX - shows loading states and gracefully degrades
- Maintainer recommended - as suggested in PR feedback

## Testing
 TypeScript check: PASSED ('pnpm check')
 Linting: PASSED ('pnpm lint')  
 Formatting: PASSED ('pnpm format')
 Manual testing: Verified homepage stays up when APIs fail
 Graceful degradation: Confirmed fallback values display correctly