### PR TITLE
fix: log out redirect uri

### DIFF
--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -70,6 +70,8 @@ export const TAXONOMY_URL = (taxo: string, productType?: ProductType) =>
 export const OAUTH_IDP_BASE_URL = PUBLIC_AUTH_BASE_URL;
 export const OAUTH_CLIENT_ID = PUBLIC_AUTH_PKCE_ID;
 export const OAUTH_REDIRECT_URI = (url: URL) => url.origin + resolve('/oauth/login/callback');
+export const OAUTH_LOGOUT_REDIRECT_URI = (url: URL) =>
+	url.origin + resolve('/oauth/logout/callback');
 
 export const KEYCLOAK_REALM = PUBLIC_KEYCLOAK_REALM;
 export const KEYCLOAK_URL = `${OAUTH_IDP_BASE_URL}/realms/${KEYCLOAK_REALM}`;

--- a/src/routes/oauth/logout/+page.ts
+++ b/src/routes/oauth/logout/+page.ts
@@ -4,11 +4,11 @@ export const ssr = false;
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
-import { resolve } from '$app/paths';
+import { OAUTH_LOGOUT_REDIRECT_URI } from '$lib/const';
 import { createKeycloakApi } from '$lib/api';
 
 export const load: PageLoad = async ({ fetch }) => {
-	const redirectUri = window.location.origin + resolve('/oauth/logout/callback');
+	const redirectUri = OAUTH_LOGOUT_REDIRECT_URI(new URL(window.location.href));
 
 	const logoutUrl = createKeycloakApi(fetch, new URL(window.location.href)).logoutUrl({
 		// Keycloak requires the refresh token for logout, but since we are doing a front-channel logout, we can leave it empty

--- a/src/routes/oauth/logout/+page.ts
+++ b/src/routes/oauth/logout/+page.ts
@@ -8,7 +8,7 @@ import { resolve } from '$app/paths';
 import { createKeycloakApi } from '$lib/api';
 
 export const load: PageLoad = async ({ fetch }) => {
-	const redirectUri = resolve('/oauth/logout/callback');
+	const redirectUri = window.location.origin + resolve('/oauth/logout/callback');
 
 	const logoutUrl = createKeycloakApi(fetch, new URL(window.location.href)).logoutUrl({
 		// Keycloak requires the refresh token for logout, but since we are doing a front-channel logout, we can leave it empty


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description
When clicking on the log out button, users are not able to log out successfully and the page is redirecting to an invalid uri.
This PR aims to fix this

### Screenshot or video
#### Before
<img width="1680" height="338" alt="Screenshot 2026-04-07 at 14 30 09" src="https://github.com/user-attachments/assets/3de31e41-1007-46d1-b602-1119a1281332" />

#### After (Successfully logged out)
<img width="1040" height="213" alt="Screenshot 2026-04-07 at 14 37 06" src="https://github.com/user-attachments/assets/ac13903c-9f6c-467f-a0e7-d0a2f28f9414" />



- Fixes:  #1295


### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logout redirect construction so the app now consistently builds a full callback URL (including origin), ensuring users are reliably returned to the app after signing out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->