### PR TITLE
fix: localize sort heading, use semantic color token, and add aria-expanded

### DIFF
--- a/src/lib/ui/SearchOptionsFooter.svelte
+++ b/src/lib/ui/SearchOptionsFooter.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { SORT_OPTIONS } from '$lib/const';
 
+	import { _ } from '$lib/i18n';
 	import IconMdiSort from '@iconify-svelte/mdi/sort';
 	import IconMdiFilter from '@iconify-svelte/mdi/filter';
 
@@ -20,7 +21,9 @@
 		<div
 			class="bg-base-100 border-base-200 animate-fade-in-up absolute right-0 bottom-14 left-0 z-50 max-h-80 w-full overflow-y-auto rounded-t-lg border py-2 shadow-xl"
 		>
-			<div class="my-2 px-4 pb-2 text-sm font-bold tracking-wide text-gray-500">SORT BY</div>
+			<div class="text-base-content/60 my-2 px-4 pb-2 text-sm font-bold tracking-wide">
+				{$_('search.sort_by_label')}
+			</div>
 			{#each SORT_OPTIONS as option (option.value)}
 				<button
 					class="hover:bg-base-200 flex w-full items-center gap-3 px-4 py-2 text-sm"
@@ -45,6 +48,7 @@
 				sortDropdownOpen = !sortDropdownOpen;
 			}}
 			aria-label="Sort"
+			aria-expanded={sortDropdownOpen}
 		>
 			<span class="flex items-center text-sm leading-tight font-semibold tracking-wide">
 				Sort <IconMdiSort class="ml-2 text-lg" />


### PR DESCRIPTION
### Description

Fixed three issues in the mobile sticky Sort/Filter footer (`SearchOptionsFooter.svelte`):

1. **Hardcoded string:** Replaced `"SORT BY"` with `$_('search.sort_by_label')` so the heading respects the user's locale
2. **Wrong color token:** Replaced `text-gray-500` with `text-base-content/60` (DaisyUI semantic token) so it adapts correctly to light/dark themes
3. **Missing accessibility attribute:** Added `aria-expanded={sortDropdownOpen}` to the Sort button so screen readers announce the dropdown's open/closed state

### Related issue(s) and discussion

- Fixes: #1274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * The sort dropdown now includes state indicators for its open/closed status.
* **Localization**
  * The sort label text is now localized and displays in the user's language.
* **Style**
  * Updated color styling for the sort options footer area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->