### PR TITLE
fix(compare/shared): validate EAN/UPC barcodes before fetch

### DIFF
--- a/src/routes/compare/shared/+page.ts
+++ b/src/routes/compare/shared/+page.ts
@@ -1,5 +1,59 @@
 import OpenFoodFacts, { type Product } from '@openfoodfacts/openfoodfacts-nodejs';
+import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
+
+function hasValidEan13CheckDigit(code: string): boolean {
+	const digits = code.split('').map(Number);
+	const checksum =
+		digits.slice(0, 12).reduce((sum, digit, index) => {
+			return sum + digit * (index % 2 === 0 ? 1 : 3);
+		}, 0) % 10;
+
+	const checkDigit = (10 - checksum) % 10;
+	return checkDigit === digits[12];
+}
+
+function hasValidUpcACheckDigit(code: string): boolean {
+	const digits = code.split('').map(Number);
+	const checksum =
+		digits.slice(0, 11).reduce((sum, digit, index) => {
+			return sum + digit * (index % 2 === 0 ? 3 : 1);
+		}, 0) % 10;
+
+	const checkDigit = (10 - checksum) % 10;
+	return checkDigit === digits[11];
+}
+
+function hasValidEan8CheckDigit(code: string): boolean {
+	const digits = code.split('').map(Number);
+	const checksum =
+		digits.slice(0, 7).reduce((sum, digit, index) => {
+			return sum + digit * (index % 2 === 0 ? 3 : 1);
+		}, 0) % 10;
+
+	const checkDigit = (10 - checksum) % 10;
+	return checkDigit === digits[7];
+}
+
+function isValidEanOrUpc(code: string): boolean {
+	if (!/^\d+$/.test(code)) {
+		return false;
+	}
+
+	if (code.length === 8) {
+		return hasValidEan8CheckDigit(code);
+	}
+
+	if (code.length === 12) {
+		return hasValidUpcACheckDigit(code);
+	}
+
+	if (code.length === 13) {
+		return hasValidEan13CheckDigit(code);
+	}
+
+	return false;
+}
 
 export const load: PageLoad = async ({ url, fetch }) => {
 	const barcodesParam = url.searchParams.get('barcodes');
@@ -12,14 +66,21 @@ export const load: PageLoad = async ({ url, fetch }) => {
 		};
 	}
 
-	const barcodes = barcodesParam.split(',').filter(Boolean);
+	const barcodes = barcodesParam
+		.split(',')
+		.map((barcode) => barcode.trim())
+		.filter((barcode) => barcode.length > 0);
+
+	if (!barcodes.every(isValidEanOrUpc)) {
+		error(400, 'Invalid barcodes parameter');
+	}
 
 	const offApi = new OpenFoodFacts(fetch);
 
 	// Fetch all products in parallel
 	const productPromises = barcodes.map(async (barcode) => {
 		try {
-			const { data, error } = await offApi.getProductV3(barcode.trim());
+			const { data, error } = await offApi.getProductV3(barcode);
 			if (error) {
 				console.error(`Error fetching product ${barcode}:`, error);
 				return null;


### PR DESCRIPTION
## Description

Adds strict barcode format validation in the shared compare loader before product fetch calls are attempted.

- Parses and trims barcodes query values.
- Accepts only valid numeric EAN-8, UPC-A, and EAN-13 codes.
- Verifies checksum digits for each supported format.
- Rejects malformed entries early with HTTP 400.

Why this check exists:
The shared link input is user-controlled. Without format checks, malformed tokens still trigger upstream fetch attempts and extra error logging. This change is a minimal fail-fast guard to avoid unnecessary calls for clearly invalid input.

Fixes # (issue)

N/A

---

## Checklist:

**Author Self-Review:**

- [x] I have performed a self-review of my own code.
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

**LLM Usage Disclosure:**
_Please be transparent about the use of AI assistance._

- [x] If I did use an AI Large Language Model, I have reviewed the generated code and text to ensure its accuracy, security, and relevance to the project context and licensing.

**Triggering Code Review:**

- You can request an AI-powered code review by commenting /gemini review on this PR after it is created.