### PR TITLE
feat: add smooth slide transition to mobile search bar toggle

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
 
 	import { goto } from '$app/navigation';
 	import { navigating, page } from '$app/state';
+	import { slide } from 'svelte/transition';
 
 	import Logo from '$lib/ui/Logo.svelte';
 	import Navbar from '$lib/ui/Navbar.svelte';
@@ -354,7 +355,7 @@
 	</div>
 
 	{#if searchActive}
-		<div class="flex justify-center">
+		<div class="flex justify-center" transition:slide={{ duration: 200 }}>
 			<SearchBar bind:searchQuery onSearch={gotoProductsSearch} loading={isSearching} />
 		</div>
 	{/if}


### PR DESCRIPTION
### Description

Added a smooth `slide` transition (200ms) to the mobile navbar search bar toggle. Previously, tapping the search icon caused the search bar to appear/disappear abruptly with no animation. Now it slides down and up smoothly.

**Changes:**
- Imported `slide` from `svelte/transition` in `+layout.svelte`
- Added `transition:slide={{ duration: 200 }}` to the mobile search bar container

This is a global improvement that applies to all pages, not specific to any route.

### Screenshot or video


https://github.com/user-attachments/assets/3b4ac11a-3cd9-49b9-a27a-be69ccdbc7a0



### Related issue(s) and discussion

- Fixes: #1291

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Mobile search bar now animates smoothly when toggling open and closed, improving visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->