### PR TITLE
fix: SSR rendering of the product list on the home page.

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 
 	import { _ } from '$lib/i18n';
-	import { createRobotoffApi, getProductReducedForCard, getBulkProductAttributes } from '$lib/api';
-	import { deduplicate } from '$lib/utils';
+
 	import { personalizedSearch } from '$lib/stores/preferencesStore';
-	import type { ProductAttributeForScoringGroup } from '$lib/api/product';
 
 	import Logo from '$lib/ui/Logo.svelte';
 	import ProductGrid from '$lib/ui/ProductGrid.svelte';
@@ -23,13 +20,6 @@
 	import type { PageProps } from './$types';
 	let { data }: PageProps = $props();
 
-	type ReducedState = Awaited<ReturnType<typeof getProducts>>[number];
-	let products: Promise<ReducedState[]> = $state(Promise.resolve([]));
-
-	let attributesByCode: Promise<Record<string, ProductAttributeForScoringGroup[]>> = $state(
-		Promise.resolve({})
-	);
-
 	import chocoBarIcon from '$lib/assets/chocolate-bar.svg';
 	import cheeseIcon from '$lib/assets/cheese.svg';
 	import butterIcon from '$lib/assets/butter.svg';
@@ -40,43 +30,7 @@
 
 	// random icons
 	heroIcons.sort(() => Math.random() - 0.5);
-
-	const INSIGHT_COUNT = 12;
 	const SKELETON_COUNT = 6;
-
-	async function getProducts() {
-		const roffApi = createRobotoffApi(fetch);
-		const { data: robotoffData } = await roffApi.insights({ count: INSIGHT_COUNT });
-
-		const insights = robotoffData?.insights ?? [];
-
-		const productsPromises = insights.map((question) =>
-			getProductReducedForCard(fetch, question.barcode.toString())
-		);
-		const productStates = await Promise.all(productsPromises);
-
-		// filter out products that failed to load
-		const products = productStates
-			.map((res) => res.data)
-			.filter((res) => res != null)
-			.filter((state) => state?.status !== 'failure');
-
-		// remove duplicate products
-		return deduplicate(products, (it) => it.product.code);
-	}
-
-	async function getAttributes(products: ReducedState[]) {
-		const productCodes = products.map((state) => state.product.code);
-		const attrs = await getBulkProductAttributes(fetch, productCodes);
-		return attrs;
-	}
-
-	onMount(() => {
-		products = getProducts();
-		products.then((prod) => {
-			attributesByCode = getAttributes(prod);
-		});
-	});
 </script>
 
 <svelte:head>
@@ -203,7 +157,7 @@
 	</div>
 
 	<div class="flex w-full">
-		{#await Promise.all([products, attributesByCode])}
+		{#await Promise.all([data.products, data.attributesByCode])}
 			<div
 				class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-2 xl:grid-cols-3"
 			>
@@ -211,10 +165,10 @@
 					<div class="skeleton h-36 w-full rounded-lg"></div>
 				{/each}
 			</div>
-		{:then [resolvedProducts, attributes]}
+		{:then [products, attributesByCode]}
 			<ProductGrid
-				products={resolvedProducts.map((state) => state.product)}
-				{attributes}
+				products={products.map((state) => state.product)}
+				attributes={attributesByCode}
 				sortByScore={$personalizedSearch.classifyProductsEnabled}
 			/>
 		{/await}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -2,6 +2,10 @@ import { createProductsApi } from '$lib/api';
 import { API_HOST } from '$lib/const';
 import { fetchRequired } from '$lib/promises';
 import type { PageLoad } from './$types';
+import { createRobotoffApi, getProductReducedForCard, getBulkProductAttributes } from '$lib/api';
+import { deduplicate } from '$lib/utils';
+
+const INSIGHT_COUNT = 12;
 
 async function getNumberOfProducts(fetch: typeof window.fetch): Promise<number> {
 	// The API doesn't provide a dedicated endpoint for getting the total number of products,
@@ -25,11 +29,36 @@ async function getNumberOfContributors(fetch: typeof window.fetch): Promise<numb
 	return data.count;
 }
 
+async function getProductsWithAttributes(fetch: typeof window.fetch) {
+	const roffApi = createRobotoffApi(fetch);
+	const { data: robotoffData } = await roffApi.insights({ count: INSIGHT_COUNT });
+	const insights = robotoffData?.insights ?? [];
+
+	const productsPromises = insights.map((question) =>
+		getProductReducedForCard(fetch, question.barcode.toString())
+	);
+	const productStates = await Promise.all(productsPromises);
+
+	const products = deduplicate(
+		productStates.map((res) => res.data).filter((res) => res?.status !== 'failure' && res != null),
+		(it) => it.product.code
+	);
+
+	const productCodes = products.map((state) => state.product.code);
+	const attributes = await getBulkProductAttributes(fetch, productCodes);
+
+	return { products, attributes };
+}
+
 export const load: PageLoad = async ({ fetch }) => {
 	const productCount = getNumberOfProducts(fetch);
 	const contributorCount = getNumberOfContributors(fetch);
+
+	const productsWithAttributes = getProductsWithAttributes(fetch);
 	return {
 		productCount,
-		contributorCount
+		contributorCount,
+		products: productsWithAttributes.then((res) => res.products),
+		attributesByCode: productsWithAttributes.then((res) => res.attributes)
 	};
 };


### PR DESCRIPTION
### Description
The home page has a list of products that will be displayed on the page mounted.
But the component is an SSR, therefore the onMount effect is disregarded.
This PR changes the onMount logic to load while keeping data fetching asynchronous.

#### Before
<img width="985" height="613" alt="Screenshot 2026-04-10 at 14 59 50" src="https://github.com/user-attachments/assets/4053b525-71eb-4c36-81ef-13e876a1772c" />

#### After
<img width="1160" height="632" alt="Screenshot 2026-04-10 at 15 00 09" src="https://github.com/user-attachments/assets/e3c78f4c-b1d3-449c-a126-7b26dde4036b" />


### Screenshot or video

<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- Fixes: #1300 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0
