### PR TITLE
fix: nutrition information check/uncheck logic

### DIFF
--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -102,11 +102,8 @@
 		if (input.checked) {
 			product = {
 				...product,
-				no_nutrition_data: true,
-				nutriments: {} as Nutriments,
-				serving_size: ''
+				no_nutrition_data: true
 			};
-			additionalNutrients = [];
 		} else {
 			product = {
 				...product,

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -99,17 +99,10 @@
 	function handleNoNutritionData(event: Event) {
 		const input = event.currentTarget as HTMLInputElement;
 
-		if (input.checked) {
-			product = {
-				...product,
-				no_nutrition_data: true
-			};
-		} else {
-			product = {
-				...product,
-				no_nutrition_data: false
-			};
-		}
+		product = {
+			...product,
+			no_nutrition_data: input.checked
+		};
 	}
 
 	const bySeverity = (a: Issue, b: Issue) => {

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -99,10 +99,20 @@
 	function handleNoNutritionData(event: Event) {
 		const input = event.currentTarget as HTMLInputElement;
 
-		product = {
-			...product,
-			no_nutrition_data: input.checked
-		};
+		if (input.checked) {
+			product = {
+				...product,
+				no_nutrition_data: true,
+				nutriments: {} as Nutriments,
+				serving_size: ''
+			};
+			additionalNutrients = [];
+		} else {
+			product = {
+				...product,
+				no_nutrition_data: false
+			};
+		}
 	}
 
 	const bySeverity = (a: Issue, b: Issue) => {
@@ -254,29 +264,6 @@
 	<div>
 		<div class="space-y-4">
 			<div>
-				<label>
-					<span class="label mb-2 flex items-center gap-2 leading-0">
-						{$_('product.edit.serving_size')}
-						<InfoTooltip text={$_('product.edit.tooltips.serving_size')} />
-						{#if servingSizeIssue}
-							{@render issueTooltip(servingSizeIssue)}
-						{/if}
-					</span>
-					<input
-						id="serving-size-input"
-						type="text"
-						class={['input input-bordered w-full text-sm sm:text-base', servingSizeInputClass]}
-						value={product.serving_size ?? ''}
-						oninput={handleServingSize}
-						placeholder={servingSizePlaceholder}
-					/>
-				</label>
-				{#if servingSizeIssue}
-					{@render issueAlert(servingSizeIssue)}
-				{/if}
-			</div>
-
-			<div>
 				<label class="label">
 					<input
 						type="checkbox"
@@ -289,6 +276,31 @@
 					</span>
 				</label>
 			</div>
+
+			{#if !product.no_nutrition_data}
+				<div>
+					<label>
+						<span class="label mb-2 flex items-center gap-2 leading-0">
+							{$_('product.edit.serving_size')}
+							<InfoTooltip text={$_('product.edit.tooltips.serving_size')} />
+							{#if servingSizeIssue}
+								{@render issueTooltip(servingSizeIssue)}
+							{/if}
+						</span>
+						<input
+							id="serving-size-input"
+							type="text"
+							class={['input input-bordered w-full text-sm sm:text-base', servingSizeInputClass]}
+							value={product.serving_size ?? ''}
+							oninput={handleServingSize}
+							placeholder={servingSizePlaceholder}
+						/>
+					</label>
+					{#if servingSizeIssue}
+						{@render issueAlert(servingSizeIssue)}
+					{/if}
+				</div>
+			{/if}
 		</div>
 
 		{#if !product.no_nutrition_data}


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description


"No nutrition information on the product" toggle has been moved to the top of the component (above the serving size) and now toggling it - hides the serving size, and clears all nutrient data. This ensures that the database doesn't end up with "hidden" nutrition values while the product is flagged as having none.

### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- Fixes: #1345 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] if you (a human) has done this. If this is done by LLM, please disclose it in the next session -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Serving size input, its tooltip, and validation alert are now displayed only when nutrition data is enabled, removing unnecessary fields from the editor.
  * Toggling "no nutrition data" updates only that flag and no longer clears other nutrition fields, preventing unintended data loss.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfoodfacts/openfoodfacts-explorer/pull/1370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->