### PR TITLE
refactor: centralize Open Prices URL handling into constants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,6 @@ PUBLIC_AUTH_BASE_URL=https://auth.openfoodfacts.net
 PUBLIC_AUTH_PKCE_ID=explorer
 PUBLIC_KEYCLOAK_REALM=openfoodfacts
 PUBLIC_PRICES_API_URL=https://prices.openfoodfacts.net
-PUBLIC_OPEN_PRICES_BASE_URL=https://prices.openfoodfacts.org
 
 PUBLIC_ROBOTOFF_URL=https://robotoff.openfoodfacts.net
 PUBLIC_IMAGES_URL=https://images.openfoodfacts.net

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ PUBLIC_AUTH_BASE_URL=https://auth.openfoodfacts.net
 PUBLIC_AUTH_PKCE_ID=explorer
 PUBLIC_KEYCLOAK_REALM=openfoodfacts
 PUBLIC_PRICES_API_URL=https://prices.openfoodfacts.net
+PUBLIC_OPEN_PRICES_BASE_URL=https://prices.openfoodfacts.org
 
 PUBLIC_ROBOTOFF_URL=https://robotoff.openfoodfacts.net
 PUBLIC_IMAGES_URL=https://images.openfoodfacts.net

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -8,7 +8,8 @@ const {
 	PUBLIC_NUTRIPATROL_URL,
 	PUBLIC_AUTH_BASE_URL,
 	PUBLIC_AUTH_PKCE_ID,
-	PUBLIC_KEYCLOAK_REALM
+	PUBLIC_KEYCLOAK_REALM,
+	PUBLIC_OPEN_PRICES_BASE_URL
 } = publicEnv;
 
 export {
@@ -83,11 +84,12 @@ export const SORT_OPTIONS = [
 	{ label: 'Recently modified products', value: '-last_modified_t' }
 ];
 
-export const OPEN_PRICES_BASE_URL = 'https://prices.openfoodfacts.org';
+export const OPEN_PRICES_BASE_URL =
+	PUBLIC_OPEN_PRICES_BASE_URL || 'https://prices.openfoodfacts.org';
 export const OPEN_PRICES_PRODUCT_URL = (barcode: string) =>
-	`${OPEN_PRICES_BASE_URL}/product/${barcode}`;
+	`${OPEN_PRICES_BASE_URL}/product/${encodeURIComponent(barcode)}`;
 export const OPEN_PRICES_PRODUCTS_URL = (barcode: string) =>
-	`${OPEN_PRICES_BASE_URL}/products/${barcode}`;
+	`${OPEN_PRICES_BASE_URL}/products/${encodeURIComponent(barcode)}`;
 
 export const MATOMO_SITE_ID = 17;
 export const MATOMO_HOST = 'https://analytics.openfoodfacts.org';

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -9,7 +9,7 @@ const {
 	PUBLIC_AUTH_BASE_URL,
 	PUBLIC_AUTH_PKCE_ID,
 	PUBLIC_KEYCLOAK_REALM,
-	PUBLIC_OPEN_PRICES_BASE_URL
+	PUBLIC_PRICES_API_URL
 } = publicEnv;
 
 export {
@@ -84,12 +84,11 @@ export const SORT_OPTIONS = [
 	{ label: 'Recently modified products', value: '-last_modified_t' }
 ];
 
-export const OPEN_PRICES_BASE_URL =
-	PUBLIC_OPEN_PRICES_BASE_URL || 'https://prices.openfoodfacts.org';
+export const OPEN_PRICES_BASE_URL = PUBLIC_PRICES_API_URL || 'https://prices.openfoodfacts.org';
 export const OPEN_PRICES_PRODUCT_URL = (barcode: string) =>
-	`${OPEN_PRICES_BASE_URL}/product/${encodeURIComponent(barcode)}`;
+	`${OPEN_PRICES_BASE_URL}/product/${barcode}`;
 export const OPEN_PRICES_PRODUCTS_URL = (barcode: string) =>
-	`${OPEN_PRICES_BASE_URL}/products/${encodeURIComponent(barcode)}`;
+	`${OPEN_PRICES_BASE_URL}/products/${barcode}`;
 
 export const MATOMO_SITE_ID = 17;
 export const MATOMO_HOST = 'https://analytics.openfoodfacts.org';

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -83,6 +83,12 @@ export const SORT_OPTIONS = [
 	{ label: 'Recently modified products', value: '-last_modified_t' }
 ];
 
+export const OPEN_PRICES_BASE_URL = 'https://prices.openfoodfacts.org';
+export const OPEN_PRICES_PRODUCT_URL = (barcode: string) =>
+	`${OPEN_PRICES_BASE_URL}/product/${barcode}`;
+export const OPEN_PRICES_PRODUCTS_URL = (barcode: string) =>
+	`${OPEN_PRICES_BASE_URL}/products/${barcode}`;
+
 export const MATOMO_SITE_ID = 17;
 export const MATOMO_HOST = 'https://analytics.openfoodfacts.org';
 

--- a/src/lib/ui/BarcodeInfo.svelte
+++ b/src/lib/ui/BarcodeInfo.svelte
@@ -2,6 +2,7 @@
 	import JsBarcode from 'jsbarcode';
 	import Card from './Card.svelte';
 	import { createPricesApi } from '$lib/api/prices';
+	import { OPEN_PRICES_PRODUCT_URL } from '$lib/const';
 
 	let { code }: { code: string } = $props();
 
@@ -59,7 +60,7 @@
 				<li>
 					<a
 						class="text-xs text-green-600 hover:underline"
-						href={`https://prices.openfoodfacts.org/product/${code}`}
+						href={OPEN_PRICES_PRODUCT_URL(code)}
 						target="_blank"
 						rel="noopener noreferrer"
 						title="Open Prices"

--- a/src/lib/ui/Navbar.svelte
+++ b/src/lib/ui/Navbar.svelte
@@ -2,12 +2,13 @@
 	import { _ } from '$lib/i18n';
 	import { page } from '$app/state';
 	import { shouldBeContainer } from '$lib/layout';
+	import { OPEN_PRICES_BASE_URL } from '$lib/const';
 
 	const navItems = [
 		{ name: 'discover_link', href: '/static/discover' },
 		{ name: 'contribute_link', href: '/static/contribute' },
 		{ name: 'producers_link', href: '/static/producers' },
-		{ name: 'prices_link', href: 'https://prices.openfoodfacts.org' },
+		{ name: 'prices_link', href: OPEN_PRICES_BASE_URL },
 		{ name: 'folksonomy_link', href: '/folksonomy' },
 		{ name: 'facets_link', href: '/facets' }
 	];

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,7 +23,13 @@
 	import CompareFloatingButton from '$lib/ui/CompareFloatingButton.svelte';
 
 	import { _, getLocale, locale } from '$lib/i18n';
-	import { IMAGE_HOST, MATOMO_HOST, MATOMO_SITE_ID, ROBOTOFF_URL } from '$lib/const';
+	import {
+		IMAGE_HOST,
+		MATOMO_HOST,
+		MATOMO_SITE_ID,
+		OPEN_PRICES_BASE_URL,
+		ROBOTOFF_URL
+	} from '$lib/const';
 	import { userInfo } from '$lib/stores/user';
 	import { extractQuery } from '$lib/facets';
 	import { dev } from '$app/environment';
@@ -363,7 +369,7 @@
 		<a class="btn btn-outline link" href="/static/producers">
 			{$_('producers_link')}
 		</a>
-		<a class="btn btn-outline link" href="https://prices.openfoodfacts.org">
+		<a class="btn btn-outline link" href={OPEN_PRICES_BASE_URL}>
 			{$_('prices_link')}
 		</a>
 		<a class="btn btn-outline link" href="/folksonomy">

--- a/src/routes/products/[barcode]/Prices.svelte
+++ b/src/routes/products/[barcode]/Prices.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 
 	import { _ } from '$lib/i18n';
+	import { OPEN_PRICES_PRODUCTS_URL } from '$lib/const';
 
 	import Card from '$lib/ui/Card.svelte';
 	import type { PriceFull } from '@openfoodfacts/openfoodfacts-nodejs';
@@ -40,7 +41,7 @@
 
 	<div class="mt-4 text-end">
 		<a
-			href="https://prices.openfoodfacts.org/products/{barcode}"
+			href={OPEN_PRICES_PRODUCTS_URL(barcode)}
 			class="text-secondary link text-sm italic"
 			target="_blank"
 			rel="noopener noreferrer"


### PR DESCRIPTION
### Description

Centralized all hardcoded `prices.openfoodfacts.org` URLs into `src/lib/const.ts`. Added three constants (`OPEN_PRICES_BASE_URL`, `OPEN_PRICES_PRODUCT_URL`, `OPEN_PRICES_PRODUCTS_URL`) and updated 4 files to use them instead of inline URLs.

### Screenshot or video

N/A (no visual changes)

### Related issue(s) and discussion

- Fixes: #1294

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced hardcoded Open Prices links with a centralized, environment-configurable pricing endpoint and URL builders. All "Prices" links across the app now derive from this shared setting with a sensible default, making the destination configurable per deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->