### PR TITLE
feat: replace taxonomy type with sdk type

### DIFF
--- a/src/lib/api/taxonomy/types.ts
+++ b/src/lib/api/taxonomy/types.ts
@@ -1,4 +1,16 @@
-export type LocalizedString = Record<string, string>;
+import type { TaxoNode } from '@openfoodfacts/openfoodfacts-nodejs';
+
+export type {
+	LocalizedString,
+	Taxonomy,
+	TaxoNode,
+	Label,
+	Category,
+	Store,
+	Brand,
+	Language,
+	Country
+} from '@openfoodfacts/openfoodfacts-nodejs';
 
 export function getOrDefault<T>(localized: Record<string, T>, lang: string = 'en'): T | undefined {
 	const nonNullLang = lang?.toLowerCase() ?? 'en';
@@ -10,43 +22,7 @@ export function getOrDefault<T>(localized: Record<string, T>, lang: string = 'en
 	);
 }
 
-export type Taxonomy<T extends TaxoNode = TaxoNode> = Record<string, T>;
-
-export type TaxoNode = {
-	name: LocalizedString;
-	parents?: string[];
-	children?: string[];
-	wikidata_category?: LocalizedString;
-	wikidata?: LocalizedString;
-	synonyms?: Record<string, string[]>;
-};
-
-export type Label = TaxoNode & {
-	country: LocalizedString;
-	auth_url: LocalizedString;
-};
-
-export type Category = TaxoNode & {
-	agribalyse_food_code?: LocalizedString;
-	ciqual_food_name?: LocalizedString;
-};
-
-export type Store = TaxoNode & object;
-
-export type Brand = TaxoNode & object;
-
 export type Origin = TaxoNode & object;
-
-export type Country = TaxoNode & object;
-
-export type Language = TaxoNode & {
-	language_code_2: {
-		en: string;
-	};
-	language_code_3: {
-		en: string;
-	};
-};
 
 export const TAXONOMIES_NAMES: Record<string, string> = {
 	labels: 'Label',


### PR DESCRIPTION
### Description
This PR aims to reuse taxonomy type from the SDK inside the explorer.


---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal type definitions by aligning taxonomy types with the external openfoodfacts-nodejs library, improving code consistency and reducing duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->