### PR TITLE
feat(ui): display manufacturing places as badges in product header

### DIFF
--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -94,7 +94,7 @@
 	}
 </script>
 
-v{#snippet loadingTaxonomy()}
+{#snippet loadingTaxonomy()}
 	<div class="skeleton h-6 w-full"></div>
 {/snippet}
 

--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -256,6 +256,17 @@
 				{/if}
 
 				<!-- Traceability Codes -->
+				<!-- Manufacturing Places -->
+				{#if product.manufacturing_places}
+					<div class="mb-2">
+						<div class="text-secondary mb-2 text-sm font-bold">Manufacturing Places</div>
+						<div class="flex flex-wrap justify-center gap-1 md:justify-start">
+							{#each product.manufacturing_places.split(',').filter((p) => p.trim()) as place}
+								<span class="badge wrap-break-word">{place.trim()}</span>
+							{/each}
+						</div>
+					</div>
+				{/if}
 				{#if product.emb_codes_tags != null && product.emb_codes_tags.length > 0}
 					<div class="mb-2">
 						<div class="text-secondary mb-2 text-sm font-bold">

--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -94,7 +94,7 @@
 	}
 </script>
 
-{#snippet loadingTaxonomy()}
+v{#snippet loadingTaxonomy()}
 	<div class="skeleton h-6 w-full"></div>
 {/snippet}
 
@@ -192,9 +192,13 @@
 							{@render loadingTaxonomy()}
 						{:then brands}
 							{#each product.brands_tags ?? [] as tag, i (i)}
-								<a class="badge wrap-break-word" href="/facets/brands/{tag}">
-									{localizedTaxoName(brands, tag)}
-								</a>
+								{@const name = localizedTaxoName(brands, tag)}
+								<!-- Skip tags that failed taxonomy lookup (shown as "? brand") -->
+								{#if name && !name.startsWith('?')}
+									<a class="badge wrap-break-word" href="/facets/brands/{tag}">
+										{name}
+									</a>
+								{/if}
 							{/each}
 						{/await}
 					</div>


### PR DESCRIPTION
## Problem
Manufacturing places were not displayed anywhere on the product 
page, even though the data exists in the API.

## Fix
Added a new section in ProductHeader.svelte that displays 
manufacturing places as badges, consistent with how other 
fields like brands and labels are displayed.

## Related Issue
Fixes #1367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Manufacturing Places metadata block displaying product manufacturing locations as individual badges.

* **Bug Fixes**
  * Improved brand taxonomy rendering to display localized names accurately and prevent displaying invalid links for unknown entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfoodfacts/openfoodfacts-explorer/pull/1411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->