### PR TITLE
feat: add X-OpenFoodFacts-App header to backend requests

### DIFF
--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -141,7 +141,10 @@ export function wrapFetchWithAuth(fetch: typeof window.fetch): typeof window.fet
 
 			// Add the valid access token to the Authorization header
 			headers.set('Authorization', 'Bearer ' + validTokens.access_token);
-			const response = await fetch(input, { ...init, headers });
+
+			// Clone request input to allow retry if body exists
+			const requestInit = { ...init, headers };
+			const response = await fetch(input, requestInit);
 
 			// If still getting 401 (e.g., token was revoked), try one more refresh
 			if (response.status === 401) {

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -116,10 +116,21 @@ export function isTokenExpired(tokens: KeycloakTokens, bufferSeconds = 60): bool
 }
 
 export function wrapFetchWithAuth(fetch: typeof window.fetch): typeof window.fetch {
+	const appHeaderValue = `Explorer (v. ${import.meta.env.PACKAGE_VERSION})`;
+
 	return async (input, init) => {
+		const headers = new Headers(input instanceof Request ? input.headers : undefined);
+		// Add any headers from the init object
+		if (init?.headers) {
+			const initHeaders = new Headers(init.headers);
+			initHeaders.forEach((value, key) => headers.set(key, value));
+		}
+		// Add the application identification header
+		headers.set('X-OpenFoodFacts-App', appHeaderValue);
+
 		const tokens = get(userAuthTokens);
 		if (!tokens) {
-			return fetch(input, init);
+			return fetch(input, { ...init, headers });
 		}
 
 		// Proactively ensure token is valid before making the request
@@ -128,13 +139,8 @@ export function wrapFetchWithAuth(fetch: typeof window.fetch): typeof window.fet
 			const url = new URL(window.location.href);
 			const validTokens = await ensureValidToken(url);
 
-			const headers = new Headers(input instanceof Request ? input.headers : undefined);
-			if (init?.headers) {
-				const initHeaders = new Headers(init.headers);
-				initHeaders.forEach((value, key) => headers.set(key, value));
-			}
+			// Add the valid access token to the Authorization header
 			headers.set('Authorization', 'Bearer ' + validTokens.access_token);
-
 			const response = await fetch(input, { ...init, headers });
 
 			// If still getting 401 (e.g., token was revoked), try one more refresh


### PR DESCRIPTION
### Description

This PR adds the `X-OpenFoodFacts-App` header to backend requests sent via `wrapFetchWithAuth` to identify the Explorer app and its version.

### Screenshot or video

N/A

### Related issue(s) and discussion

- Fixes:

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Antigravity (Gemini 3.5 Flash)
  - **How it was used:** Agentic helper to add the requested header, run validation commands, and open the PR.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Always include a merged set of request headers (including app identification) for outgoing API calls.
  * Use valid access tokens when available; on 401 responses, perform a one-time token refresh and retry the request.
  * If token validation or refresh fails due to missing credentials, clear stored auth data to prevent repeated failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->