### PR TITLE
feat: add P0 analytics tracking events

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Open Food Facts contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Centralized analytics helper for Open Food Facts Explorer.
+ *
+ * Naming convention follows openfoodfacts-server style (category/action/name/value)
+ * with lowercase snake_case. The category string already encodes the slash path,
+ * e.g. category "product" + action "has_nutriscore" → "product/has_nutriscore".
+ *
+ * No barcode, email, username, or image URL should ever be passed here.
+ */
+
+import { get } from 'svelte/store';
+import { tracker } from '$lib/matomo';
+
+/**
+ * Track an Open Food Facts event via Matomo.
+ *
+ * @param category  Event namespace, e.g. "product", "account", "personal_search"
+ * @param action    Specific event, e.g. "has_nutriscore", "login_success"
+ * @param name      Optional label, e.g. grade ("a"), group ("1"), image type ("front")
+ * @param value     Optional numeric value
+ */
+export function trackOffEvent(
+	category: string,
+	action: string,
+	name?: string,
+	value?: number
+): void {
+	const t = get(tracker);
+	if (!t) return;
+
+	try {
+		t.trackEvent(category, action, name, value);
+	} catch {
+		// Analytics should never break the app
+	}
+}

--- a/src/lib/ui/ObsoleteProductCard.svelte
+++ b/src/lib/ui/ObsoleteProductCard.svelte
@@ -2,6 +2,7 @@
 	import { _ } from '$lib/i18n';
 	import IconMdiStoreOff from '@iconify-svelte/mdi/store-off';
 	import type { Product } from '$lib/api';
+	import { trackOffEvent } from '$lib/analytics';
 
 	type Props = {
 		product: Product;
@@ -14,6 +15,7 @@
 	function handleToggle(e: Event) {
 		const target = e.target as HTMLInputElement;
 		product.obsolete = target.checked ? 'on' : '';
+		trackOffEvent('product', 'delete_toggle', target.checked ? 'on' : 'off');
 	}
 </script>
 

--- a/src/lib/ui/edit-product-steps/IngredientsStep.svelte
+++ b/src/lib/ui/edit-product-steps/IngredientsStep.svelte
@@ -14,6 +14,7 @@
 	import { getShortcutCtx } from '$lib/stores/shortcuts';
 	import { onMount } from 'svelte';
 	import { focusEditField } from '$lib/utils/fieldFocus';
+	import { trackOffEvent } from '$lib/analytics';
 	import TagsString from '../../../routes/products/[barcode]/edit/TagsString.svelte';
 
 	type OCRResult = {
@@ -46,6 +47,7 @@
 		}
 
 		ocrLoading = true;
+		trackOffEvent('product', 'launch_ocr', 'ingredients');
 
 		try {
 			const openfoodfacts = createProductsApi(fetch);

--- a/src/lib/ui/images/PhotoManager.svelte
+++ b/src/lib/ui/images/PhotoManager.svelte
@@ -16,6 +16,7 @@
 	} from '$lib/api/product';
 	import type { ImageEditData } from '$lib/utils/imageEdit';
 	import { getToastCtx } from '$lib/stores/toasts';
+	import { trackOffEvent } from '$lib/analytics';
 
 	import PhotoTypeSection from './PhotoTypeSection.svelte';
 	import PhotoEditDialog from './PhotoEditDialog.svelte';
@@ -276,6 +277,7 @@
 			await saveImageWithSelectAndCrop(editingImageData, cropData, rotationAngle);
 
 			toast.success($_('product.edit.images.toast.save_success'));
+			trackOffEvent('product', 'crop_save_image', editingImageData.typeId);
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 			console.error('Error processing image:', error);
@@ -342,6 +344,7 @@
 
 			if (result.data?.status === 'success' || !result.error) {
 				toast.success($_('product.edit.images.toast.unselect_success'));
+				trackOffEvent('product', 'unselect_image', image.typeId);
 				await invalidateAll();
 				editingImageModal?.closeModal();
 			} else {

--- a/src/lib/ui/images/PhotoTypeSection.svelte
+++ b/src/lib/ui/images/PhotoTypeSection.svelte
@@ -15,6 +15,7 @@
 	import IconMdiImagePlus from '@iconify-svelte/mdi/image-plus';
 	import IconMdiFlagOutline from '@iconify-svelte/mdi/flag-outline';
 	import { IMAGE_REPORT_URL } from '$lib/const';
+	import { trackOffEvent } from '$lib/analytics';
 	import { userInfo } from '$lib/stores/user';
 
 	type PhotoType = { id: string; label: string };
@@ -99,6 +100,7 @@
 
 					if (imgid) {
 						toast.success($_('product.edit.images.toast.upload_success'));
+						trackOffEvent('product', 'upload_image', sectionType.id);
 						onImageUploaded(imgid);
 					} else {
 						console.warn('Image upload successful but no valid imgid received:', uploadResult.data);
@@ -138,6 +140,7 @@
 
 			if (result.data?.status === 'success' || !result.error) {
 				toast.success($_('product.edit.images.toast.unselect_success'));
+				trackOffEvent('product', 'unselect_image', sectionType.id);
 				await invalidateAll();
 			} else {
 				console.warn('Image unselect failed:', result);

--- a/src/routes/oauth/login/callback/+page.svelte
+++ b/src/routes/oauth/login/callback/+page.svelte
@@ -7,6 +7,7 @@
 	import { resolve } from '$app/paths';
 	import { createKeycloakApi } from '$lib/api';
 	import { getSafeRedirectUrl } from '$lib/utils';
+	import { trackOffEvent } from '$lib/analytics';
 
 	async function doPkceExchange() {
 		const url = page.url;
@@ -40,6 +41,7 @@
 			});
 			localStorage.removeItem('verifier');
 			saveAuthTokens(jwt);
+			trackOffEvent('account', 'login_success');
 
 			const redirectUrl = localStorage.getItem('authRedirect');
 			localStorage.removeItem('authRedirect');

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -33,6 +33,7 @@
 	import { PRODUCT_URL } from '$lib/const';
 	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
+	import { trackOffEvent } from '$lib/analytics';
 
 	let { data }: PageProps = $props();
 	let { state: productState } = $derived(data);
@@ -59,6 +60,20 @@
 	$effect(() => {
 		// Update website context based on product type
 		if (product.product_type) websiteCtx.flavor = product.product_type;
+	});
+
+	// Track product score presence (fire once per product page view)
+	$effect(() => {
+		const p = product;
+		if (p.nutriscore_grade) {
+			trackOffEvent('product', 'has_nutriscore', p.nutriscore_grade);
+		}
+		if (p.ecoscore_grade) {
+			trackOffEvent('product', 'has_greenscore', p.ecoscore_grade);
+		}
+		if (p.nova_group) {
+			trackOffEvent('product', 'has_nova', String(p.nova_group));
+		}
 	});
 
 	let useWCFolksonomyEditor = $state(false);
@@ -162,7 +177,10 @@
 		<BarcodeInfo code={product.code} />
 	{/if}
 
-	<robotoff-contribution-message product-code={product.code} is-logged-in={$userInfo != null}
+	<robotoff-contribution-message
+		product-code={product.code}
+		is-logged-in={$userInfo != null}
+		onclick={() => trackOffEvent('product', 'open_nutrisight')}
 	></robotoff-contribution-message>
 
 	{#await productAttributes}

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { isConfigured as isPriceConfigured } from '$lib/api/prices';
 	import { isConfigured as isFolksonomyConfigured } from '$lib/api/folksonomy';
 	import { _ } from '$lib/i18n';
@@ -33,6 +35,7 @@
 	import { PRODUCT_URL } from '$lib/const';
 	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { trackOffEvent } from '$lib/analytics';
 
 	let { data }: PageProps = $props();
@@ -63,17 +66,25 @@
 	});
 
 	// Track product score presence (fire once per product page view)
+	const trackedScores = new SvelteSet<string>();
 	$effect(() => {
-		const p = product;
-		if (p.nutriscore_grade) {
-			trackOffEvent('product', 'has_nutriscore', p.nutriscore_grade);
-		}
-		if (p.ecoscore_grade) {
-			trackOffEvent('product', 'has_greenscore', p.ecoscore_grade);
-		}
-		if (p.nova_group) {
-			trackOffEvent('product', 'has_nova', String(p.nova_group));
-		}
+		// Depend only on pathname (navigation), not product data (invalidateAll)
+		const path = page.url.pathname;
+		untrack(() => {
+			const p = product;
+			if (p.code && !trackedScores.has(path)) {
+				trackedScores.add(path);
+				if (p.nutriscore_grade) {
+					trackOffEvent('product', 'has_nutriscore', p.nutriscore_grade);
+				}
+				if (p.ecoscore_grade) {
+					trackOffEvent('product', 'has_greenscore', p.ecoscore_grade);
+				}
+				if (p.nova_group) {
+					trackOffEvent('product', 'has_nova', String(p.nova_group));
+				}
+			}
+		});
 	});
 
 	let useWCFolksonomyEditor = $state(false);

--- a/src/routes/products/[barcode]/edit/+page.svelte
+++ b/src/routes/products/[barcode]/edit/+page.svelte
@@ -3,6 +3,7 @@
 	import ISO6391 from 'iso-639-1';
 	import { SvelteSet } from 'svelte/reactivity';
 	import { _ } from '$lib/i18n';
+	import { trackOffEvent } from '$lib/analytics';
 
 	import {
 		getOrDefault,
@@ -335,6 +336,7 @@
 					return;
 				} else {
 					console.debug('Obsolete status updated successfully');
+					trackOffEvent('product', 'delete_submitted');
 				}
 				console.groupEnd();
 			}


### PR DESCRIPTION
## Summary

Add centralized `trackOffEvent` helper (`src/lib/analytics.ts`) for consistent Matomo event naming following openfoodfacts-server conventions (`category/action/name`).

### Events implemented

| Event | Trigger | Privacy |
|---|---|---|
| `product/has_nutriscore/{grade}` | Product page view | grade only, no barcode |
| `product/has_greenscore/{grade}` | Product page view | grade only |
| `product/has_nova/{group}` | Product page view | group only |
| `product/open_nutrisight` | Robotoff contribution CTA click | click only, no OCR text |
| `account/login_success` | OAuth PKCE callback after token save | no email/username |
| `product/delete_toggle` | Obsolete checkbox toggle | on/off only |
| `product/delete_submitted` | V3 obsolete API success | no barcode |
| `product/upload_image` | Image upload success | image type only |
| `product/crop_save_image` | Image crop/save success | image type only |
| `product/unselect_image` | Image unselect success | image type only |
| `product/launch_ocr` | Ingredients OCR button click | "ingredients" only |

### Privacy

No barcode, email, username, or image URLs are included in any event payload. Only grade/group/image type labels are sent.

### Verification

- [x] `pnpm check` — 0 errors
- [x] `pnpm lint` — clean
- [x] `pnpm format` — clean
- [x] `pnpm build` — success
- [x] `pnpm test` — 23/23 pass

This is an AI-generated PR. Agent: task, model: xiaomi/mimo-v2.5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive analytics tracking throughout the app to capture user interactions including product edits, image management, OCR launches, login events, and product page views with metadata indicators.

* **Chores**
  * Established centralized analytics helper module for consistent event tracking across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->