### PR TITLE
fix(compare/shared): prevent SSR barcode fanout DoS

### DIFF
--- a/src/routes/compare/shared/+page.ts
+++ b/src/routes/compare/shared/+page.ts
@@ -1,5 +1,32 @@
 import OpenFoodFacts, { type Product } from '@openfoodfacts/openfoodfacts-nodejs';
+import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
+
+const MAX_SHARED_COMPARE_BARCODES = 10;
+const MAX_PARALLEL_PRODUCT_FETCHES = 4;
+
+async function mapWithConcurrency<T, R>(
+	items: T[],
+	concurrency: number,
+	mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+	const results: R[] = new Array(items.length);
+	let nextIndex = 0;
+
+	const worker = async () => {
+		while (nextIndex < items.length) {
+			const currentIndex = nextIndex;
+			nextIndex += 1;
+			results[currentIndex] = await mapper(items[currentIndex]);
+		}
+	};
+
+	await Promise.all(
+		Array.from({ length: Math.min(concurrency, items.length) }, async () => worker())
+	);
+
+	return results;
+}
 
 export const load: PageLoad = async ({ url, fetch }) => {
 	const barcodesParam = url.searchParams.get('barcodes');
@@ -12,34 +39,47 @@ export const load: PageLoad = async ({ url, fetch }) => {
 		};
 	}
 
-	const barcodes = barcodesParam.split(',').filter(Boolean);
+	const barcodes = barcodesParam
+		.split(',')
+		.map((barcode) => barcode.trim())
+		.filter(Boolean);
+
+	if (barcodes.length > MAX_SHARED_COMPARE_BARCODES) {
+		throw error(
+			400,
+			`Too many barcodes in shared comparison: maximum is ${MAX_SHARED_COMPARE_BARCODES}.`
+		);
+	}
 
 	const offApi = new OpenFoodFacts(fetch);
 
-	// Fetch all products in parallel
-	const productPromises = barcodes.map(async (barcode) => {
-		try {
-			const { data, error } = await offApi.getProductV3(barcode.trim());
-			if (error) {
-				console.error(`Error fetching product ${barcode}:`, error);
-				return null;
-			} else if (!data) {
-				console.error(`No data returned for product ${barcode}`);
-				return null;
-			} else if (data.status === 'failure') {
-				console.error(`Product ${barcode} not found:`, data.errors);
+	const productsOrNull = await mapWithConcurrency(
+		barcodes,
+		MAX_PARALLEL_PRODUCT_FETCHES,
+		async (barcode) => {
+			try {
+				const { data, error } = await offApi.getProductV3(barcode);
+				if (error) {
+					console.error(`Error fetching product ${barcode}:`, error);
+					return null;
+				} else if (!data) {
+					console.error(`No data returned for product ${barcode}`);
+					return null;
+				} else if (data.status === 'failure') {
+					console.error(`Product ${barcode} not found:`, data.errors);
+					return null;
+				}
+				return data.product;
+			} catch (error) {
+				console.error(`Failed to fetch product ${barcode}:`, error);
 				return null;
 			}
-			return data.product;
-		} catch (error) {
-			console.error(`Failed to fetch product ${barcode}:`, error);
-			return null;
 		}
-	});
+	);
 
 	// @ts-expect-error - Product should not have { [key: string]: string }, because
 	// that means it ONLY has string values
-	const products: Product[] = (await Promise.all(productPromises)).filter((p) => p !== null);
+	const products: Product[] = productsOrNull.filter((p) => p !== null);
 
 	return {
 		products,

--- a/src/routes/compare/shared/+page.ts
+++ b/src/routes/compare/shared/+page.ts
@@ -1,5 +1,8 @@
 import OpenFoodFacts, { type Product } from '@openfoodfacts/openfoodfacts-nodejs';
+import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
+
+const MAX_SHARED_COMPARE_BARCODES = 10;
 
 export const load: PageLoad = async ({ url, fetch }) => {
 	const barcodesParam = url.searchParams.get('barcodes');
@@ -12,14 +15,24 @@ export const load: PageLoad = async ({ url, fetch }) => {
 		};
 	}
 
-	const barcodes = barcodesParam.split(',').filter(Boolean);
+	const barcodes = barcodesParam
+		.split(',')
+		.map((barcode) => barcode.trim())
+		.filter(Boolean);
+
+	if (barcodes.length > MAX_SHARED_COMPARE_BARCODES) {
+		throw error(
+			400,
+			`Too many barcodes in shared comparison: maximum is ${MAX_SHARED_COMPARE_BARCODES}.`
+		);
+	}
 
 	const offApi = new OpenFoodFacts(fetch);
 
 	// Fetch all products in parallel
 	const productPromises = barcodes.map(async (barcode) => {
 		try {
-			const { data, error } = await offApi.getProductV3(barcode.trim());
+			const { data, error } = await offApi.getProductV3(barcode);
 			if (error) {
 				console.error(`Error fetching product ${barcode}:`, error);
 				return null;


### PR DESCRIPTION
## Description

Mitigates an SSR request-fanout DoS risk in shared compare loading by strictly bounding server-side upstream fetch fanout.

Changes are intentionally limited to [src/routes/compare/shared/+page.ts](src/routes/compare/shared/+page.ts):
- Added a hard cap of 10 barcodes from the shared compare URL (`barcodes` query param).
- Rejects oversized barcode lists with HTTP 400.
- Replaced unbounded `Promise.all` fanout with a bounded concurrency mapper (max 4 parallel product fetches).

Fixes # (issue)

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I **did** use an AI Large Language Model, I have reviewed the generated code/text to ensure its accuracy, security, and relevance to the project's context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting `/gemini review` on this PR after it's been created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation limiting shared comparisons to 10 barcodes with a clear error message.

* **Improvements**
  * Improved barcode parsing to trim whitespace and ignore empty entries.
  * Ensured product lookup skips invalid/empty barcodes so comparisons only include valid items.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfoodfacts/openfoodfacts-explorer/pull/1321)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->