### PR TITLE
feat: add allergens and traces inputs to product edit form

### DIFF
--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -511,6 +511,11 @@ export type Product = ProductDataSection & {
 	emb_codes: string;
 	emb_codes_tags: string[];
 
+	allergens: string;
+	allergens_tags: string[];
+	traces: string;
+	traces_tags: string[];
+
 	nutriments: Nutriments;
 
 	no_nutrition_data?: boolean;

--- a/src/lib/api/taxonomy/types.ts
+++ b/src/lib/api/taxonomy/types.ts
@@ -9,7 +9,8 @@ export type {
 	Store,
 	Brand,
 	Language,
-	Country
+	Country,
+	Allergen
 } from '@openfoodfacts/openfoodfacts-nodejs';
 
 export function getOrDefault<T>(localized: Record<string, T>, lang: string = 'en'): T | undefined {
@@ -34,5 +35,6 @@ export const TAXONOMIES_NAMES: Record<string, string> = {
 	brands: 'Brand',
 	countries: 'Country',
 	origins: 'Origin',
-	languages: 'Language'
+	languages: 'Language',
+	allergens: 'Allergen'
 };

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -299,8 +299,12 @@
 				"traceability_code": "In this section, you can input codes related to packaging marks, identification marks or health marks.",
 				"countries": "Countries where the product is widely available (not including stores specialising in foreign products).",
 				"product_type": "Select the type of product: Food, Beauty, Pet Food, or Other.",
-				"empty_fiber": "Enter a hyphen (-) if the value is not present on the packaging."
+				"empty_fiber": "Enter a hyphen (-) if the value is not present on the packaging.",
+				"allergens": "List the allergens present in the product (e.g. Milk, Gluten, Eggs).",
+				"traces": "List any traces of allergens that may be present due to cross-contamination (e.g. Nuts, Soy)."
 			},
+			"allergens": "Allergens",
+			"traces": "Traces",
 			"main_language": "Main language",
 			"add_product": "Add product",
 			"nutrition_issues": "Nutrition issues",

--- a/src/lib/ui/AddProductForm.svelte
+++ b/src/lib/ui/AddProductForm.svelte
@@ -71,6 +71,7 @@
 		originNames: string[];
 		countriesNames: string[];
 		units: string[];
+		allergenNames: string[];
 	};
 
 	let {
@@ -89,6 +90,7 @@
 		originNames,
 		countriesNames,
 		units,
+		allergenNames,
 		isSubmitting,
 		submit
 	}: Props = $props();
@@ -154,7 +156,7 @@
 {:else if currentStep === 2}
 	<LanguagesStep bind:product codes={languages} {addLanguage} />
 {:else if currentStep === 3}
-	<IngredientsStep bind:product {getIngredientsImage} />
+	<IngredientsStep bind:product {getIngredientsImage} {allergenNames} />
 {:else if currentStep === 4}
 	<NutritionStep bind:product {units} {getNutritionImage} {handleNutrimentInput} />
 {:else if currentStep === 5}

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -52,6 +52,7 @@
 		originNames: string[];
 		countriesNames: string[];
 		units: string[];
+		allergenNames: string[];
 	};
 
 	let {
@@ -70,6 +71,7 @@
 		originNames,
 		countriesNames,
 		units,
+		allergenNames,
 		isSubmitting,
 		submit,
 		onCorrectBarcode
@@ -136,7 +138,7 @@
 			{$_('product.edit.sections.ingredients')}
 		</div>
 		<div class="collapse-content">
-			<IngredientsStep bind:product {getIngredientsImage} />
+			<IngredientsStep bind:product {getIngredientsImage} {allergenNames} />
 		</div>
 	</div>
 

--- a/src/lib/ui/edit-product-steps/IngredientsStep.svelte
+++ b/src/lib/ui/edit-product-steps/IngredientsStep.svelte
@@ -14,6 +14,7 @@
 	import { getShortcutCtx } from '$lib/stores/shortcuts';
 	import { onMount } from 'svelte';
 	import { focusEditField } from '$lib/utils/fieldFocus';
+	import TagsString from '../../../routes/products/[barcode]/edit/TagsString.svelte';
 
 	type OCRResult = {
 		status?: number;
@@ -27,9 +28,10 @@
 	type Props = {
 		product: Product;
 		getIngredientsImage: (language: string) => string | null;
+		allergenNames?: string[];
 	};
 
-	let { product = $bindable(), getIngredientsImage }: Props = $props();
+	let { product = $bindable(), getIngredientsImage, allergenNames = [] }: Props = $props();
 
 	let showInfo = $state(false);
 	let ocrLoading = $state(false);
@@ -182,4 +184,34 @@
 			{$_('product.edit.no_languages_found')}
 		</div>
 	{/if}
+</div>
+
+<div class="mt-8 space-y-6 border-t border-base-300 pt-6">
+	<div class="form-control w-full">
+		<label class="label">
+			<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
+				{$_('product.edit.allergens', { default: 'Allergens' })}
+				<InfoTooltip
+					text={$_('product.edit.tooltips.allergens', {
+						default: 'Allergens present in the product'
+					})}
+				/>
+			</span>
+		</label>
+		<TagsString bind:tagsString={product.allergens} autocomplete={allergenNames} />
+	</div>
+
+	<div class="form-control w-full">
+		<label class="label">
+			<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
+				{$_('product.edit.traces', { default: 'Traces' })}
+				<InfoTooltip
+					text={$_('product.edit.tooltips.traces', {
+						default: 'Traces of allergens that may be present'
+					})}
+				/>
+			</span>
+		</label>
+		<TagsString bind:tagsString={product.traces} autocomplete={allergenNames} />
+	</div>
 </div>

--- a/src/lib/ui/edit-product-steps/IngredientsStep.svelte
+++ b/src/lib/ui/edit-product-steps/IngredientsStep.svelte
@@ -186,10 +186,10 @@
 	{/if}
 </div>
 
-<div class="mt-8 space-y-6 border-t border-base-300 pt-6">
-	<div class="form-control w-full">
+<div class="mt-6 space-y-6">
+	<div class="flex flex-col gap-1.5 w-full">
 		<label class="label">
-			<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
+			<span class="flex items-center gap-2 text-sm font-medium sm:text-base">
 				{$_('product.edit.allergens', { default: 'Allergens' })}
 				<InfoTooltip
 					text={$_('product.edit.tooltips.allergens', {
@@ -201,9 +201,9 @@
 		<TagsString bind:tagsString={product.allergens} autocomplete={allergenNames} />
 	</div>
 
-	<div class="form-control w-full">
+	<div class="flex flex-col gap-1.5 w-full">
 		<label class="label">
-			<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
+			<span class="flex items-center gap-2 text-sm font-medium sm:text-base">
 				{$_('product.edit.traces', { default: 'Traces' })}
 				<InfoTooltip
 					text={$_('product.edit.tooltips.traces', {

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -75,6 +75,8 @@
 			stores: '',
 			origins: '',
 			countries: '',
+			allergens: '',
+			traces: '',
 			link: '',
 			ingredients_text: '',
 			ingredients_text_en: '',
@@ -113,6 +115,8 @@
 			labels_tags: [],
 			origins_tags: [],
 			countries_tags: [],
+			allergens_tags: [],
+			traces_tags: [],
 
 			nutriments: {} as Nutriments,
 
@@ -171,6 +175,7 @@
 	let storeNames = $derived(getNames(data.stores));
 	let originNames = $derived(getNames(data.origins));
 	let countriesNames = $derived(getNames(data.countries));
+	let allergenNames = $derived(getNames(data.allergens));
 	let units = $derived(getUnits(data.units));
 
 	function createProductStore(data: PageData): Product {
@@ -187,6 +192,10 @@
 					stores: data.state.product.stores ?? '',
 					origins: data.state.product.origins ?? '',
 					countries: data.state.product.countries ?? '',
+					allergens: data.state.product.allergens ?? '',
+					traces: data.state.product.traces ?? '',
+					allergens_tags: (data.state.product.allergens_tags as string[]) ?? [],
+					traces_tags: (data.state.product.traces_tags as string[]) ?? [],
 					languages_codes: data.state.product.languages_codes ?? {},
 					// @ts-expect-error - FIXME: to be fixed in the SDK
 					images: data.state.product.images ?? {},
@@ -492,6 +501,7 @@
 			{storeNames}
 			{units}
 			{handleNutrimentInput}
+			{allergenNames}
 		/>
 	{:else}
 		<EditProductForm
@@ -511,6 +521,7 @@
 			{originNames}
 			{storeNames}
 			{units}
+			{allergenNames}
 			languages={filteredLanguages}
 			onCorrectBarcode={handleBarcodeCorrection}
 		/>

--- a/src/routes/products/[barcode]/edit/+page.ts
+++ b/src/routes/products/[barcode]/edit/+page.ts
@@ -10,6 +10,7 @@ import {
 	type Store,
 	type Country,
 	type Unit,
+	type Allergen,
 	createProductsApi
 } from '$lib/api';
 import { userInfo } from '$lib/stores/user';
@@ -64,15 +65,17 @@ export const load: PageLoad = async ({ fetch, params }) => {
 	const productType =
 		productState.status !== 'failure' ? productState.product.product_type : undefined;
 
-	const [categories, labels, brands, stores, origins, countries, units] = await Promise.all([
-		getTaxo<Category>('categories', fetch, productType),
-		getTaxo<Label>('labels', fetch, productType),
-		getTaxo<Brand>('brands', fetch, productType),
-		getTaxo<Store>('stores', fetch, productType),
-		getTaxo<Origin>('origins', fetch, productType),
-		getTaxo<Country>('countries', fetch, productType),
-		getTaxo<Unit>('units', fetch, productType)
-	]);
+	const [categories, labels, brands, stores, origins, countries, units, allergens] =
+		await Promise.all([
+			getTaxo<Category>('categories', fetch, productType),
+			getTaxo<Label>('labels', fetch, productType),
+			getTaxo<Brand>('brands', fetch, productType),
+			getTaxo<Store>('stores', fetch, productType),
+			getTaxo<Origin>('origins', fetch, productType),
+			getTaxo<Country>('countries', fetch, productType),
+			getTaxo<Unit>('units', fetch, productType),
+			getTaxo<Allergen>('allergens', fetch, productType)
+		]);
 
 	console.debug(`Product state for barcode ${params.barcode}:`, productState.status);
 
@@ -89,7 +92,8 @@ export const load: PageLoad = async ({ fetch, params }) => {
 			stores,
 			origins,
 			countries,
-			units
+			units,
+			allergens
 		};
 	}
 
@@ -101,6 +105,7 @@ export const load: PageLoad = async ({ fetch, params }) => {
 		stores,
 		origins,
 		countries,
-		units
+		units,
+		allergens
 	};
 };


### PR DESCRIPTION
Closes #1346 

- Exposed the missing `allergens` and `traces` fields in the product edit/add forms. 
- Integrated them under the Ingredients section with auto-complete dropdown suggestions from the allergens taxonomy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Products now support allergen and trace fields.
  * Added editable Allergens and Traces fields (with labels and tooltips) to product create/edit forms.
  * Autocomplete suggestions for allergens and traces powered by an allergens taxonomy are available when editing products.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->