### PR TITLE
fix(ui): hide unknown brand badges when taxonomy lookup fails

### DIFF
--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -94,7 +94,7 @@
 	}
 </script>
 
-v{#snippet loadingTaxonomy()}
+{#snippet loadingTaxonomy()}
 	<div class="skeleton h-6 w-full"></div>
 {/snippet}
 

--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -94,7 +94,7 @@
 	}
 </script>
 
-{#snippet loadingTaxonomy()}
+v{#snippet loadingTaxonomy()}
 	<div class="skeleton h-6 w-full"></div>
 {/snippet}
 
@@ -192,9 +192,13 @@
 							{@render loadingTaxonomy()}
 						{:then brands}
 							{#each product.brands_tags ?? [] as tag, i (i)}
-								<a class="badge wrap-break-word" href="/facets/brands/{tag}">
-									{localizedTaxoName(brands, tag)}
-								</a>
+								{@const name = localizedTaxoName(brands, tag)}
+								<!-- Skip tags that failed taxonomy lookup (shown as "? brand") -->
+								{#if name && !name.startsWith('?')}
+									<a class="badge wrap-break-word" href="/facets/brands/{tag}">
+										{name}
+									</a>
+								{/if}
 							{/each}
 						{/await}
 					</div>


### PR DESCRIPTION
## Problem
When a product has no brand or the brand tag is not found in the 
taxonomy, the badge displays "? brand" which looks broken and 
confusing to users.

## Fix
Skip rendering the brand badge if the resolved name starts with "?"
(which indicates a failed taxonomy lookup).

## Related Issue
Fixes #1409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Product page now properly handles failed brand lookups by hiding invalid or missing brand badges, providing users with a cleaner display and more accurate product information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfoodfacts/openfoodfacts-explorer/pull/1410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->