### PR TITLE
fix: open external prices links in a new tab

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -425,7 +425,8 @@
 		"prices": {
 			"no_prices_found": "No prices found for this product",
 			"loading": "Loading prices…",
-			"view_prices": "View prices on Open Prices"
+			"view_prices": "View prices on Open Prices",
+			"view_prices_new_tab": "View prices (opens in a new tab)"
 		},
 		"knowledge_panels": {
 			"action": {

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -160,6 +160,9 @@
 			"comment_placeholder": "Add a comment to this edit",
 			"save_btn": "Save",
 			"debug": "Debug"
+		},
+		"prices": {
+			"view_prices_new_tab": "View prices (opens in a new tab)"
 		}
 	},
 	"errors": {

--- a/src/lib/ui/BarcodeInfo.svelte
+++ b/src/lib/ui/BarcodeInfo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import JsBarcode from 'jsbarcode';
+	import { _ } from '$lib/i18n';
 	import Card from './Card.svelte';
 	import { createPricesApi } from '$lib/api/prices';
 
@@ -63,7 +64,7 @@
 						href={`https://prices.openfoodfacts.org/product/${code}`}
 						target="_blank"
 						rel="noopener noreferrer"
-						aria-label="Open Prices (opens in a new tab)"
+						aria-label={$_('product.prices.view_prices_new_tab')}
 						title="Open Prices"
 					>
 						Open Prices {openPricesStatus === null

--- a/src/lib/ui/BarcodeInfo.svelte
+++ b/src/lib/ui/BarcodeInfo.svelte
@@ -57,11 +57,13 @@
 					</a>
 				</li>
 				<li>
+					<!-- Open external Prices links in a new tab to preserve app context. -->
 					<a
 						class="text-xs text-green-600 hover:underline"
 						href={`https://prices.openfoodfacts.org/product/${code}`}
 						target="_blank"
 						rel="noopener noreferrer"
+						aria-label="Open Prices (opens in a new tab)"
 						title="Open Prices"
 					>
 						Open Prices {openPricesStatus === null

--- a/src/lib/ui/Navbar.svelte
+++ b/src/lib/ui/Navbar.svelte
@@ -27,7 +27,7 @@
 						href={item.href}
 						target={isPricesLink ? '_blank' : undefined}
 						rel={isPricesLink ? 'noopener noreferrer' : undefined}
-						aria-label={isPricesLink ? `${itemLabel} (opens in a new tab)` : undefined}
+						aria-label={isPricesLink ? $_('product.prices.view_prices_new_tab') : undefined}
 						class="text-secondary-content font-medium hover:underline"
 					>
 						{itemLabel}

--- a/src/lib/ui/Navbar.svelte
+++ b/src/lib/ui/Navbar.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { _ } from '$lib/i18n';
 	import { page } from '$app/state';
 	import { shouldBeContainer } from '$lib/layout';
@@ -11,15 +11,26 @@
 		{ name: 'folksonomy_link', href: '/folksonomy' },
 		{ name: 'facets_link', href: '/facets' }
 	];
+
+	const isPricesExternalUrl = (href: string) => href.startsWith('https://prices.openfoodfacts.org');
 </script>
 
 <nav class="bg-secondary mt-2 px-4 {!shouldBeContainer(page.url.pathname) ? '' : 'mb-8'}">
 	<ul class="flex justify-center">
 		<div class="m-2 flex w-3/4 items-center justify-evenly 2xl:w-[60%]">
 			{#each navItems as item (item.name)}
+				{@const isPricesLink = isPricesExternalUrl(item.href)}
+				{@const itemLabel = $_(item.name)}
 				<li>
-					<a href={item.href} class="text-secondary-content font-medium hover:underline">
-						{$_(item.name)}
+					<!-- Open external Prices links in a new tab to preserve app context. -->
+					<a
+						href={item.href}
+						target={isPricesLink ? '_blank' : undefined}
+						rel={isPricesLink ? 'noopener noreferrer' : undefined}
+						aria-label={isPricesLink ? `${itemLabel} (opens in a new tab)` : undefined}
+						class="text-secondary-content font-medium hover:underline"
+					>
+						{itemLabel}
 					</a>
 				</li>
 			{/each}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -362,7 +362,14 @@
 		<a class="btn btn-outline link" href="/static/producers">
 			{$_('producers_link')}
 		</a>
-		<a class="btn btn-outline link" href="https://prices.openfoodfacts.org">
+		<!-- Open external Prices links in a new tab to preserve app context. -->
+		<a
+			class="btn btn-outline link"
+			href="https://prices.openfoodfacts.org"
+			target="_blank"
+			rel="noopener noreferrer"
+			aria-label={`${$_('prices_link')} (opens in a new tab)`}
+		>
 			{$_('prices_link')}
 		</a>
 		<a class="btn btn-outline link" href="/folksonomy">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -368,7 +368,7 @@
 			href="https://prices.openfoodfacts.org"
 			target="_blank"
 			rel="noopener noreferrer"
-			aria-label={`${$_('prices_link')} (opens in a new tab)`}
+			aria-label={$_('product.prices.view_prices_new_tab')}
 		>
 			{$_('prices_link')}
 		</a>

--- a/src/routes/products/[barcode]/Prices.svelte
+++ b/src/routes/products/[barcode]/Prices.svelte
@@ -41,11 +41,11 @@
 	<div class="mt-4 text-end">
 		<!-- Open external Prices links in a new tab to preserve app context. -->
 		<a
-			href={`https://prices.openfoodfacts.org/products/${barcode}`}
+			href={`https://prices.openfoodfacts.org/product/${barcode}`}
 			class="text-secondary link text-sm italic"
 			target="_blank"
 			rel="noopener noreferrer"
-			aria-label={`${$_('product.prices.view_prices')} (opens in a new tab)`}
+			aria-label={$_('product.prices.view_prices_new_tab')}
 		>
 			{$_('product.prices.view_prices')}
 		</a>

--- a/src/routes/products/[barcode]/Prices.svelte
+++ b/src/routes/products/[barcode]/Prices.svelte
@@ -39,11 +39,13 @@
 	{/if}
 
 	<div class="mt-4 text-end">
+		<!-- Open external Prices links in a new tab to preserve app context. -->
 		<a
-			href="https://prices.openfoodfacts.org/products/{barcode}"
+			href={`https://prices.openfoodfacts.org/products/${barcode}`}
 			class="text-secondary link text-sm italic"
 			target="_blank"
 			rel="noopener noreferrer"
+			aria-label={`${$_('product.prices.view_prices')} (opens in a new tab)`}
 		>
 			{$_('product.prices.view_prices')}
 		</a>


### PR DESCRIPTION
### Description

Fixes: #1273 

Clicking on the "Prices" link currently redirects users to prices.openfoodfacts.org in the same tab.

This causes users to lose their current context in the Explorer (such as navigation state and scroll position).

This PR updates external Prices links to open in a new tab using `target="_blank"` and `rel="noopener noreferrer"` to preserve user context and improve navigation experience.

---

### Related issue(s) and discussion

- Fixes: #1273 

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).

## Large Language Models usage disclosure

- [x] Used ChatGPT (GPT-5.3) for guidance in structuring the PR and reviewing the implementation. All code changes were manually verified and tested locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “View prices” links now open in a new browser tab on product pages and the mobile header.

* **Accessibility**
  * Added descriptive aria-labels so assistive technologies announce that price links open in a new tab.

* **Localization**
  * New localized string for “View prices (opens in a new tab)” added for supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->