### PR TITLE
feat: integrate nutripatrol-flag-form web component

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -228,7 +228,8 @@
 		"share_text": "Check out this product on Open Food Facts: {productName}",
 		"toast": {
 			"copied_link": "Link copied to clipboard!",
-			"failed_copy": "Failed to copy link"
+			"failed_copy": "Failed to copy link",
+			"report_login_required": "Please log in to report a product."
 		},
 		"header": {
 			"quantity": "Quantity",
@@ -444,6 +445,7 @@
 			"images": {
 				"toast": {
 					"login_required": "Please log in to upload images.",
+					"report_login_required": "Please log in to report an image.",
 					"upload_success": "Image uploaded successfully!",
 					"upload_failed": "Upload failed: {error}",
 					"upload_failed_generic": "Upload failed. Please try again.",
@@ -484,6 +486,7 @@
 				"crop_click_to_start": "Click and drag to start cropping",
 				"resize_handle_aria_label": "Resize {action} handle",
 				"report_image": "Report Image",
+				"report_to_moderators": "Report image to our moderators",
 				"save_changes": "Save Changes"
 			},
 			"comment_description": "Add a comment about your changes (optional)",

--- a/src/lib/knowledgepanels/Action.svelte
+++ b/src/lib/knowledgepanels/Action.svelte
@@ -2,15 +2,18 @@
 	import type { KnowledgeActionElement } from '$lib/api';
 	import { goto } from '$app/navigation';
 	import { _ } from '$lib/i18n';
-	import { NUTRIPATROL_URL } from '$lib/const';
 	import { resolve } from '$app/paths';
 	import HtmlPurify from '$lib/ui/HtmlPurify.svelte';
+	import { openNutriPatrolFlag } from '$lib/stores/nutripatrol';
+	import { userInfo } from '$lib/stores/user';
+	import { getToastCtx } from '$lib/stores/toasts';
 
 	type Props = {
 		element: KnowledgeActionElement;
 		code?: string;
 	};
 	let { element, code: code }: Props = $props();
+	const toastCtx = getToastCtx();
 
 	function requireCode() {
 		if (code == null) {
@@ -35,16 +38,18 @@
 		{
 			type: 'report_product_to_nutripatrol',
 			action: () => {
-				const params = new URLSearchParams({
+				if ($userInfo == null) {
+					toastCtx.warning(
+						$_('product.toast.report_login_required', {
+							default: 'Please log in to report a product.'
+						})
+					);
+					return;
+				}
+				openNutriPatrolFlag({
 					barcode: requireCode(),
-					source: 'web',
-					flavor: 'off'
+					type: 'product'
 				});
-				window.open(
-					`${NUTRIPATROL_URL}/flag/product/?${params.toString()}`,
-					'_blank',
-					'noopener,noreferrer'
-				);
 			}
 		},
 		{

--- a/src/lib/stores/nutripatrol.ts
+++ b/src/lib/stores/nutripatrol.ts
@@ -1,0 +1,19 @@
+import { writable } from 'svelte/store';
+
+export type NutriPatrolFlagConfig = {
+	barcode: string;
+	imageId?: string;
+	url?: string;
+	type?: 'product' | 'image' | 'search';
+	flavor?: 'off' | 'obf' | 'opff' | 'opf' | 'off-pro';
+};
+
+export const nutripatrolFlagStore = writable<NutriPatrolFlagConfig | null>(null);
+
+export function openNutriPatrolFlag(config: NutriPatrolFlagConfig) {
+	nutripatrolFlagStore.set(config);
+}
+
+export function closeNutriPatrolFlag() {
+	nutripatrolFlagStore.set(null);
+}

--- a/src/lib/ui/ImageButton.svelte
+++ b/src/lib/ui/ImageButton.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
-	import { IMAGE_REPORT_URL } from '$lib/const';
 	import ImageModal from './ImageModal.svelte';
 	import IconMdiFlagOutline from '@iconify-svelte/mdi/flag-outline';
+	import { openNutriPatrolFlag } from '$lib/stores/nutripatrol';
+	import { userInfo } from '$lib/stores/user';
+	import { getToastCtx } from '$lib/stores/toasts';
+	import { _ } from 'svelte-i18n';
+
+	import { getContext } from 'svelte';
 
 	type Props = { src?: string; alt?: string; rawImageId?: number; productCode?: string };
 	let { src, alt, rawImageId, productCode }: Props = $props();
 
 	let modal: ImageModal;
+
+	const toast = getToastCtx();
+	const getProductImages =
+		getContext<() => Record<string, { imgid?: string | number }> | undefined>('product-images');
 
 	function getFullSizeImageUrl(url: string): string {
 		return url.replace(/\.400\.|\.200\.|\.100\./, '.full.');
@@ -16,8 +25,23 @@
 	let imageId = $derived.by(() => {
 		if (rawImageId != null) return rawImageId;
 		if (src == null) return undefined;
-		const match = src.match(/\/(\d+)\.(full|400|200|100)\.jpg/);
-		return match ? parseInt(match[1]) : undefined;
+
+		// Extract raw numeric ID directly (e.g. 1.jpg)
+		const numericMatch = src.match(/\/(\d+)\.(full|400|200|100)?\.(jpg|png|webp)/i);
+		if (numericMatch) return parseInt(numericMatch[1], 10);
+
+		// Extract selected image key (e.g. front_en, ingredients_fr) and lookup using product-images context
+		const keyMatch = src.match(
+			/\/([a-zA-Z_]+)(?:\.\d+)?(?:\.(full|400|200|100))?\.(jpg|jpeg|png|webp)/i
+		);
+		if (keyMatch && getProductImages) {
+			const images = getProductImages();
+			const imageKey = keyMatch[1];
+			const imgid = images?.[imageKey]?.imgid;
+			if (imgid) return parseInt(imgid.toString(), 10);
+		}
+
+		return undefined;
 	});
 
 	let onclick = $derived.by(() => {
@@ -47,17 +71,36 @@
 
 	{#if imageId && productCode}
 		<div class="absolute top-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100">
-			<a
+			<button
+				type="button"
 				class="btn btn-circle btn-sm bg-base-100/80 hover:bg-base-100"
-				href={IMAGE_REPORT_URL(productCode, imageId)}
-				target="_blank"
-				rel="noopener noreferrer"
-				aria-label="Report to NutriPatrol"
-				title="Report to NutriPatrol"
-				onclick={(e) => e.stopPropagation()}
+				aria-label={$_('product.edit.images.report_to_moderators', {
+					default: 'Report image to our moderators'
+				})}
+				title={$_('product.edit.images.report_to_moderators', {
+					default: 'Report image to our moderators'
+				})}
+				onclick={(e) => {
+					e.stopPropagation();
+					if ($userInfo == null) {
+						toast.warning(
+							$_('product.edit.images.toast.report_login_required', {
+								default: 'Please log in to report an image.'
+							})
+						);
+						return;
+					}
+					if (src) {
+						openNutriPatrolFlag({
+							barcode: productCode,
+							imageId: imageId.toString(),
+							url: src
+						});
+					}
+				}}
 			>
 				<IconMdiFlagOutline class="h-4 w-4" />
-			</a>
+			</button>
 		</div>
 	{/if}
 </div>

--- a/src/lib/ui/ImageModal.svelte
+++ b/src/lib/ui/ImageModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { IMAGE_REPORT_URL } from '$lib/const';
 	import { userInfo } from '$lib/stores/user';
+	import { openNutriPatrolFlag } from '$lib/stores/nutripatrol';
+	import { getToastCtx } from '$lib/stores/toasts';
 	import { resolve } from '$app/paths';
 	import { _ } from 'svelte-i18n';
 	import ResizableImage from './ResizableImage.svelte';
@@ -20,6 +21,7 @@
 	let zoomLevel = $state(1);
 	let translation = $state({ x: 0, y: 0 });
 	const MAX_ZOOM = 3;
+	const toast = getToastCtx();
 
 	let rotation = $state(0);
 
@@ -175,15 +177,30 @@
 
 				<!-- Flag/Report button -->
 				{#if image?.imageid}
-					<a
+					<button
+						type="button"
 						class="btn btn-sm bg-base-100/80 hover:bg-base-100 gap-2"
-						href={IMAGE_REPORT_URL(image.productCode, image.imageid)}
-						target="_blank"
-						rel="noopener noreferrer"
+						onclick={() => {
+							if ($userInfo == null) {
+								toast.warning(
+									$_('product.edit.images.toast.report_login_required', {
+										default: 'Please log in to report an image.'
+									})
+								);
+								return;
+							}
+							if (image?.productCode && image?.imageid && image?.url) {
+								openNutriPatrolFlag({
+									barcode: image.productCode,
+									imageId: image.imageid.toString(),
+									url: image.url
+								});
+							}
+						}}
 					>
 						<IconMdiFlagOutline class="h-5 w-5" />
 						<span>{$_('product.buttons.report_issue', { default: 'Report' })}</span>
-					</a>
+					</button>
 				{/if}
 			{/if}
 		</div>

--- a/src/lib/ui/images/PhotoEditDialog.svelte
+++ b/src/lib/ui/images/PhotoEditDialog.svelte
@@ -2,8 +2,10 @@
 	import { untrack } from 'svelte';
 	import 'cropperjs';
 	import type { ProductImage } from '$lib/api';
-	import { getToastCtx } from '$lib/stores/toasts';
 	import { _ } from '$lib/i18n';
+	import { openNutriPatrolFlag } from '$lib/stores/nutripatrol';
+	import { userInfo } from '$lib/stores/user';
+	import { getToastCtx } from '$lib/stores/toasts';
 
 	import IconMdiClose from '@iconify-svelte/mdi/close';
 	import IconMdiRotateLeft from '@iconify-svelte/mdi/rotate-left';
@@ -57,13 +59,13 @@
 
 	type Props = {
 		image: ProductImage;
-		reportImageUrl: string;
+		barcode?: string;
 		onSave: (data: EditData) => void;
 		onImageUnselected: () => void;
 		onClose?: () => void;
 	};
 
-	let { image, reportImageUrl, onClose, onSave, onImageUnselected }: Props = $props();
+	let { image, barcode, onClose, onSave, onImageUnselected }: Props = $props();
 
 	const toast = getToastCtx();
 
@@ -703,17 +705,32 @@
 					{$_('product.edit.images.unselect_image', { default: 'Unselect Image' })}
 				</button>
 
-				{#if reportImageUrl}
-					<a
-						href={reportImageUrl}
-						target="_blank"
-						rel="noopener noreferrer"
+				{#if barcode}
+					<button
+						type="button"
 						class="btn btn-outline hover:btn-outline hover:btn-warning"
 						aria-label="Report this image"
+						onclick={() => {
+							if ($userInfo == null) {
+								toast.warning(
+									$_('product.edit.images.toast.report_login_required', {
+										default: 'Please log in to report an image.'
+									})
+								);
+								return;
+							}
+							if (image.imgid && image.url) {
+								openNutriPatrolFlag({
+									barcode,
+									imageId: image.imgid.toString(),
+									url: image.url
+								});
+							}
+						}}
 					>
 						<IconMdiFlag class="h-4 w-4" aria-hidden="true" />
 						{$_('product.edit.images.report_image', { default: 'Report Image' })}
-					</a>
+					</button>
 				{/if}
 			</div>
 

--- a/src/lib/ui/images/PhotoManager.svelte
+++ b/src/lib/ui/images/PhotoManager.svelte
@@ -20,7 +20,6 @@
 	import PhotoTypeSection from './PhotoTypeSection.svelte';
 	import PhotoEditDialog from './PhotoEditDialog.svelte';
 	import PhotoSelectDialog from './PhotoSelectDialog.svelte';
-	import { IMAGE_REPORT_URL } from '$lib/const';
 
 	type Props = { product: Product };
 	let { product }: Props = $props();
@@ -354,10 +353,6 @@
 		}
 	}
 
-	function getNutriPatrolReportUrl(image: ProductImage) {
-		return IMAGE_REPORT_URL(product.code, image.imgid);
-	}
-
 	let selectingImageModal: PhotoSelectDialog | undefined = $state();
 	let selectingImageSection: string | undefined = $state();
 	let isSelectingImage = $state(false);
@@ -458,7 +453,7 @@
 {#if editingImageData}
 	<PhotoEditDialog
 		bind:this={editingImageModal}
-		reportImageUrl={getNutriPatrolReportUrl(editingImageData)}
+		barcode={product.code}
 		image={editingImageData}
 		onClose={closeEditModal}
 		onSave={saveCurrentImage}

--- a/src/lib/ui/images/PhotoTypeSection.svelte
+++ b/src/lib/ui/images/PhotoTypeSection.svelte
@@ -13,9 +13,9 @@
 	import IconMdiImageRemove from '@iconify-svelte/mdi/image-remove';
 	import IconMdiPencil from '@iconify-svelte/mdi/pencil';
 	import IconMdiImagePlus from '@iconify-svelte/mdi/image-plus';
-	import IconMdiFlagOutline from '@iconify-svelte/mdi/flag-outline';
-	import { IMAGE_REPORT_URL } from '$lib/const';
+	import { openNutriPatrolFlag } from '$lib/stores/nutripatrol';
 	import { userInfo } from '$lib/stores/user';
+	import IconMdiFlagOutline from '@iconify-svelte/mdi/flag-outline';
 
 	type PhotoType = { id: string; label: string };
 
@@ -253,10 +253,10 @@
 				class:opacity-50={isUploading || isUnselecting}
 			>
 				{#each imagesToShow as image (image.url)}
-					<div>
+					<div class="group relative">
 						<button
 							type="button"
-							class="group relative aspect-square cursor-pointer overflow-hidden rounded border bg-transparent p-0 transition-shadow hover:shadow-lg"
+							class="relative aspect-square cursor-pointer overflow-hidden rounded border bg-transparent p-0 transition-shadow hover:shadow-lg w-full"
 							disabled={isUploading || isUnselecting}
 							onclick={() => onImageEdit?.(image.url, image.alt)}
 							title="Click to edit this image"
@@ -277,17 +277,36 @@
 						<div
 							class="absolute top-1 right-1 z-10 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
 						>
-							<a
+							<button
+								type="button"
 								class="btn btn-circle btn-xs bg-base-100/80 hover:bg-base-100 text-base-content border-none"
-								href={IMAGE_REPORT_URL(product.code, image.imgid)}
-								target="_blank"
-								rel="noopener noreferrer"
-								aria-label="Report to NutriPatrol"
-								title="Report to NutriPatrol"
-								onclick={(e) => e.stopPropagation()}
+								aria-label={$_('product.edit.images.report_to_moderators', {
+									default: 'Report image to our moderators'
+								})}
+								title={$_('product.edit.images.report_to_moderators', {
+									default: 'Report image to our moderators'
+								})}
+								onclick={(e) => {
+									e.stopPropagation();
+									if ($userInfo == null) {
+										toast.warning(
+											$_('product.edit.images.toast.report_login_required', {
+												default: 'Please log in to report images.'
+											})
+										);
+										return;
+									}
+									if (product.code && image.imgid) {
+										openNutriPatrolFlag({
+											barcode: product.code,
+											imageId: image.imgid.toString(),
+											url: image.url
+										});
+									}
+								}}
 							>
 								<IconMdiFlagOutline class="h-3.5 w-3.5" />
-							</a>
+							</button>
 						</div>
 
 						<p class="text-base-content/70 mt-1 line-clamp-1 text-center text-xs">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -36,7 +36,7 @@
 	import { dev } from '$app/environment';
 	import type { LayoutProps } from './$types';
 	import { setWebsiteCtx } from '$lib/stores/website';
-	import type { WebsiteFlavor } from '$lib/flavor';
+	import { WEBSITE_FLAVOR_METADATA, type WebsiteFlavor } from '$lib/flavor';
 	import { setToastCtx, type Toast as ToastType, type ToastContext } from '$lib/stores/toasts';
 	import Shortcuts from './Shortcuts.svelte';
 	import { setShortcutCtx, type Shortcut } from '$lib/stores/shortcuts';
@@ -44,6 +44,7 @@
 	import { SvelteMap } from 'svelte/reactivity';
 	import { shouldBeContainer } from '$lib/layout';
 	import { resolve } from '$app/paths';
+	import { nutripatrolFlagStore, closeNutriPatrolFlag } from '$lib/stores/nutripatrol';
 
 	// == Global website context setup ==
 	let websiteCtx: { flavor: WebsiteFlavor } = $state({
@@ -424,6 +425,21 @@
 <CompareFloatingButton />
 <Footer />
 <Toast />
+
+{#if $nutripatrolFlagStore}
+	<nutripatrol-flag-form
+		type={$nutripatrolFlagStore.type ?? 'image'}
+		barcode={$nutripatrolFlagStore.barcode}
+		image-id={$nutripatrolFlagStore.imageId ?? ''}
+		url={$nutripatrolFlagStore.url ?? ''}
+		flavor={$nutripatrolFlagStore.flavor ??
+			WEBSITE_FLAVOR_METADATA[websiteCtx.flavor]?.reportFlavor ??
+			'off'}
+		user-id={$userInfo?.preferred_username ?? ''}
+		open={true}
+		onclose={closeNutriPatrolFlag}
+	></nutripatrol-flag-form>
+{/if}
 
 {#if navigationTooSlow != null}
 	{#await navigationTooSlow then}

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -26,7 +26,7 @@
 	import { OpenFoodFacts, type Product } from '@openfoodfacts/openfoodfacts-nodejs';
 	import type { KnowledgePanels } from '$lib/api/knowledgepanels';
 	import NutritionCalculator from '$lib/ui/NutritionCalculator.svelte';
-	import { onMount } from 'svelte';
+	import { onMount, setContext } from 'svelte';
 	import { getShortcutCtx } from '$lib/stores/shortcuts';
 	import type { ProductGroupedAttributes } from './types';
 	import { personalizedSearch } from '$lib/stores/preferencesStore';
@@ -54,6 +54,9 @@
 	let product = $derived(
 		productState.status === 'success' ? (productState.product as UiProduct) : ({} as UiProduct)
 	);
+
+	// Provide product images context to child components for resolving numeric image IDs
+	setContext('product-images', () => product.images);
 
 	let websiteCtx = getWebsiteCtx();
 	$effect(() => {

--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -14,11 +14,13 @@
 		type Store,
 		type Taxonomy
 	} from '$lib/api';
-	import { PRODUCT_REPORT_URL, PRODUCT_WEBSITE_URL, TRACEABILITY_CODES_URL } from '$lib/const';
+	import { PRODUCT_WEBSITE_URL, TRACEABILITY_CODES_URL } from '$lib/const';
 	import { preferences } from '$lib/settings';
 	import { addItemToCalculator, extractNutriments } from '$lib/stores/calculatorStore';
 	import { compareStore } from '$lib/stores/compareStore';
 	import { getToastCtx } from '$lib/stores/toasts';
+	import { openNutriPatrolFlag } from '$lib/stores/nutripatrol';
+	import { userInfo } from '$lib/stores/user';
 	import Card from '$lib/ui/Card.svelte';
 	import ImageButton from '$lib/ui/ImageButton.svelte';
 
@@ -146,16 +148,28 @@
 						<span class="hidden md:block">{$_('product.buttons.share')}</span>
 					</button>
 
-					<a
+					<button
+						type="button"
 						class="btn btn-secondary btn-sm md:btn-md flex items-center gap-2"
-						href={PRODUCT_REPORT_URL(product.code!, product.product_type)}
-						target="_blank"
-						rel="noopener noreferrer"
+						onclick={() => {
+							if ($userInfo == null) {
+								toastCtx.warning(
+									$_('product.toast.report_login_required', {
+										default: 'Please log in to report a product.'
+									})
+								);
+								return;
+							}
+							openNutriPatrolFlag({
+								barcode: product.code!,
+								type: 'product'
+							});
+						}}
 						title={$_('product.buttons.report')}
 						aria-label={$_('product.buttons.report')}
 					>
 						<IconMdiFlag class="h-5 w-5" />
-					</a>
+					</button>
 
 					<button
 						class="btn btn-secondary btn-sm md:btn-md"


### PR DESCRIPTION
Closes #1354 


> **`"@openfoodfacts/openfoodfacts-webcomponents"` should be bumped to the latest version.**


- Replaces all legacy external redirections to the NutriPatrol website with the new inline web component `<nutripatrol-flag-form>` modal.

###Screenshots or videos
<img width="1905" height="939" alt="image" src="https://github.com/user-attachments/assets/6d0829b2-1165-4327-806e-cb0ac8cb242b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Image and product reporting now integrated in-app through a modal form instead of opening external links
  * Added authentication requirement for reporting with localized warning messages when users aren't logged in
  * Enhanced internationalization support for reporting and authentication-related UI text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->