### PR TITLE
feat(edit): add sidebar to product edit page 

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -274,6 +274,10 @@
 			"check_be_first": "Be the first to check this product"
 		},
 		"edit": {
+			"sidebar": {
+				"collapse_all": "Collapse All",
+				"expand_all": "Expand All"
+			},
 			"moderator_only": "Moderator only",
 			"info": {
 				"images": "Upload clear images of the product, ingredients, and nutrition facts to help others identify the product.",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -102,7 +102,9 @@ const MIGRATIONS: {
 		version: 5,
 		upgrade: (preferences) => {
 			if (preferences.editing) {
-				preferences.editing.expandAllSections = true;
+				if (preferences.editing.expandAllSections === undefined) {
+					preferences.editing.expandAllSections = true;
+				}
 			} else {
 				preferences.editing = {
 					expandAllSections: true

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -2,7 +2,7 @@ import { persisted } from 'svelte-local-storage-store';
 import { get } from 'svelte/store';
 
 const DEFAULT_PREFERENCES = {
-	version: 4,
+	version: 5,
 	lang: undefined as string | undefined,
 	country: 'world',
 	currency: 'USD',
@@ -15,7 +15,7 @@ const DEFAULT_PREFERENCES = {
 	},
 
 	editing: {
-		expandAllSections: false
+		expandAllSections: true
 	},
 
 	displayPricesInSearch: true,
@@ -94,6 +94,19 @@ const MIGRATIONS: {
 			if (!('displayPricesInSearch' in preferences)) {
 				// @ts-expect-error - adding new field
 				preferences.displayPricesInSearch = true;
+			}
+			return preferences;
+		}
+	},
+	{
+		version: 5,
+		upgrade: (preferences) => {
+			if (preferences.editing) {
+				preferences.editing.expandAllSections = true;
+			} else {
+				preferences.editing = {
+					expandAllSections: true
+				};
 			}
 			return preferences;
 		}

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -108,7 +108,7 @@
 </script>
 
 <div
-	class="relative w-full lg:grid lg:grid-cols-[auto_1fr] lg:gap-8 2xl:grid-cols-1 2xl:gap-0 items-start my-4"
+	class="relative w-full lg:grid lg:grid-cols-[auto_1fr] lg:gap-8 2xl:grid-cols-1 2xl:gap-0 my-4"
 >
 	<EditProductSidebar bind:this={sidebar} />
 

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import ImagesStep from './edit-product-steps/ImagesStep.svelte';
 	import BasicInfoStep from './edit-product-steps/BasicInfoStep.svelte';
 	import LanguagesStep from './edit-product-steps/LanguagesStep.svelte';
@@ -6,6 +7,7 @@
 	import NutritionStep from './edit-product-steps/NutritionStep.svelte';
 	import PackagingStep from './edit-product-steps/PackagingStep.svelte';
 	import CommentStep from './edit-product-steps/CommentStep.svelte';
+	import EditProductSidebar from './EditProductSidebar.svelte';
 
 	import IconMdiTranslate from '@iconify-svelte/mdi/translate';
 	import IconMdiImageMultiple from '@iconify-svelte/mdi/image-multiple';
@@ -87,167 +89,242 @@
 	}
 
 	const permissions = getPermissionsCtx();
+
+	let sidebar = $state<ReturnType<typeof EditProductSidebar>>();
+	let isMobile = $state(false);
+
+	onMount(() => {
+		const updateMobileState = () => {
+			isMobile = window.innerWidth < 1024;
+		};
+		updateMobileState();
+		window.addEventListener('resize', updateMobileState);
+		return () => window.removeEventListener('resize', updateMobileState);
+	});
+
+	function handleCollapseToggle(id: string) {
+		sidebar?.handleCollapseToggle(id);
+	}
 </script>
 
-<div class="space-y-4">
-	<!-- Languages Section -->
-	<div class="collapse-arrow bg-base-200 collapse shadow-md">
-		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
-			<IconMdiTranslate class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-			{$_('product.edit.sections.languages')}
-		</div>
-		<div class="collapse-content">
-			<LanguagesStep bind:product {addLanguage} codes={languages} />
-		</div>
-	</div>
+<div
+	class="relative w-full lg:grid lg:grid-cols-[auto_1fr] lg:gap-8 2xl:grid-cols-1 2xl:gap-0 items-start my-4"
+>
+	<EditProductSidebar bind:this={sidebar} />
 
-	<!-- Images Section -->
-	<div class="collapse-arrow bg-base-200 collapse shadow-md">
-		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
-			<IconMdiImageMultiple class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-			{$_('product.edit.sections.images')}
-		</div>
-		<div class="collapse-content">
-			<ImagesStep bind:product />
-		</div>
-	</div>
-
-	<!-- Basic Info Section -->
-	<div class="collapse-arrow bg-base-200 collapse shadow-md">
-		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
-			<IconMdiInformation class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-			{$_('product.edit.sections.basic_info')}
-		</div>
-		<div class="collapse-content">
-			<BasicInfoStep
-				bind:product
-				{brandNames}
-				{categoryNames}
-				{countriesNames}
-				{labelNames}
-				{originNames}
-				{storeNames}
+	<div class="space-y-4 min-w-0 w-full">
+		<!-- Languages Section -->
+		<div id="languages" class="collapse-arrow bg-base-200 collapse shadow-md">
+			<input
+				type="checkbox"
+				checked={isMobile ? false : $preferences.editing.expandAllSections}
+				onchange={(e) => {
+					if (e.isTrusted) handleCollapseToggle('languages');
+				}}
 			/>
-		</div>
-	</div>
-
-	<!-- Ingredients Section -->
-	<div class="collapse-arrow bg-base-200 collapse shadow-md">
-		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
-			<IconMdiFormatListBulleted class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-			{$_('product.edit.sections.ingredients')}
-		</div>
-		<div class="collapse-content">
-			<IngredientsStep bind:product {getIngredientsImage} {allergenNames} />
-		</div>
-	</div>
-
-	<!-- Nutrition Section -->
-	<!-- overflow-visible is needed for the sticky image -->
-	<div class="collapse-arrow bg-base-200 collapse overflow-visible shadow-md">
-		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
-			<IconMdiNutrition class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-			{$_('product.edit.sections.nutrition')}
-		</div>
-		<div class="collapse-content">
-			<NutritionStep bind:product {units} {getNutritionImage} {handleNutrimentInput} />
-		</div>
-	</div>
-
-	<!-- Prices Section -->
-	<div class="collapse-arrow bg-base-200 collapse shadow-md">
-		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
-			<IconMdiTagMultiple class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-			{$_('product.edit.sections.prices')}
-		</div>
-		<div class="collapse-content">
-			<p class="text-base-content/70 mt-2 mb-4 text-sm">
-				{$_('product.edit.info.prices')}
-			</p>
-			{#if product.code != null}
-				<a
-					href={getOpenPricesUrl(product.code)}
-					class="btn btn-secondary btn-sm"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					<IconMdiOpenInNew class="mr-1 h-4 w-4" />
-					{$_('product.edit.prices.add_price_btn')}
-				</a>
-			{/if}
-		</div>
-	</div>
-
-	<!-- Packaging Section -->
-	<div class="collapse-arrow bg-base-200 collapse shadow-md" id="packaging">
-		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
-			<IconMdiPackageVariant class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-			{$_('product.edit.sections.packaging')}
-		</div>
-		<div class="collapse-content">
-			<PackagingStep bind:product {getPackagingImage} />
-		</div>
-	</div>
-
-	<!-- Comment Section -->
-	<div class="collapse-arrow bg-base-200 collapse shadow-md">
-		<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-		<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
-			<IconMdiCommentText class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-			{$_('product.edit.sections.comment')}
-		</div>
-		<div class="collapse-content">
-			<CommentStep bind:comment />
-		</div>
-	</div>
-
-	<!-- Moderator Tools Section -->
-	{#if permissions.isModerator && $preferences.moderator}
-		<div class="collapse-arrow bg-base-200 collapse shadow-md">
-			<input type="checkbox" checked={$preferences.editing.expandAllSections} />
-			<div class="collapse-title text-warning flex items-center text-sm font-bold sm:text-base">
-				<IconMdiShieldAccount class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-				{$_('product.edit.sections.moderator_tools')}
+			<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+				<IconMdiTranslate class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+				{$_('product.edit.sections.languages')}
 			</div>
 			<div class="collapse-content">
-				<p class="text-base-content/70 mb-4 text-sm">
-					{$_('product.edit.info.moderator_tools')}
+				<LanguagesStep bind:product {addLanguage} codes={languages} />
+			</div>
+		</div>
+
+		<!-- Images Section -->
+		<div id="images" class="collapse-arrow bg-base-200 collapse shadow-md">
+			<input
+				type="checkbox"
+				checked={isMobile ? false : $preferences.editing.expandAllSections}
+				onchange={(e) => {
+					if (e.isTrusted) handleCollapseToggle('images');
+				}}
+			/>
+			<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+				<IconMdiImageMultiple class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+				{$_('product.edit.sections.images')}
+			</div>
+			<div class="collapse-content">
+				<ImagesStep bind:product />
+			</div>
+		</div>
+
+		<!-- Basic Info Section -->
+		<div id="basic-info" class="collapse-arrow bg-base-200 collapse shadow-md">
+			<input
+				type="checkbox"
+				checked={isMobile ? false : $preferences.editing.expandAllSections}
+				onchange={(e) => {
+					if (e.isTrusted) handleCollapseToggle('basic-info');
+				}}
+			/>
+			<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+				<IconMdiInformation class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+				{$_('product.edit.sections.basic_info')}
+			</div>
+			<div class="collapse-content">
+				<BasicInfoStep
+					bind:product
+					{brandNames}
+					{categoryNames}
+					{countriesNames}
+					{labelNames}
+					{originNames}
+					{storeNames}
+				/>
+			</div>
+		</div>
+
+		<!-- Ingredients Section -->
+		<div id="ingredients" class="collapse-arrow bg-base-200 collapse shadow-md">
+			<input
+				type="checkbox"
+				checked={isMobile ? false : $preferences.editing.expandAllSections}
+				onchange={(e) => {
+					if (e.isTrusted) handleCollapseToggle('ingredients');
+				}}
+			/>
+			<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+				<IconMdiFormatListBulleted class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+				{$_('product.edit.sections.ingredients')}
+			</div>
+			<div class="collapse-content">
+				<IngredientsStep bind:product {getIngredientsImage} {allergenNames} />
+			</div>
+		</div>
+
+		<!-- Nutrition Section -->
+		<!-- overflow-visible is needed for the sticky image -->
+		<div id="nutrition" class="collapse-arrow bg-base-200 collapse overflow-visible shadow-md">
+			<input
+				type="checkbox"
+				checked={isMobile ? false : $preferences.editing.expandAllSections}
+				onchange={(e) => {
+					if (e.isTrusted) handleCollapseToggle('nutrition');
+				}}
+			/>
+			<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+				<IconMdiNutrition class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+				{$_('product.edit.sections.nutrition')}
+			</div>
+			<div class="collapse-content">
+				<NutritionStep bind:product {units} {getNutritionImage} {handleNutrimentInput} />
+			</div>
+		</div>
+
+		<!-- Prices Section -->
+		<div id="prices" class="collapse-arrow bg-base-200 collapse shadow-md">
+			<input
+				type="checkbox"
+				checked={isMobile ? false : $preferences.editing.expandAllSections}
+				onchange={(e) => {
+					if (e.isTrusted) handleCollapseToggle('prices');
+				}}
+			/>
+			<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+				<IconMdiTagMultiple class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+				{$_('product.edit.sections.prices')}
+			</div>
+			<div class="collapse-content">
+				<p class="text-base-content/70 mt-2 mb-4 text-sm">
+					{$_('product.edit.info.prices')}
 				</p>
-				<BarcodeCorrectionCard currentCode={product.code} onCorrect={onCorrectBarcode} />
-				<div class="divider"></div>
-				<ObsoleteProductCard bind:product />
-				{#if onDeleteProduct}
-					<div class="divider"></div>
-					<DeleteProductCard
-						barcode={product.code}
-						productName={product.product_name || product.product_name_en || ''}
-						onDelete={onDeleteProduct}
-					/>
+				{#if product.code != null}
+					<a
+						href={getOpenPricesUrl(product.code)}
+						class="btn btn-secondary btn-sm"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						<IconMdiOpenInNew class="mr-1 h-4 w-4" />
+						{$_('product.edit.prices.add_price_btn')}
+					</a>
 				{/if}
 			</div>
 		</div>
-	{/if}
 
-	<div class="mt-8 flex justify-end">
-		<button
-			class="btn btn-primary w-full text-sm sm:w-auto sm:text-base"
-			onclick={submit}
-			disabled={isSubmitting}
-			aria-busy={isSubmitting}
-			type="button"
-		>
-			{#if isSubmitting}
-				<span class="loading loading-spinner loading-xs sm:loading-sm mr-2" aria-hidden="true"
-				></span>
-			{/if}
-			{$_('product.edit.save_btn')}
-		</button>
+		<!-- Packaging Section -->
+		<div class="collapse-arrow bg-base-200 collapse shadow-md" id="packaging">
+			<input
+				type="checkbox"
+				checked={isMobile ? false : $preferences.editing.expandAllSections}
+				onchange={(e) => {
+					if (e.isTrusted) handleCollapseToggle('packaging');
+				}}
+			/>
+			<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+				<IconMdiPackageVariant class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+				{$_('product.edit.sections.packaging')}
+			</div>
+			<div class="collapse-content">
+				<PackagingStep bind:product {getPackagingImage} />
+			</div>
+		</div>
+
+		<!-- Comment Section -->
+		<div id="comment" class="collapse-arrow bg-base-200 collapse shadow-md">
+			<input
+				type="checkbox"
+				checked={isMobile ? false : $preferences.editing.expandAllSections}
+				onchange={(e) => {
+					if (e.isTrusted) handleCollapseToggle('comment');
+				}}
+			/>
+			<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+				<IconMdiCommentText class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+				{$_('product.edit.sections.comment')}
+			</div>
+			<div class="collapse-content">
+				<CommentStep bind:comment />
+			</div>
+		</div>
+
+		<!-- Moderator Tools Section -->
+		{#if permissions.isModerator && $preferences.moderator}
+			<div id="moderator-tools" class="collapse-arrow bg-base-200 collapse shadow-md">
+				<input
+					type="checkbox"
+					checked={isMobile ? false : $preferences.editing.expandAllSections}
+					onchange={(e) => {
+						if (e.isTrusted) handleCollapseToggle('moderator-tools');
+					}}
+				/>
+				<div class="collapse-title text-warning flex items-center text-sm font-bold sm:text-base">
+					<IconMdiShieldAccount class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+					{$_('product.edit.sections.moderator_tools')}
+				</div>
+				<div class="collapse-content">
+					<p class="text-base-content/70 mb-4 text-sm">
+						{$_('product.edit.info.moderator_tools')}
+					</p>
+					<BarcodeCorrectionCard currentCode={product.code} onCorrect={onCorrectBarcode} />
+					<div class="divider"></div>
+					<ObsoleteProductCard bind:product />
+					{#if onDeleteProduct}
+						<div class="divider"></div>
+						<DeleteProductCard
+							barcode={product.code}
+							productName={product.product_name || product.product_name_en || ''}
+							onDelete={onDeleteProduct}
+						/>
+					{/if}
+				</div>
+			</div>
+		{/if}
 	</div>
+</div>
+
+<div class="mt-8 flex justify-end">
+	<button
+		class="btn btn-primary w-full text-sm sm:w-auto sm:text-base"
+		onclick={submit}
+		disabled={isSubmitting}
+		aria-busy={isSubmitting}
+		type="button"
+	>
+		{#if isSubmitting}
+			<span class="loading loading-spinner loading-xs sm:loading-sm mr-2" aria-hidden="true"></span>
+		{/if}
+		{$_('product.edit.save_btn')}
+	</button>
 </div>

--- a/src/lib/ui/EditProductSidebar.svelte
+++ b/src/lib/ui/EditProductSidebar.svelte
@@ -1,8 +1,30 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, type Component } from 'svelte';
 	import { _ } from '$lib/i18n';
 	import { preferences } from '$lib/settings';
 	import { getPermissionsCtx } from '$lib/stores/user';
+
+	import IconMdiTranslate from '@iconify-svelte/mdi/translate';
+	import IconMdiImageMultiple from '@iconify-svelte/mdi/image-multiple';
+	import IconMdiInformation from '@iconify-svelte/mdi/information';
+	import IconMdiFormatListBulleted from '@iconify-svelte/mdi/format-list-bulleted';
+	import IconMdiNutrition from '@iconify-svelte/mdi/nutrition';
+	import IconMdiTagMultiple from '@iconify-svelte/mdi/tag-multiple';
+	import IconMdiPackageVariant from '@iconify-svelte/mdi/package-variant';
+	import IconMdiCommentText from '@iconify-svelte/mdi/comment-text';
+	import IconMdiShieldAccount from '@iconify-svelte/mdi/shield-account';
+
+	const icons = {
+		languages: IconMdiTranslate,
+		images: IconMdiImageMultiple,
+		'basic-info': IconMdiInformation,
+		ingredients: IconMdiFormatListBulleted,
+		nutrition: IconMdiNutrition,
+		prices: IconMdiTagMultiple,
+		packaging: IconMdiPackageVariant,
+		comment: IconMdiCommentText,
+		'moderator-tools': IconMdiShieldAccount
+	} as const;
 
 	const permissions = getPermissionsCtx();
 
@@ -23,8 +45,20 @@
 		}
 	});
 
-	const sidebarSections = $derived.by(() => {
-		const list = [
+	interface SidebarSection {
+		id: string;
+		label: string;
+		icon?: Component;
+	}
+
+	interface Props {
+		sections?: SidebarSection[];
+	}
+
+	let { sections }: Props = $props();
+
+	const defaultSections = $derived.by(() => {
+		const list: SidebarSection[] = [
 			{ id: 'languages', label: $_('product.edit.sections.languages', { default: 'Languages' }) },
 			{ id: 'images', label: $_('product.edit.sections.images', { default: 'Images' }) },
 			{
@@ -49,6 +83,14 @@
 		}
 
 		return list;
+	});
+
+	const sidebarSections = $derived.by(() => {
+		const baseList: SidebarSection[] = sections || defaultSections;
+		return baseList.map((item) => ({
+			...item,
+			icon: item.icon || icons[item.id as keyof typeof icons]
+		}));
 	});
 
 	let ignoreObserver = false;
@@ -102,9 +144,13 @@
 		}, 1000);
 
 		$preferences.editing.expandAllSections = !$preferences.editing.expandAllSections;
-		const checkboxes = document.querySelectorAll(
-			'.collapse-arrow > input[type="checkbox"]'
-		) as NodeListOf<HTMLInputElement>;
+		const checkboxes = sidebarSections
+			.map((section) => {
+				const el = document.getElementById(section.id);
+				return el ? el.querySelector('.collapse-arrow > input[type="checkbox"]') : null;
+			})
+			.filter(Boolean) as HTMLInputElement[];
+
 		checkboxes.forEach((cb) => {
 			cb.checked = $preferences.editing.expandAllSections;
 			cb.dispatchEvent(new Event('change'));
@@ -201,25 +247,35 @@
 		</div>
 		<nav
 			bind:this={navElement}
+			aria-label={$_('product.edit.sidebar_navigation', { default: 'Product edit sections' })}
 			class="relative border-l-2 border-base-300 flex flex-col gap-1 pl-4 text-sm"
 		>
 			<!-- Active indicator line with smooth sliding transition -->
 			{#if indicatorHeight > 0}
 				<div
+					aria-hidden="true"
 					class="absolute -left-0.5 w-0.5 bg-primary rounded-full transition-all duration-300 ease-in-out"
 					style="top: {indicatorTop}px; height: {indicatorHeight}px;"
 				></div>
 			{/if}
 			{#each sidebarSections as section (section.id)}
+				{@const IconComponent = section.icon}
 				<button
 					type="button"
 					data-section={section.id}
+					aria-controls={section.id}
+					aria-current={activeSection === section.id ? 'true' : 'false'}
 					onclick={() => scrollToSection(section.id)}
 					class="group flex items-center py-2 text-left relative transition-all duration-200 outline-none select-none hover:text-primary cursor-pointer {activeSection ===
 					section.id
 						? 'text-primary font-semibold'
 						: 'text-base-content/60'}"
 				>
+					{#if IconComponent}
+						<IconComponent
+							class="w-4 h-4 mr-2 transition-transform duration-200 group-hover:scale-110"
+						/>
+					{/if}
 					<span>{section.label}</span>
 				</button>
 			{/each}

--- a/src/lib/ui/EditProductSidebar.svelte
+++ b/src/lib/ui/EditProductSidebar.svelte
@@ -254,7 +254,10 @@
 			{#if indicatorHeight > 0}
 				<div
 					aria-hidden="true"
-					class="absolute -left-0.5 w-0.5 bg-primary rounded-full transition-all duration-300 ease-in-out"
+					class="absolute -left-0.5 w-0.5 rounded-full transition-all duration-300 ease-in-out {activeSection ===
+					'moderator-tools'
+						? 'bg-warning'
+						: 'bg-primary'}"
 					style="top: {indicatorTop}px; height: {indicatorHeight}px;"
 				></div>
 			{/if}
@@ -266,10 +269,14 @@
 					aria-controls={section.id}
 					aria-current={activeSection === section.id ? 'true' : 'false'}
 					onclick={() => scrollToSection(section.id)}
-					class="group flex items-center py-2 text-left relative transition-all duration-200 outline-none select-none hover:text-primary cursor-pointer {activeSection ===
-					section.id
-						? 'text-primary font-semibold'
-						: 'text-base-content/60'}"
+					class="group flex items-center py-2 text-left relative transition-all duration-200 outline-none select-none cursor-pointer {section.id ===
+					'moderator-tools'
+						? activeSection === section.id
+							? 'text-warning font-semibold'
+							: 'text-warning/70 hover:text-warning'
+						: activeSection === section.id
+							? 'text-primary font-semibold'
+							: 'text-base-content/60 hover:text-primary'}"
 				>
 					{#if IconComponent}
 						<IconComponent

--- a/src/lib/ui/EditProductSidebar.svelte
+++ b/src/lib/ui/EditProductSidebar.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { _ } from '$lib/i18n';
+	import { preferences } from '$lib/settings';
+	import { getPermissionsCtx } from '$lib/stores/user';
+
+	const permissions = getPermissionsCtx();
+
+	let activeSection = $state('languages');
+	let navElement = $state<HTMLElement>();
+	let indicatorTop = $state(0);
+	let indicatorHeight = $state(0);
+
+	$effect(() => {
+		if (activeSection && navElement) {
+			const activeBtn = navElement.querySelector(
+				`[data-section="${activeSection}"]`
+			) as HTMLElement;
+			if (activeBtn) {
+				indicatorTop = activeBtn.offsetTop;
+				indicatorHeight = activeBtn.offsetHeight;
+			}
+		}
+	});
+
+	const sidebarSections = $derived.by(() => {
+		const list = [
+			{ id: 'languages', label: $_('product.edit.sections.languages', { default: 'Languages' }) },
+			{ id: 'images', label: $_('product.edit.sections.images', { default: 'Images' }) },
+			{
+				id: 'basic-info',
+				label: $_('product.edit.sections.basic_info', { default: 'Basic Info' })
+			},
+			{
+				id: 'ingredients',
+				label: $_('product.edit.sections.ingredients', { default: 'Ingredients' })
+			},
+			{ id: 'nutrition', label: $_('product.edit.sections.nutrition', { default: 'Nutrition' }) },
+			{ id: 'prices', label: $_('product.edit.sections.prices', { default: 'Prices' }) },
+			{ id: 'packaging', label: $_('product.edit.sections.packaging', { default: 'Packaging' }) },
+			{ id: 'comment', label: $_('product.edit.sections.comment', { default: 'Comment' }) }
+		];
+
+		if (permissions.isModerator && $preferences.moderator) {
+			list.push({
+				id: 'moderator-tools',
+				label: $_('product.edit.sections.moderator_tools', { default: 'Moderator Tools' })
+			});
+		}
+
+		return list;
+	});
+
+	let ignoreObserver = false;
+	let observerTimeout: ReturnType<typeof setTimeout>;
+
+	function scrollToSection(id: string) {
+		const el = document.getElementById(id);
+		if (el) {
+			const checkbox = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+
+			// Lock scroll observer during manual selection & animations
+			ignoreObserver = true;
+			clearTimeout(observerTimeout);
+			observerTimeout = setTimeout(() => {
+				ignoreObserver = false;
+			}, 1000);
+
+			// If already active, toggle collapse state
+			if (activeSection === id) {
+				if (checkbox) {
+					checkbox.checked = !checkbox.checked;
+					checkbox.dispatchEvent(new Event('change'));
+				}
+			} else {
+				if (checkbox && !checkbox.checked) {
+					checkbox.checked = true;
+					checkbox.dispatchEvent(new Event('change'));
+				}
+			}
+
+			// Scroll and ensure active
+			const headerOffset = 100;
+			const elementPosition = el.getBoundingClientRect().top + window.scrollY;
+			const offsetPosition = elementPosition - headerOffset;
+
+			window.scrollTo({
+				top: offsetPosition,
+				behavior: 'smooth'
+			});
+
+			activeSection = id;
+		}
+	}
+
+	function toggleAllSections() {
+		// Lock sidebar during global toggle
+		ignoreObserver = true;
+		clearTimeout(observerTimeout);
+		observerTimeout = setTimeout(() => {
+			ignoreObserver = false;
+		}, 1000);
+
+		$preferences.editing.expandAllSections = !$preferences.editing.expandAllSections;
+		const checkboxes = document.querySelectorAll(
+			'.collapse-arrow > input[type="checkbox"]'
+		) as NodeListOf<HTMLInputElement>;
+		checkboxes.forEach((cb) => {
+			cb.checked = $preferences.editing.expandAllSections;
+			cb.dispatchEvent(new Event('change'));
+		});
+	}
+
+	export function handleCollapseToggle(id: string) {
+		// Lock sidebar during collapse transition
+		ignoreObserver = true;
+		clearTimeout(observerTimeout);
+		observerTimeout = setTimeout(() => {
+			ignoreObserver = false;
+		}, 1000);
+
+		activeSection = id;
+	}
+
+	function updateActiveSection() {
+		if (ignoreObserver) return;
+
+		let currentSection = sidebarSections[0]?.id || '';
+		let isPreviousCollapsed = false;
+
+		const isAtBottom =
+			window.scrollY > 0 &&
+			window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 50;
+
+		if (isAtBottom) {
+			currentSection = sidebarSections[sidebarSections.length - 1]?.id || '';
+		} else {
+			for (let i = 0; i < sidebarSections.length; i++) {
+				const section = sidebarSections[i];
+				const el = document.getElementById(section.id);
+				if (el) {
+					const rect = el.getBoundingClientRect();
+
+					const threshold = i > 0 && isPreviousCollapsed ? 60 : 120;
+
+					if (rect.top <= threshold) {
+						currentSection = section.id;
+					} else {
+						break;
+					}
+
+					const checkbox = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+					isPreviousCollapsed = checkbox ? !checkbox.checked : false;
+				}
+			}
+		}
+
+		if (currentSection && activeSection !== currentSection) {
+			activeSection = currentSection;
+		}
+	}
+
+	onMount(() => {
+		let ticking = false;
+
+		function handleScroll() {
+			if (!ticking) {
+				window.requestAnimationFrame(() => {
+					updateActiveSection();
+					ticking = false;
+				});
+				ticking = true;
+			}
+		}
+
+		window.addEventListener('scroll', handleScroll, { passive: true });
+
+		const timer = setTimeout(() => {
+			updateActiveSection();
+		}, 300);
+
+		return () => {
+			clearTimeout(timer);
+			window.removeEventListener('scroll', handleScroll);
+		};
+	});
+</script>
+
+<div class="hidden lg:block 2xl:absolute 2xl:right-full 2xl:mr-8 2xl:top-0 2xl:h-full">
+	<aside class="sticky top-24 w-60 max-h-[calc(100vh-140px)] overflow-y-auto pr-2">
+		<div class="flex items-center justify-end mb-4 px-1">
+			<button
+				type="button"
+				onclick={toggleAllSections}
+				class="text-xs text-primary/70 hover:text-primary transition-colors cursor-pointer select-none underline font-medium"
+			>
+				{$preferences.editing.expandAllSections
+					? $_('product.edit.sidebar.collapse_all', { default: 'Collapse All' })
+					: $_('product.edit.sidebar.expand_all', { default: 'Expand All' })}
+			</button>
+		</div>
+		<nav
+			bind:this={navElement}
+			class="relative border-l-2 border-base-300 flex flex-col gap-1 pl-4 text-sm"
+		>
+			<!-- Active indicator line with smooth sliding transition -->
+			{#if indicatorHeight > 0}
+				<div
+					class="absolute -left-0.5 w-0.5 bg-primary rounded-full transition-all duration-300 ease-in-out"
+					style="top: {indicatorTop}px; height: {indicatorHeight}px;"
+				></div>
+			{/if}
+			{#each sidebarSections as section (section.id)}
+				<button
+					type="button"
+					data-section={section.id}
+					onclick={() => scrollToSection(section.id)}
+					class="group flex items-center py-2 text-left relative transition-all duration-200 outline-none select-none hover:text-primary cursor-pointer {activeSection ===
+					section.id
+						? 'text-primary font-semibold'
+						: 'text-base-content/60'}"
+				>
+					<span>{section.label}</span>
+				</button>
+			{/each}
+		</nav>
+	</aside>
+</div>


### PR DESCRIPTION
Closes #1477 

### Screenshot or video


https://github.com/user-attachments/assets/c6184a33-289e-49f5-a8e3-297c0f510539



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive product-edit sidebar with smooth section navigation, active-section highlighting, and a sliding indicator.
  * Added global **Expand All / Collapse All** controls that keep section states in sync.
  * Improved collapsible behavior on mobile (sections default to collapsed).

* **Chores**
  * Updated the saved “expand sections” preference to default to expanded, with an automatic migration to apply it.
  * Added i18n text for **Expand All** and **Collapse All**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->