### PR TITLE
feat(explore): visually differentiate hero search bar with typing animation and glow

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -517,7 +517,14 @@
 		"random_product": "Random Product",
 		"random_product_desc": "Feeling lucky? Discover a random product from our database.",
 		"learn_more": "Learn More",
-		"learn_more_desc": "Find out how Open Food Facts works and how you can help."
+		"learn_more_desc": "Find out how Open Food Facts works and how you can help.",
+		"placeholders": {
+			"search_product": "Search for a product...",
+			"try_nutella": "Try \"Nutella\"",
+			"search_brand": "Search by brand...",
+			"try_organic_pasta": "Try \"organic pasta\"",
+			"search_barcode": "Search by barcode..."
+		}
 	},
 	"compare": {
 		"page_title": "Compare Products",

--- a/src/lib/ui/SearchBar.svelte
+++ b/src/lib/ui/SearchBar.svelte
@@ -9,11 +9,13 @@
 		searchQuery = $bindable(''),
 		minQueryLength = 3,
 		loading = false,
+		placeholder = null as string | null,
 		onSearch
 	}: {
 		searchQuery?: string;
 		minQueryLength?: number;
 		loading?: boolean;
+		placeholder?: string | null;
 		onSearch: (query: string) => void;
 	} = $props();
 
@@ -147,7 +149,7 @@
 				type="text"
 				bind:value={searchQuery}
 				class="input join-item input-bordered w-full"
-				placeholder={$_('search.placeholder')}
+				placeholder={placeholder ?? $_('search.placeholder')}
 				disabled={loading}
 				aria-label={$_('search.placeholder')}
 				onkeydown={handleKeyDown}

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -5,25 +5,72 @@
 	import type { PageProps } from './$types';
 	import WcProductCard from '$lib/ui/WcProductCard.svelte';
 	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
 
 	let { data }: PageProps = $props();
 	let searchQuery = $state('');
+	let typingPlaceholder = $state(' ');
+
+	const placeholders = [
+		'Search for a product...',
+		'Try "Nutella"',
+		'Search by brand...',
+		'Try "organic pasta"',
+		'Search by barcode...'
+	];
+
+	onMount(() => {
+		let phraseIndex = 0;
+		let charIndex = 0;
+		let isDeleting = false;
+		let timeout: ReturnType<typeof setTimeout>;
+
+		function tick() {
+			const current = placeholders[phraseIndex];
+
+			if (!isDeleting) {
+				typingPlaceholder = current.slice(0, charIndex + 1);
+				charIndex++;
+
+				if (charIndex === current.length) {
+					isDeleting = true;
+					timeout = setTimeout(tick, 1500);
+					return;
+				}
+				timeout = setTimeout(tick, 80);
+			} else {
+				typingPlaceholder = current.slice(0, charIndex - 1);
+				charIndex--;
+
+				if (charIndex === 0) {
+					isDeleting = false;
+					phraseIndex = (phraseIndex + 1) % placeholders.length;
+					timeout = setTimeout(tick, 400);
+					return;
+				}
+				timeout = setTimeout(tick, 40);
+			}
+		}
+
+		tick();
+		return () => clearTimeout(timeout);
+	});
 
 	function handleSearch(query: string) {
 		goto(`/search?q=${encodeURIComponent(query)}`);
 	}
 </script>
 
-<section class="bg-base-100 flex flex-col items-center justify-center px-4 py-12">
+<section class="bg-base-100 flex flex-col items-center justify-center px-4 py-16">
 	<Logo />
-	<h1 class="text-primary mb-2 text-center text-4xl font-bold drop-shadow-lg sm:text-5xl">
+	<h1 class="text-primary mb-3 text-center text-4xl font-bold drop-shadow-lg sm:text-5xl">
 		{$_('explore.title')}
 	</h1>
-	<p class="text-primary mb-6 max-w-2xl text-center text-lg">
+	<p class="text-base-content/60 mb-8 max-w-2xl text-center text-lg">
 		{$_('explore.subtitle')}
 	</p>
-	<div class="mb-8 flex w-full max-w-xl justify-center">
-		<SearchBar bind:searchQuery onSearch={handleSearch} />
+	<div data-hero-search class="flex w-full max-w-2xl justify-center">
+		<SearchBar bind:searchQuery onSearch={handleSearch} placeholder={typingPlaceholder} />
 	</div>
 </section>
 
@@ -52,3 +99,14 @@
 		</div>
 	{/if}
 </div>
+
+<style>
+	[data-hero-search] :global(.input) {
+		border-color: var(--color-secondary);
+		box-shadow: 0 0 12px color-mix(in oklch, var(--color-secondary) 25%, transparent);
+	}
+
+	[data-hero-search] :global(.input:focus) {
+		box-shadow: 0 0 20px color-mix(in oklch, var(--color-secondary) 40%, transparent);
+	}
+</style>

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -12,11 +12,11 @@
 	let typingPlaceholder = $state(' ');
 
 	const placeholders = [
-		'Search for a product...',
-		'Try "Nutella"',
-		'Search by brand...',
-		'Try "organic pasta"',
-		'Search by barcode...'
+		$_('explore.placeholders.search_product'),
+		$_('explore.placeholders.try_nutella'),
+		$_('explore.placeholders.search_brand'),
+		$_('explore.placeholders.try_organic_pasta'),
+		$_('explore.placeholders.search_barcode')
 	];
 
 	onMount(() => {


### PR DESCRIPTION
### Description

Visually differentiated the hero search bar on the `/explore` page from the global navbar search bar:

1. **Typing animation placeholder** — The hero search bar cycles through animated placeholder suggestions (*"Search for a product..."*, *"Try "Nutella""*, etc.) with a typewriter effect, while the navbar keeps its static "Query or barcode" placeholder
2. **Subtle glow effect** — Added a secondary-colored border and soft box-shadow glow around the hero search input, with an intensified glow on focus
3. **Added `placeholder` prop to `SearchBar`** — The `SearchBar` component now accepts an optional `placeholder` prop, falling back to the i18n default when not provided

### Screens
<img width="1470" height="880" alt="Screenshot 2026-04-19 at 10 02 31 AM" src="https://github.com/user-attachments/assets/f4235df0-acd1-4a46-8a63-b6802738daf1" />
hot or video



### Related issue(s) and discussion

- Fixes: #1291

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search bar now features an animated placeholder that cycles through suggested search phrases on the explore page.
  * Search bar placeholder text is now customizable.

* **Improvements**
  * Enhanced visual styling of the search input with improved focus states and visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->