### PR TITLE
fix: Do not parse API_HOST as URL

### DIFF
--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -24,8 +24,7 @@ export type PackagingComponent = {
 
 export function createProductsApi(fetch: typeof window.fetch) {
 	const fetchToUse = wrapFetchWithAuth(fetch);
-	const urlToUse = new URL(API_HOST);
-	return new OpenFoodFacts(fetchToUse, { host: urlToUse.toString() });
+	return new OpenFoodFacts(fetchToUse, { host: API_HOST });
 }
 
 export async function getBulkProductAttributes(


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description
The change provides a solution to double slash inside the facet/contributors.json uri.
The error accure when loading the home page, the account page, etc.

This is due to how the createProductsApi is passing the uri to the OpenFoodFacts class instance.
The uri provided ends with a slash, that result to a double slash when concatenated with the other part of the uri later. 

### Screenshot 
#### The image of the issue
<img width="748" height="96" alt="Screenshot 2026-04-13 at 17 05 54" src="https://github.com/user-attachments/assets/6560de5a-ed0a-48c1-b9fe-67dd288fc9d0" />





<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

### Related issue(s) and discussion
- Fixes: #1307


---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized API client initialization for improved code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->