### PR TITLE
feat: add contextual search links near barcode (#1265)

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -432,6 +432,14 @@
 				"add_price_btn": "Add a price on Open Prices"
 			}
 		},
+		"external": {
+			"openfoodfacts": "OpenFoodFacts",
+			"openfoodfacts_title": "View product on OpenFoodFacts",
+			"barcode_lookup": "Barcode Lookup",
+			"barcode_lookup_title": "Search barcode on Barcode Lookup",
+			"open_prices": "Open Prices",
+			"open_prices_title": "View product prices on Open Prices"
+		},
 		"prices": {
 			"no_prices_found": "No prices found for this product",
 			"loading": "Loading prices…",

--- a/src/lib/i18n/messages/it-IT.json
+++ b/src/lib/i18n/messages/it-IT.json
@@ -160,6 +160,14 @@
 			"comment_placeholder": "Add a comment to this edit",
 			"save_btn": "Save",
 			"debug": "Debug"
+		},
+		"external": {
+			"openfoodfacts": "OpenFoodFacts",
+			"openfoodfacts_title": "View product on OpenFoodFacts",
+			"barcode_lookup": "Barcode Lookup",
+			"barcode_lookup_title": "Search barcode on Barcode Lookup",
+			"open_prices": "Open Prices",
+			"open_prices_title": "View product prices on Open Prices"
 		}
 	},
 	"errors": {

--- a/src/lib/ui/ContextualLinks.svelte
+++ b/src/lib/ui/ContextualLinks.svelte
@@ -23,7 +23,7 @@
 
 	<a
 		class="btn btn-outline"
-		href={`https://www.barcodelookup.com/${encodedBarcode}`}
+		href={`https://www.barcodelookup.com/?query=${encodedBarcode}`}
 		target="_blank"
 		rel="noopener noreferrer"
 		title={$_('product.external.barcode_lookup_title')}

--- a/src/lib/ui/ContextualLinks.svelte
+++ b/src/lib/ui/ContextualLinks.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { _ } from '$lib/i18n';
+
+	interface Props {
+		barcode: string;
+	}
+
+	let { barcode }: Props = $props();
+
+	let encodedBarcode = $derived(barcode ? encodeURIComponent(barcode) : '');
+</script>
+
+<div class="my-4 flex flex-wrap gap-2">
+	<a
+		class="btn btn-outline"
+		href={`https://world.openfoodfacts.org/product/${encodedBarcode}`}
+		target="_blank"
+		rel="noopener noreferrer"
+		title={$_('product.external.openfoodfacts_title')}
+	>
+		{$_('product.external.openfoodfacts')}
+	</a>
+
+	<a
+		class="btn btn-outline"
+		href={`https://www.barcodelookup.com/${encodedBarcode}`}
+		target="_blank"
+		rel="noopener noreferrer"
+		title={$_('product.external.barcode_lookup_title')}
+	>
+		{$_('product.external.barcode_lookup')}
+	</a>
+
+	<a
+		class="btn btn-outline"
+		href={`https://prices.openfoodfacts.org/products/${encodedBarcode}`}
+		target="_blank"
+		rel="noopener noreferrer"
+		title={$_('product.external.open_prices_title')}
+	>
+		{$_('product.external.open_prices')}
+	</a>
+</div>

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -159,10 +159,6 @@
 <div class="flex flex-col gap-4">
 	<ProductHeader {product} taxonomies={data.taxo} />
 
-	{#if showBarcode && product.code != null}
-		<BarcodeInfo code={product.code} />
-	{/if}
-
 	<robotoff-contribution-message product-code={product.code} is-logged-in={$userInfo != null}
 	></robotoff-contribution-message>
 

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -13,7 +13,6 @@
 
 	import Gs1Country from './GS1Country.svelte';
 	import ProductHeader from './ProductHeader.svelte';
-	import BarcodeInfo from '$lib/ui/BarcodeInfo.svelte';
 
 	import type { PageProps } from './$types';
 	import Prices from './Prices.svelte';

--- a/src/routes/products/[barcode]/GS1Country.svelte
+++ b/src/routes/products/[barcode]/GS1Country.svelte
@@ -180,7 +180,17 @@
 	$effect(() => {
 		if (barcodeEl && barcode) {
 			try {
-				JsBarcode(barcodeEl, barcode, { format: 'ean13' });
+				if (!barcode || isNaN(Number(barcode))) return;
+
+				let format = 'ean13';
+
+				if (barcode.length === 12) {
+					format = 'upc';
+				} else if (barcode.length === 8) {
+					format = 'ean8';
+				}
+
+				JsBarcode(barcodeEl, barcode, { format });
 			} catch (e) {
 				console.error(e);
 			}

--- a/src/routes/products/[barcode]/GS1Country.svelte
+++ b/src/routes/products/[barcode]/GS1Country.svelte
@@ -3,7 +3,6 @@
 
 	import ContextualLinks from '$lib/ui/ContextualLinks.svelte';
 	import JsBarcode from 'jsbarcode';
-	import { onMount } from 'svelte';
 
 	interface Props {
 		barcode: string;
@@ -177,9 +176,14 @@
 	}
 
 	let country = $derived(getCountry(barcode));
-	onMount(() => {
-		if (barcode) {
-			JsBarcode('#gs1-barcode', barcode, { format: 'ean13' });
+	let barcodeEl: SVGSVGElement | null = null;
+	$effect(() => {
+		if (barcodeEl && barcode) {
+			try {
+				JsBarcode(barcodeEl, barcode, { format: 'ean13' });
+			} catch (e) {
+				console.error(e);
+			}
 		}
 	});
 </script>
@@ -217,9 +221,8 @@
 			</div>
 		</div>
 
-		<div class="flex flex-col items-center items-end md:items-end">
-			<svg id="gs1-barcode" class="h-auto w-44"></svg>
-
+		<div class="flex flex-col items-end">
+			<svg bind:this={barcodeEl} class="h-auto w-44"></svg>
 			<p class="text-secondary mt-4 text-end text-sm italic">
 				Source: <a
 					class="link"

--- a/src/routes/products/[barcode]/GS1Country.svelte
+++ b/src/routes/products/[barcode]/GS1Country.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import Card from '$lib/ui/Card.svelte';
 
+	import ContextualLinks from '$lib/ui/ContextualLinks.svelte';
+	import JsBarcode from 'jsbarcode';
+	import { onMount } from 'svelte';
+
 	interface Props {
 		barcode: string;
 	}
@@ -173,37 +177,57 @@
 	}
 
 	let country = $derived(getCountry(barcode));
+	onMount(() => {
+		if (barcode) {
+			JsBarcode('#gs1-barcode', barcode, { format: 'ean13' });
+		}
+	});
 </script>
 
 <Card>
 	<h1 class="my-4 text-2xl font-bold sm:text-4xl">Barcode information</h1>
 
-	<div>
-		<div class="flex items-center gap-2">
-			<div class="text-xl sm:text-3xl">{getFlagEmoji(country.code)}</div>
-			<p class="sm:text-md text-xs">
-				<strong>GS1 Country:</strong>
-				{country.name}
-			</p>
+	<p class="text-sm text-gray-600">
+		<strong>Barcode:</strong>
+		{barcode}
+	</p>
+	<div class="flex flex-col items-center justify-between gap-4 md:flex-row">
+		<div class="w-full md:w-auto">
+			<div class="flex items-center gap-2">
+				<div class="text-xl sm:text-3xl">{getFlagEmoji(country.code)}</div>
+				<p class="sm:text-md text-xs">
+					<strong>GS1 Country:</strong>
+					{country.name}
+				</p>
+			</div>
+
+			<div class="my-4">
+				<a
+					class="btn btn-secondary"
+					href={`https://www.gs1.org/services/verified-by-gs1/results?gtin=${barcode}`}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					Get more information from GS1
+				</a>
+			</div>
+
+			<div class="mt-3">
+				<ContextualLinks {barcode} />
+			</div>
 		</div>
 
-		<div class="my-4">
-			<a
-				class="btn btn-secondary"
-				href="https://www.gs1.org/services/verified-by-gs1/results?gtin={barcode}"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				Get more information from GS1
-			</a>
+		<div class="flex flex-col items-center items-end md:items-end">
+			<svg id="gs1-barcode" class="h-auto w-44"></svg>
+
+			<p class="text-secondary mt-4 text-end text-sm italic">
+				Source: <a
+					class="link"
+					href="https://www.gs1.org/standards/id-keys/company-prefix"
+					target="_blank"
+					rel="noopener noreferrer">GS1</a
+				>
+			</p>
 		</div>
-		<p class="text-secondary mt-4 text-end text-sm italic">
-			Source: <a
-				class="link"
-				href="https://www.gs1.org/standards/id-keys/company-prefix"
-				target="_blank"
-				rel="noopener noreferrer">GS1</a
-			>
-		</p>
 	</div>
 </Card>


### PR DESCRIPTION
## Add contextual search links near barcode (#1265)

This PR adds contextual external links near the GS1 barcode section so users can quickly check product information on other platforms.

### What’s included
- Added a small reusable component for external links (ContextualLinks.svelte)
- Integrated it into the GS1 barcode card
- Added links to:
  - OpenFoodFacts
  - Barcode Lookup
  - Open Prices
- Used encodeURIComponent to safely pass barcode values
- Added translation support for link labels
- Replaced duplicate BarcodeInfo component usage
### UI changes

The links are now placed directly below the GS1 section to keep them close to the barcode and avoid scattering related actions.

### After

<br>
<img width="1902" height="940" alt="Final Image of barcode information" src="https://github.com/user-attachments/assets/a3f4fa80-92de-4e6b-9d96-c332680d511c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EAN-13 barcode visualization on product pages.
  * Added contextual external links to OpenFoodFacts, barcode lookup, and Open Prices.
  * Added English and Italian labels/titles for these external integrations.

* **Chores**
  * Removed the previous inline BarcodeInfo rendering from the product page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->