### PR TITLE
fix(vite): update image source path for webcomponents assets

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,8 +27,11 @@ export default defineConfig({
 		viteStaticCopy({
 			targets: [
 				{
-					src: 'node_modules/@openfoodfacts/openfoodfacts-webcomponents/dist/assets/**/*',
-					dest: 'assets/webcomponents'
+					src: 'node_modules/@openfoodfacts/openfoodfacts-webcomponents/dist/assets/images/**/*',
+					dest: 'assets/webcomponents',
+					rename: {
+						stripBase: 6
+					}
 				}
 			]
 		})


### PR DESCRIPTION
Fix https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced build-time asset copying by only including webcomponent images in the public assets output.
  * Normalized copied asset paths so webcomponent images are placed consistently under the assets/webcomponents location, improving asset organization and build efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfoodfacts/openfoodfacts-explorer/pull/1421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->