### PR TITLE
fix: debounce folksonomy value lookup and prevent stale updates

### DIFF
--- a/src/routes/products/[barcode]/Folksonomy.svelte
+++ b/src/routes/products/[barcode]/Folksonomy.svelte
@@ -99,32 +99,67 @@
 
 	let possibleValues: { v: string; product_count: number }[] | null = $state(null);
 
-	$effect(() => {
-		// when newKey changes, fetch possible values
-		const key = newKey;
+	type DebouncedFn = (() => void) & {
+		cancel: () => void;
+	};
 
-		debounce(100, () => {
-			if (key == '') {
-				possibleValues = null;
-				return;
-			}
-			console.debug('Fetching possible values for key:', key);
+	// Create a single debounced function that maintains state across calls
+	const debouncedFetchValues = createDebounce(100, () => {
+		if (newKey == '') {
+			possibleValues = null;
+			return;
+		}
+		const requestedKey = newKey;
+		console.debug('Fetching possible values for key:', requestedKey);
 
-			getFolksonomyValues(fetch, key).then((values) => {
-				console.debug('Possible values for key', key, ':', values);
+		getFolksonomyValues(fetch, requestedKey)
+			.then((values) => {
+				if (requestedKey !== newKey) {
+					return;
+				}
+
+				console.debug('Possible values for key', requestedKey, ':', values);
 				possibleValues = values;
+			})
+			.catch((error) => {
+				if (requestedKey !== newKey) {
+					return;
+				}
+
+				console.error('Failed to fetch possible values for key', requestedKey, error);
 			});
-		});
 	});
 
-	function debounce(delay: number, fn: () => void) {
+	$effect(() => {
+		// when newKey changes, call the debounced fetch
+		// Reference newKey to make it a reactive dependency
+		void newKey;
+		debouncedFetchValues();
+
+		return () => {
+			debouncedFetchValues.cancel();
+		};
+	});
+
+	function createDebounce(delay: number, fn: () => void): DebouncedFn {
 		let timeoutId: number | undefined;
-		(() => {
-			if (timeoutId) {
+
+		// Return a function that maintains timeoutId through closure
+		const debounced = () => {
+			if (timeoutId !== undefined) {
 				clearTimeout(timeoutId);
 			}
 			timeoutId = window.setTimeout(fn, delay);
-		})();
+		};
+
+		debounced.cancel = () => {
+			if (timeoutId !== undefined) {
+				clearTimeout(timeoutId);
+				timeoutId = undefined;
+			}
+		};
+
+		return debounced;
 	}
 
 	let isLoading: boolean = $state(false);


### PR DESCRIPTION
Replacement for closed #1230.

This PR reapplies the same debounce and stale-response fix on a fresh branch from latest upstream main.

Problem
- Debounce timer state was not preserved across calls.
- Each keystroke could trigger immediate API calls.
- Stale responses could overwrite newer input state.
- Timeout cleanup was missing on effect teardown.

Solution
1. Use a closure-based debounce function with a cancel method.
2. Snapshot requested key and ignore stale responses.
3. Add effect cleanup to cancel pending timers.
4. Guard error handling against stale state.

Validation
- pnpm install --frozen-lockfile
- pnpm lint: pass
- pnpm check: 0 errors, existing warning only
- pnpm build: codespace process exits with 143, reproducible on upstream main in this environment