### PR TITLE
feat: implement post login redirect

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -63,6 +63,10 @@ export function requireInt(value: string | null, error: () => never) {
  * @returns A safe relative path if valid, or '/' as a fallback
  */
 export function getSafeRedirectUrl(redirectUrl: string | null | undefined, origin: string): string {
+	if (!origin || !URL.canParse(origin)) {
+		throw new Error(`getSafeRedirectUrl: invalid origin "${origin}"`);
+	}
+
 	if (!redirectUrl || !redirectUrl.startsWith('/') || redirectUrl.startsWith('//')) {
 		return '/';
 	}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -55,3 +55,26 @@ export function requireInt(value: string | null, error: () => never) {
 	}
 	return intValue;
 }
+
+/**
+ * Validates and sanitizes a redirect URL to prevent Open Redirect vulnerabilities.
+ * @param redirectUrl - The URL string to validate
+ * @param origin - The application's current origin (e.g. url.origin)
+ * @returns A safe relative path if valid, or '/' as a fallback
+ */
+export function getSafeRedirectUrl(redirectUrl: string | null | undefined, origin: string): string {
+	if (!redirectUrl || !redirectUrl.startsWith('/') || redirectUrl.startsWith('//')) {
+		return '/';
+	}
+
+	try {
+		const targetUrl = new URL(redirectUrl, origin);
+		if (targetUrl.origin !== origin) {
+			return '/';
+		}
+		// Return only the relative portion to ensure safety
+		return targetUrl.pathname + targetUrl.search + targetUrl.hash;
+	} catch {
+		return '/';
+	}
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -63,7 +63,14 @@ export function requireInt(value: string | null, error: () => never) {
  * @returns A safe relative path if valid, or '/' as a fallback
  */
 export function getSafeRedirectUrl(redirectUrl: string | null | undefined, origin: string): string {
-	if (!origin || !URL.canParse(origin)) {
+	if (!origin) {
+		throw new Error(`getSafeRedirectUrl: invalid origin "${origin}"`);
+	}
+
+	let normalizedOrigin: string;
+	try {
+		normalizedOrigin = new URL(origin).origin;
+	} catch {
 		throw new Error(`getSafeRedirectUrl: invalid origin "${origin}"`);
 	}
 
@@ -72,8 +79,8 @@ export function getSafeRedirectUrl(redirectUrl: string | null | undefined, origi
 	}
 
 	try {
-		const targetUrl = new URL(redirectUrl, origin);
-		if (targetUrl.origin !== origin) {
+		const targetUrl = new URL(redirectUrl, normalizedOrigin);
+		if (targetUrl.origin !== normalizedOrigin) {
 			return '/';
 		}
 		// Return only the relative portion to ensure safety

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -269,7 +269,11 @@
 						>{$_('navbar.logout', { default: 'Logout' })}</a
 					>
 				{:else}
-					<a class="btn btn-outline link" href={resolve('/oauth/login')}
+					<a
+						class="btn btn-outline link"
+						href={resolve('/oauth/login') +
+							'?redirect=' +
+							encodeURIComponent(page.url.pathname + page.url.search)}
 						>{$_('navbar.login', { default: 'Login' })}</a
 					>
 				{/if}
@@ -393,7 +397,11 @@
 				>{$_('navbar.logout', { default: 'Logout' })}</a
 			>
 		{:else}
-			<a class="btn btn-outline link" href={resolve('/oauth/login')}
+			<a
+				class="btn btn-outline link"
+				href={resolve('/oauth/login') +
+					'?redirect=' +
+					encodeURIComponent(page.url.pathname + page.url.search)}
 				>{$_('navbar.login', { default: 'Login' })}</a
 			>
 		{/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -174,6 +174,10 @@
 		isSearching = false;
 	}
 
+	function getLoginUrl(url: URL) {
+		return resolve('/oauth/login') + '?redirect=' + encodeURIComponent(url.pathname + url.search);
+	}
+
 	let searchActive = $state(false);
 	let accordionOpen = $state(false);
 	const mobileMenuId = 'mobile-menu-panel';
@@ -269,11 +273,7 @@
 						>{$_('navbar.logout', { default: 'Logout' })}</a
 					>
 				{:else}
-					<a
-						class="btn btn-outline link"
-						href={resolve('/oauth/login') +
-							'?redirect=' +
-							encodeURIComponent(page.url.pathname + page.url.search)}
+					<a class="btn btn-outline link" href={getLoginUrl(page.url)}
 						>{$_('navbar.login', { default: 'Login' })}</a
 					>
 				{/if}
@@ -397,11 +397,7 @@
 				>{$_('navbar.logout', { default: 'Logout' })}</a
 			>
 		{:else}
-			<a
-				class="btn btn-outline link"
-				href={resolve('/oauth/login') +
-					'?redirect=' +
-					encodeURIComponent(page.url.pathname + page.url.search)}
+			<a class="btn btn-outline link" href={getLoginUrl(page.url)}
 				>{$_('navbar.login', { default: 'Login' })}</a
 			>
 		{/if}

--- a/src/routes/oauth/login/+page.ts
+++ b/src/routes/oauth/login/+page.ts
@@ -38,6 +38,12 @@ export const load: PageLoad = async ({ url }) => {
 	localStorage.setItem('verifier', verifier);
 	localStorage.setItem('authState', state);
 
+	// Store the redirect URL if present
+	const redirectUrl = url.searchParams.get('redirect');
+	if (redirectUrl) {
+		localStorage.setItem('authRedirect', redirectUrl);
+	}
+
 	// 4. Create and redirect to the Keycloak login URL
 	const api = createKeycloakApi(fetch, url);
 

--- a/src/routes/oauth/login/+page.ts
+++ b/src/routes/oauth/login/+page.ts
@@ -42,6 +42,8 @@ export const load: PageLoad = async ({ url }) => {
 	const redirectUrl = url.searchParams.get('redirect');
 	if (redirectUrl && redirectUrl.startsWith('/') && !redirectUrl.startsWith('//')) {
 		localStorage.setItem('authRedirect', redirectUrl);
+	} else {
+		localStorage.removeItem('authRedirect');
 	}
 
 	// 4. Create and redirect to the Keycloak login URL

--- a/src/routes/oauth/login/+page.ts
+++ b/src/routes/oauth/login/+page.ts
@@ -38,9 +38,9 @@ export const load: PageLoad = async ({ url }) => {
 	localStorage.setItem('verifier', verifier);
 	localStorage.setItem('authState', state);
 
-	// Store the redirect URL if present
+	// Only store if it's a safe, same-origin relative path
 	const redirectUrl = url.searchParams.get('redirect');
-	if (redirectUrl) {
+	if (redirectUrl && redirectUrl.startsWith('/') && !redirectUrl.startsWith('//')) {
 		localStorage.setItem('authRedirect', redirectUrl);
 	}
 

--- a/src/routes/oauth/login/+page.ts
+++ b/src/routes/oauth/login/+page.ts
@@ -42,11 +42,7 @@ export const load: PageLoad = async ({ url }) => {
 	// Only store if it's a safe, same-origin relative path
 	const redirectUrl = url.searchParams.get('redirect');
 	const safeRedirect = getSafeRedirectUrl(redirectUrl, url.origin);
-	if (safeRedirect !== '/') {
-		localStorage.setItem('authRedirect', safeRedirect);
-	} else {
-		localStorage.removeItem('authRedirect');
-	}
+	localStorage.setItem('authRedirect', safeRedirect);
 
 	// 4. Create and redirect to the Keycloak login URL
 	const api = createKeycloakApi(fetch, url);

--- a/src/routes/oauth/login/+page.ts
+++ b/src/routes/oauth/login/+page.ts
@@ -5,6 +5,7 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 import { createKeycloakApi } from '$lib/api';
+import { getSafeRedirectUrl } from '$lib/utils';
 
 /**
  * Encodes a Uint8Array to a base64 URL-safe string.
@@ -40,8 +41,9 @@ export const load: PageLoad = async ({ url }) => {
 
 	// Only store if it's a safe, same-origin relative path
 	const redirectUrl = url.searchParams.get('redirect');
-	if (redirectUrl && redirectUrl.startsWith('/') && !redirectUrl.startsWith('//')) {
-		localStorage.setItem('authRedirect', redirectUrl);
+	const safeRedirect = getSafeRedirectUrl(redirectUrl, url.origin);
+	if (safeRedirect !== '/') {
+		localStorage.setItem('authRedirect', safeRedirect);
 	} else {
 		localStorage.removeItem('authRedirect');
 	}

--- a/src/routes/oauth/login/callback/+page.svelte
+++ b/src/routes/oauth/login/callback/+page.svelte
@@ -43,7 +43,13 @@
 			const redirectUrl = localStorage.getItem('authRedirect');
 			localStorage.removeItem('authRedirect');
 
-			await goto(new URL(redirectUrl || '/', url.origin));
+			// Verify the destination is same-origin
+			let targetUrl = new URL(redirectUrl || '/', url.origin);
+			if (targetUrl.origin !== url.origin) {
+				targetUrl = new URL('/', url.origin);
+			}
+
+			await goto(targetUrl);
 		} catch (error) {
 			console.error('Token exchange failed:', error);
 			throw new Error('Authentication failed: Token exchange error', { cause: error });

--- a/src/routes/oauth/login/callback/+page.svelte
+++ b/src/routes/oauth/login/callback/+page.svelte
@@ -39,7 +39,11 @@
 			});
 			localStorage.removeItem('verifier');
 			saveAuthTokens(jwt);
-			await goto(resolve('/'));
+
+			const redirectUrl = localStorage.getItem('authRedirect');
+			localStorage.removeItem('authRedirect');
+
+			await goto(new URL(redirectUrl || '/', url.origin));
 		} catch (error) {
 			console.error('Token exchange failed:', error);
 			throw new Error('Authentication failed: Token exchange error', { cause: error });

--- a/src/routes/oauth/login/callback/+page.svelte
+++ b/src/routes/oauth/login/callback/+page.svelte
@@ -6,6 +6,7 @@
 	import { onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import { createKeycloakApi } from '$lib/api';
+	import { getSafeRedirectUrl } from '$lib/utils';
 
 	async function doPkceExchange() {
 		const url = page.url;
@@ -44,12 +45,9 @@
 			localStorage.removeItem('authRedirect');
 
 			// Verify the destination is same-origin
-			let targetUrl = new URL(redirectUrl || '/', url.origin);
-			if (targetUrl.origin !== url.origin) {
-				targetUrl = new URL('/', url.origin);
-			}
+			const targetPath = getSafeRedirectUrl(redirectUrl, url.origin);
 
-			await goto(targetUrl);
+			await goto(targetPath);
 		} catch (error) {
 			console.error('Token exchange failed:', error);
 			throw new Error('Authentication failed: Token exchange error', { cause: error });
@@ -72,7 +70,7 @@
 				<p class="text-lg text-gray-600">You will be redirected shortly.</p>
 			{:then _}
 				<div class="mb-4 text-4xl font-bold text-green-600">Login Successful</div>
-				<p class="text-lg text-gray-600">Redirecting to the homepage...</p>
+				<p class="text-lg text-gray-600">Redirecting...</p>
 			{:catch error}
 				<div class="mb-4 text-4xl font-bold text-red-600">Login Failed</div>
 				<p class="text-base-content text-lg">{error.message}</p>


### PR DESCRIPTION
### Description
Currently, users are always redirected back to the home page after a successful login through Keycloak. This is a poor UX, especially when a user was in the middle of viewing or searching a product.

So I fixed this by storing the current URL as a "redirect" tag in `localStorage` whenever the user clicks "Login". Once the user successfully logs in, it finds that tag and immediately returns the user to the page where the user left off. 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login links now include a redirect parameter and the app preserves the intended destination so users return to their original page after signing in.
  * Post-login flow reads the preserved destination and navigates users back when available; status text now shows a generic "Redirecting..." message.

* **Bug Fixes / Security**
  * Redirect handling enforces same-origin validation and rejects unsafe redirects, falling back to the homepage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->