### PR TITLE
docs: move CONTRIBUTING and DESIGN to docs/ and list webcomponents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This is the canonical guide for AI agents working on this repository.
 **Read this file before doing anything else.**
 
-> Humans contributing code should read [CONTRIBUTING.md](CONTRIBUTING.md) instead.
+> Humans contributing code should read [CONTRIBUTING.md](docs/CONTRIBUTING.md) instead.
 > This file is intentionally structured for machine consumption.
 
 ---
@@ -108,7 +108,7 @@ src/
 
 ### UI & Design
 
-- **Read [DESIGN.md](DESIGN.md) before writing any UI code.** It defines the component patterns, colour tokens, button hierarchy, and responsive conventions.
+- **Read [DESIGN.md](docs/DESIGN.md) before writing any UI code.** It defines the component patterns, colour tokens, button hierarchy, and responsive conventions.
 - Always use DaisyUI semantic tokens (`bg-primary`, `text-base-content`) — never hardcode hex values.
 - Follow the button priority hierarchy defined in DESIGN.md.
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ By building a new frontend, we want to be able to iterate faster on the user exp
 >
 > Remember that most people here are volunteers, and the free time they spend on this project is time they could have spent with their family, friends, or on other hobbies. Please respect that by making sure your contributions are of high quality and don't create extra work for the maintainers.
 >
-> For more information, see the [Contribution Guidelines](CONTRIBUTING.md).
+> For more information, see the [Contribution Guidelines](docs/CONTRIBUTING.md).
 
 ## Contributing
 
-| Guide                              | Audience                                 |
-| ---------------------------------- | ---------------------------------------- |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | Humans contributing code                 |
-| [AGENTS.md](AGENTS.md)             | AI agents (Claude, Copilot, Codex, etc.) |
-| [DESIGN.md](DESIGN.md)             | Anyone building or reviewing UI          |
+| Guide                                   | Audience                                 |
+| --------------------------------------- | ---------------------------------------- |
+| [CONTRIBUTING.md](docs/CONTRIBUTING.md) | Humans contributing code                 |
+| [AGENTS.md](AGENTS.md)                  | AI agents (Claude, Copilot, Codex, etc.) |
+| [DESIGN.md](docs/DESIGN.md)             | Anyone building or reviewing UI          |
 
 ## Design
 
-> **New to the project?** Check out our **[Design Guide](DESIGN.md)** for patterns, colors, and best practices.
+> **New to the project?** Check out our **[Design Guide](docs/DESIGN.md)** for patterns, colors, and best practices.
 
 - We currently don’t have any real visual mockup of it, nor “artistic direction” so for the time being, we're copying key features from the current frontend, improving them whenever we can.
 - [![Figma](https://img.shields.io/badge/figma-%23F24E1E.svg?logo=figma&logoColor=white) Mockups on the current website](https://www.figma.com/design/Qg9URUyrjHgYmnDHXRsTTB/Current-Website-design?m=auto&t=RokuCr1uXrGFMhTB-6)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to the OpenFoodFacts Explorer projec
 
 ### Contributing as an AI agent
 
-If you are an AI agent (Claude, Copilot, Codex, or similar), read [`AGENTS.md`](AGENTS.md) before doing anything else. It contains all rules, commands, quality gates, and UI conventions you must follow.
+If you are an AI agent (Claude, Copilot, Codex, or similar), read [`AGENTS.md`](../AGENTS.md) before doing anything else. It contains all rules, commands, quality gates, and UI conventions you must follow.
 
 In addition:
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -28,7 +28,7 @@ Our UI is built on a modern stack:
 
 ### Themes & Colors
 
-We define custom **Light** and **Dark** themes in [`src/app.css`](src/app.css). The palette uses warm, natural tones to reflect our food-focused mission.
+We define custom **Light** and **Dark** themes in [`src/app.css`](../src/app.css). The palette uses warm, natural tones to reflect our food-focused mission.
 
 | Token               | Semantic Role                  | Light Mode               | Dark Mode              |
 | ------------------- | ------------------------------ | ------------------------ | ---------------------- |

--- a/docs/webcomponents.md
+++ b/docs/webcomponents.md
@@ -1,0 +1,64 @@
+# Web Components Documentation
+
+This project uses Lit-based web components provided by the `@openfoodfacts/openfoodfacts-webcomponents` library to render interactive widgets and edit UI sections.
+
+## Installation & Setup
+
+1. **Dependency**: Registered in `package.json` under `dependencies`:
+   - `@openfoodfacts/openfoodfacts-webcomponents`
+   - `@webcomponents/webcomponentsjs` (for polyfill loader support)
+
+2. **Loading**: Web components are dynamically imported on the client-side within the `onMount` lifecycle of [layout.svelte](../src/routes/%2Blayout.svelte):
+
+   ```typescript
+   onMount(async () => {
+   	await import('@openfoodfacts/openfoodfacts-webcomponents');
+   });
+   ```
+
+3. **Global Configuration**:
+   The component `<off-webcomponents-configuration>` is declared once in [layout.svelte](../src/routes/%2Blayout.svelte) to configure global settings:
+
+   ```html
+   <off-webcomponents-configuration
+       bind:this={config}
+       language-code={$preferences.lang ?? getLocale()?.split('-')[0]?.toLowerCase() ?? 'en'}
+       assets-images-path="/assets/webcomponents"
+       robotoff-configuration={JSON.stringify({
+           dryRun: dev,
+           apiUrl: ROBOTOFF_URL + '/api/v1',
+           imgUrl: IMAGE_HOST + '/images/products'
+       })}
+   >
+   </off-webcomponents-configuration>
+   ```
+
+---
+
+## Used Web Components
+
+### 1. `<off-webcomponents-configuration>`
+
+- **Description**: Configures global variables for all other Open Food Facts web components (such as language, assets base path, and Robotoff API details).
+- **Location**: Used in [layout.svelte](../src/routes/%2Blayout.svelte).
+- **Key attributes**:
+  - `language-code`: Sets the interface language.
+  - `assets-images-path`: Directory path for component asset images.
+  - `robotoff-configuration`: A JSON string containing settings for Robotoff interactions.
+
+### 2. `<robotoff-contribution-message>`
+
+- **Description**: Displays interactive question/contribution cards from Robotoff (Open Food Facts' AI engine) to gather user annotations for a product.
+- **Location**: Used in [page.svelte](../src/routes/products/%5Bbarcode%5D/%2Bpage.svelte).
+- **Key attributes**:
+  - `product-code`: The barcode of the product.
+  - `is-logged-in`: Boolean determining if the current user is authenticated.
+
+### 3. `<folksonomy-editor>`
+
+- **Description**: Renders the Folksonomy editor panel, letting users edit custom, informal, or community properties for a product.
+- **Location**: Used in [page.svelte](../src/routes/products/%5Bbarcode%5D/%2Bpage.svelte).
+- **Key attributes**:
+  - `page-type`: Set to `"edit"`.
+  - `product-code`: The barcode of the product.
+  - `auth-token`: The user's OAuth access token.


### PR DESCRIPTION
### Description

This PR reorganizes the documentation and documents web component dependencies:
- Moved `CONTRIBUTING.md` and `DESIGN.md` under `docs/`.
- Updated all relative links and references in `AGENTS.md`, `README.md`, `docs/CONTRIBUTING.md`, and `docs/DESIGN.md` to match the new structure.
- Created `docs/webcomponents.md` listing and documenting the web components used in the application.
- Deleted the old root files.

### Related issue(s) and discussion

- Fixes:

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes Im proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Antigravity (Gemini 3.5 Flash)
  - **How it was used:** agentic (fully automated)
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated contribution and design links into a centralized docs directory for clearer navigation.
  * Updated internal cross-references and relative asset paths for accuracy.
  * Added a new web components guide describing client-side dynamic imports, one-time global configuration, and a detailed list of web components used in routes with their purposes and key attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->