### PR TITLE
chore: enforce strict typescript no-explicit-any eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,6 +64,7 @@ export default [
 					argsIgnorePattern: '^_$'
 				}
 			],
+			'@typescript-eslint/no-explicit-any': 'error',
 			// Re-enable when the following issues are resolved:
 			// - https://github.com/sveltejs/eslint-plugin-svelte/issues/1336
 			// - https://github.com/sveltejs/eslint-plugin-svelte/issues/1329


### PR DESCRIPTION
This PR updates the ESLint configuration to enforce that any usage of the `any` type triggers an ESLint compilation error.

We previously verified that the codebase passes this check with zero warnings or errors.

## LLM Disclosure
- **Agent Name:** Antigravity (Advanced Agentic Coding team)
- **Model Version:** Gemini 3.5 Flash
- **Usage:** Agentic (implemented the configuration rule change, verified linting output, and automated PR creation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality standards for the development team by enforcing stricter type checking rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->