### PR TITLE
fix(edit): support clearing nutrient values

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -387,6 +387,7 @@
 				"save_error": "Failed to save product. Please try again."
 			},
 			"add_nutrient": "Add Nutrient",
+			"remove_nutrient": "Remove nutrient",
 			"debug": "Debug",
 			"si_kilojoules": "kJ",
 			"si_kilocalories": "kcal",

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -190,9 +190,13 @@
 	);
 
 	function wipeAllNutrientValues() {
+		if (!product.nutriments) return;
+
 		product = {
 			...product,
-			nutriments: {} as Nutriments
+			nutriments: Object.fromEntries(
+				Object.keys(product.nutriments).map((key) => [key, '' as string | number])
+			) as Nutriments
 		};
 		additionalNutrients = [];
 	}
@@ -462,7 +466,7 @@
 							type="button"
 							class="btn btn-error join-item"
 							aria-label="Remove nutrient"
-							disabled={product.nutriments?.[nutrient] != null}
+							disabled={typeof product.nutriments?.[nutrient] === 'number'}
 							onclick={() => {
 								// Remove the nutrient from additional nutrients
 								additionalNutrients = additionalNutrients.filter((n) => n !== nutrient);

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -465,7 +465,7 @@
 						<button
 							type="button"
 							class="btn btn-error join-item"
-							aria-label="Remove nutrient"
+							aria-label={$_('product.edit.remove_nutrient', { default: 'Remove nutrient' })}
 							disabled={product.nutriments?.[nutrient] !== undefined &&
 								(product.nutriments?.[nutrient] as string | number) !== ''}
 							onclick={() => {

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -466,7 +466,8 @@
 							type="button"
 							class="btn btn-error join-item"
 							aria-label="Remove nutrient"
-							disabled={typeof product.nutriments?.[nutrient] === 'number'}
+							disabled={product.nutriments?.[nutrient] !== undefined &&
+								(product.nutriments?.[nutrient] as string | number) !== ''}
 							onclick={() => {
 								// Remove the nutrient from additional nutrients
 								additionalNutrients = additionalNutrients.filter((n) => n !== nutrient);

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -222,25 +222,18 @@
 	}
 
 	// Handle nutriment value changes
-	function updateNutriment(key: string, value: number | string | null) {
+	function updateNutriment(key: string, value: number | string) {
 		ensureNutriments();
 
-		if (value === null || value === '') {
-			product = {
-				...product,
-				nutriments: { ...product.nutriments, [key]: '' }
-			};
-		} else {
-			product = {
-				...product,
-				nutriments: { ...product.nutriments, [key]: value }
-			};
-		}
+		product = {
+			...product,
+			nutriments: { ...product.nutriments, [key]: value }
+		};
 	}
 
 	function handleNutrimentInput(e: Event, key: string) {
 		const target = e.currentTarget as HTMLInputElement;
-		updateNutriment(key, target.value !== '' ? Number(target.value) : null);
+		updateNutriment(key, target.value !== '' ? Number(target.value) : '');
 	}
 
 	async function submit() {

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -222,12 +222,14 @@
 	}
 
 	// Handle nutriment value changes
-	function updateNutriment(key: string, value: number | null) {
+	function updateNutriment(key: string, value: number | string | null) {
 		ensureNutriments();
 
-		if (value === null) {
-			delete product.nutriments[key];
-			product = { ...product, nutriments: { ...product.nutriments } }; // Trigger reactivity
+		if (value === null || value === '') {
+			product = {
+				...product,
+				nutriments: { ...product.nutriments, [key]: '' }
+			};
 		} else {
 			product = {
 				...product,
@@ -238,7 +240,7 @@
 
 	function handleNutrimentInput(e: Event, key: string) {
 		const target = e.currentTarget as HTMLInputElement;
-		updateNutriment(key, target.value ? Number(target.value) : null);
+		updateNutriment(key, target.value !== '' ? Number(target.value) : null);
 	}
 
 	async function submit() {


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description 

- Modified nutrient input handling in `+page.svelte` to save cleared inputs as empty strings `""` instead of deleting their keys from the state.
- Updated `wipeAllNutrientValues()` in `NutritionStep.svelte` to cleanly set all existing values to `""` to ensure the server deletes everything on a full wipe.
- Simplified the nutrient deletion button’s `disabled` state


### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- Fixes: #1387 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** <!-- e.g. GitHub Copilot (GPT-4o), Claude Sonnet 4.5, Cursor -->
  - **How it was used:** <!-- e.g. agentic (fully automated), autocomplete (suggestions accepted), review (checked my code) -->
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nutrient removal button remains enabled for empty fields and only disables for defined non-empty numeric values.
  * Clearing a nutrient field preserves the nutrient entry as an empty value (instead of deleting it), improving form stability.
  * Editing now correctly accepts numeric zero ("0") without treating it as empty.

* **Documentation**
  * Added English label for the "Remove nutrient" action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->