### PR TITLE
fix(HtmlPurify): enable RETURN_TRUSTED_TYPE in sanitize config

### DIFF
--- a/src/lib/ui/HtmlPurify.svelte
+++ b/src/lib/ui/HtmlPurify.svelte
@@ -5,7 +5,8 @@
 		dirty: string;
 		config?: Parameters<typeof sanitize>[1];
 	};
-	let { dirty, config = { USE_PROFILES: { html: true } } }: Props = $props();
+	let { dirty, config = { USE_PROFILES: { html: true }, RETURN_TRUSTED_TYPE: true } }: Props =
+		$props();
 
 	let sanitizedHtml = $derived(sanitize(dirty, config));
 </script>


### PR DESCRIPTION
Use `RETURN_TRUSTED_TYPE: true` in `HtmlPurify.svelte`, to future-proof the component for when we will add a trusted types CSP policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTML purification component configuration to enable enhanced security settings by default, improving content handling and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfoodfacts/openfoodfacts-explorer/pull/1382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->