### PR TITLE
feat(edit): show all product names in languages step, fix languages selection

### DIFF
--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -3,9 +3,9 @@ import { get } from 'svelte/store';
 import { preferences } from '$lib/settings';
 import { browser } from '$app/environment';
 
-const locales = ['en-US', 'it-IT'];
+const locales = ['en', 'it'];
 
-const FALLBACK_LOCALE = 'en-US';
+const FALLBACK_LOCALE = 'en';
 
 locales.forEach((locale) => {
 	register(locale, async () => {

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -370,6 +370,7 @@
 				"product": "Other"
 			},
 			"product_page_url": "Link to the product page on the official site of the producer",
+			"product_names": "Product names",
 			"photos": "Product Photos",
 			"no_photo_available": "No photo available",
 			"ingredients": "Ingredients",

--- a/src/lib/ui/edit-product-steps/LanguagesStep.svelte
+++ b/src/lib/ui/edit-product-steps/LanguagesStep.svelte
@@ -3,8 +3,6 @@
 	import type { Product } from '$lib/api';
 	import { getLanguageName } from '$lib/languages';
 
-	import InfoTooltip from '../InfoTooltip.svelte';
-
 	import IconMdiTranslate from '@iconify-svelte/mdi/translate';
 	import IconMdiHelpCircleOutline from '@iconify-svelte/mdi/help-circle-outline';
 	import IconMdiClose from '@iconify-svelte/mdi/close';

--- a/src/lib/ui/edit-product-steps/LanguagesStep.svelte
+++ b/src/lib/ui/edit-product-steps/LanguagesStep.svelte
@@ -105,7 +105,9 @@
 		</legend>
 
 		{#if Object.keys(product.languages_codes ?? {}).length === 0}
-			<div class="alert alert-warning text-sm sm:text-base"></div>
+			<div class="alert alert-warning text-sm sm:text-base">
+				{$_('product.edit.no_languages_found')}
+			</div>
 		{/if}
 
 		{#each Object.keys(product.languages_codes ?? {}) as code (code)}

--- a/src/lib/ui/edit-product-steps/LanguagesStep.svelte
+++ b/src/lib/ui/edit-product-steps/LanguagesStep.svelte
@@ -44,12 +44,11 @@
 		showInfo = !showInfo;
 	}
 
-	let activeLang = $state(product.lang);
 	let shortcutCtx = getShortcutCtx();
 	onMount(() => {
 		shortcutCtx.set('Shift+P', {
 			description: $_('product.shortcuts.edit_product_name'),
-			action: () => focusEditField(`#product-name-${activeLang}`)
+			action: () => focusEditField(`#product-name-${product.lang}`)
 		});
 
 		return () => {
@@ -90,15 +89,51 @@
 
 <fieldset class="fieldset">
 	<legend class="fieldset-legend">{$_('product.edit.main_language')}</legend>
-	<select class="select w-full">
-		{#each Object.keys(product.languages_codes) ?? [] as lang (lang)}
-			<option value={lang} selected={product.lang === lang}>{getLanguageName(lang)}</option>
+	<select class="select w-full" bind:value={product.lang}>
+		{#each Object.keys(product.languages_codes ?? {}) as lang (lang)}
+			<option value={lang}>{getLanguageName(lang)}</option>
 		{/each}
 	</select>
 	<span class="label">The main language of the product</span>
 </fieldset>
 
-<div class="collapse-arrow bg-base-300 dark:bg-base-200 collapse">
+<div class="mt-4 space-y-4">
+	<fieldset class="fieldset">
+		<legend class="fieldset-legend">
+			{$_('product.edit.product_names')}
+			<InfoTooltip text={$_('product.edit.tooltips.product_name')} />
+		</legend>
+
+		{#if Object.keys(product.languages_codes ?? {}).length === 0}
+			<div class="alert alert-warning text-sm sm:text-base"></div>
+		{/if}
+
+		{#each Object.keys(product.languages_codes ?? {}) as code (code)}
+			{@const langName = getLanguageName(code)}
+			<div class="flex items-center gap-2">
+				<div
+					class="bg-primary/10 text-primary flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold uppercase"
+					title={langName}
+				>
+					{code}
+				</div>
+				<input
+					id={`product-name-${code}`}
+					type="text"
+					class="input input-bordered w-full text-sm sm:text-base"
+					bind:value={product[`product_name_${code}`]}
+					aria-label={`${$_('product.edit.name')} (${langName})`}
+				/>
+			</div>
+		{/each}
+
+		<div class="label block whitespace-normal">{$_('product.edit.tooltips.product_name')}</div>
+	</fieldset>
+</div>
+
+<div
+	class="collapse-arrow bg-base-300 dark:bg-base-200 collapse mt-4 border-2 rounded-lg border-base-300"
+>
 	<input type="checkbox" />
 	<div class="collapse-title text-sm font-semibold sm:text-base">
 		{$_('product.edit.add_language')}
@@ -129,38 +164,4 @@
 			</div>
 		{/if}
 	</div>
-</div>
-
-<div class="divider"></div>
-
-<div class="tabs tabs-box mt-4">
-	{#if Object.keys(product.languages_codes ?? {}).length === 0}
-		<div class="alert alert-warning text-sm sm:text-base">
-			{$_('product.edit.no_languages_found')}
-		</div>
-	{/if}
-	{#each Object.keys(product.languages_codes ?? {}) as code (code)}
-		<input
-			type="radio"
-			name="name_tabs"
-			class="tab text-xs sm:text-sm"
-			aria-label={getLanguageName(code)}
-			checked={code === activeLang}
-			onchange={() => (activeLang = code)}
-		/>
-		<div class="tab-content form-control p-6">
-			<label class="label text-sm sm:text-base" for={`product-name-${code}`}>
-				<span class="flex items-center gap-2">
-					{$_('product.edit.name')} ({getLanguageName(code)})
-					<InfoTooltip text={$_('product.edit.tooltips.product_name')} />
-				</span>
-			</label>
-			<input
-				id={`product-name-${code}`}
-				type="text"
-				class="input input-bordered w-full text-sm sm:text-base"
-				bind:value={product[`product_name_${code}`]}
-			/>
-		</div>
-	{/each}
 </div>

--- a/src/lib/ui/edit-product-steps/LanguagesStep.svelte
+++ b/src/lib/ui/edit-product-steps/LanguagesStep.svelte
@@ -101,7 +101,6 @@
 	<fieldset class="fieldset">
 		<legend class="fieldset-legend">
 			{$_('product.edit.product_names')}
-			<InfoTooltip text={$_('product.edit.tooltips.product_name')} />
 		</legend>
 
 		{#if Object.keys(product.languages_codes ?? {}).length === 0}


### PR DESCRIPTION
### Screenshot or video

<img width="1205" height="618" alt="immagine" src="https://github.com/user-attachments/assets/fa766032-3507-4c1d-8512-12fcd0f61ec4" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added English translation for the "Product names" label in the product editor.
  * Standardized locale keys to short codes and updated the fallback locale.

* **Improvements**
  * Redesigned product languages editor with per-language inputs, clearer labels, empty-state guidance, and improved accessibility.
  * Improved keyboard shortcut behavior to focus the product name field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->