### PR TITLE
fix: add aria-label and aria-expanded to facet toggle button (#1157)

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -461,13 +461,19 @@
 		"mobile_nav": "Mobile navigation menu"
 	},
 	"facets": {
-		"facet_website_title": "Exploring {facet} - Open Food Facts Explorer",
-		"facet_website_description": "Discover the {facet} category on Open Food Facts Explorer.",
-		"facet_value_website_title": "Exploring {facet}: {value} - Open Food Facts Explorer",
-		"facet_value_website_description": "Discover the {value} category on Open Food Facts Explorer.",
-		"facet_back_to_list": "Back to facets",
-		"facet_back_to_overview": "Back to {facet} overview"
-	},
+	"facet_website_title": "Exploring {facet} - Open Food Facts Explorer",
+	"facet_website_description": "Discover the {facet} category on Open Food Facts Explorer.",
+	"facet_value_website_title": "Exploring {facet}: {value} - Open Food Facts Explorer",
+	"facet_value_website_description": "Discover the {value} category on Open Food Facts Explorer.",
+	"facet_back_to_list": "Back to facets",
+	"facet_back_to_overview": "Back to {facet} overview",
+
+	"show_all": "See All",
+	"show_less": "Show Less",
+	"show_all_options": "Show all facet options",
+	"show_less_options": "Show fewer facet options",
+	"search_placeholder": "Search..."
+},
 	"landing": {
 		"title": "Open Food Facts Explorer",
 		"subtitle": "A collaborative, free and open database of food products from around the world. Discover, search, and contribute to food transparency for everyone.",

--- a/src/routes/search/FacetCard.svelte
+++ b/src/routes/search/FacetCard.svelte
@@ -83,7 +83,13 @@
 		{/each}
 		{#if searchQuery == ''}
 			<li>
-				<button type="button" class="btn btn-link w-full" onclick={() => toggleShowAll()}>
+				<button
+					type="button"
+					class="btn btn-link w-full"
+					onclick={() => toggleShowAll()}
+					aria-label={showAll ? "Show less facet options" : "Show all facet options"}
+					aria-expanded={showAll}
+					>
 					{showAll ? 'Show Less' : 'See All'}
 				</button>
 			</li>

--- a/src/routes/search/FacetCard.svelte
+++ b/src/routes/search/FacetCard.svelte
@@ -1,3 +1,4 @@
+import { t } from '$lib/i18n';
 <script lang="ts">
 	import type { Facet, FacetItem } from '$lib/api/search';
 	import IconMdiChevronDown from '@iconify-svelte/mdi/chevron-down';
@@ -56,7 +57,7 @@
 		<li>
 			<input
 				type="text"
-				placeholder="Search..."
+				placeholder={t('facets.search_placeholder')}
 				class="input input-bordered mb-2 w-full"
 				bind:value={searchQuery}
 			/>
@@ -83,15 +84,19 @@
 		{/each}
 		{#if searchQuery == ''}
 			<li>
-				<button
-					type="button"
-					class="btn btn-link w-full"
-					onclick={() => toggleShowAll()}
-					aria-label={showAll ? "Show less facet options" : "Show all facet options"}
-					aria-expanded={showAll}
-					>
-					{showAll ? 'Show Less' : 'See All'}
-				</button>
+<button
+	type="button"
+	class="btn btn-link w-full"
+	onclick={() => toggleShowAll()}
+	aria-label={showAll 
+		? t('facets.show_less_options') 
+		: t('facets.show_all_options')}
+	aria-expanded={showAll}
+>
+	{showAll 
+		? t('facets.show_less') 
+		: t('facets.show_all')}
+</button>
 			</li>
 		{/if}
 	</ul>


### PR DESCRIPTION
### Description

Added a dynamic `aria-label` to the "See All / Show Less" toggle button in FacetCard.svelte.

Also added `aria-expanded` to reflect the current state of the toggle button.

### Screenshot or video
No visual changes. This update improves accessibility for screen reader users.

### Related issue(s) and discussion

- Fixes: #1157

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized facet strings (search placeholder, "show all"/"show less" labels and corresponding screen-reader options).

* **Bug Fixes**
  * Improved accessibility of the facet search and toggle: localized placeholder, dynamic aria-labels and aria-expanded behavior, and clearer toggle rendering when searching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->