### PR TITLE
fix(comparison): prevent incorrect best/worst when only one product has value

### DIFF
--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -197,13 +197,18 @@
 		const bestValue = getBestValue(products, nutrientKey);
 		const worstValue = getWorstValue(products, nutrientKey);
 
+		// Count how many products have this nutrient to avoid highlighting "best" when only one is compared
+		const comparableCount = products
+			.map((p) => getNutrientValue(p, nutrientKey))
+			.filter((v): v is number => v !== null).length;
+
 		return {
 			value,
 			formatted,
 			diff,
 			diffFormatted,
-			isBest: bestValue === value,
-			isWorst: value === worstValue && products.length > 1
+			isBest: comparableCount > 1 && bestValue === value,
+			isWorst: comparableCount > 1 && worstValue === value
 		};
 	}
 


### PR DESCRIPTION
## Summary
This PR addresses issue #1314 and #1315
When comparing products, the Best and Worst badges were being calculated based on `products.length > 1`, instead of the actual number of products that have valid numeric values for a given nutrient. This led to incorrect labeling when only one product had a value for a nutrient (e.g., fruits), where it was still marked as "Best" even though no real comparison existed.


## Problem
If only one product contains a numeric value for a nutrient, that product can still be marked as Best even though there is no meaningful comparison set. This results in misleading UI indicators.



## Expected Behavior
Best and Worst badges should only be shown when at least two products have valid numeric values for the same nutrient.

### Screenshots
## Before
<img width="1920" height="1020" alt="before" src="https://github.com/user-attachments/assets/4d6587cb-6915-4b30-a2bc-4217f947e14d" />


## After
<img width="1920" height="1020" alt="after" src="https://github.com/user-attachments/assets/a12d981e-e5b8-4f5e-9c5d-beb147422343" />


---
Fixes #1314 and #1315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined nutrient comparison accuracy to ensure items are only marked as best or worst when comparing two or more products with available nutrient data, preventing misleading highlights from incomplete product comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->