### PR TITLE
fix(search): validate pagination parameters

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -31,5 +31,6 @@ describe('requirePositiveInt', () => {
 		expect(() => requirePositiveInt('0', throwInvalid)).toThrow('invalid');
 		expect(() => requirePositiveInt('-1', throwInvalid)).toThrow('invalid');
 		expect(() => requirePositiveInt('abc', throwInvalid)).toThrow('invalid');
+		expect(() => requirePositiveInt('', throwInvalid)).toThrow('invalid');
 	});
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { requireInt, requirePositiveInt } from './utils';
+
+const throwInvalid = () => {
+	throw new Error('invalid');
+};
+
+describe('requireInt', () => {
+	it('returns a parsed integer for strict integer strings', () => {
+		expect(requireInt('42', throwInvalid)).toBe(42);
+		expect(requireInt('-7', throwInvalid)).toBe(-7);
+		expect(requireInt(' 3 ', throwInvalid)).toBe(3);
+	});
+
+	it('rejects malformed integer values', () => {
+		expect(() => requireInt(null, throwInvalid)).toThrow('invalid');
+		expect(() => requireInt('abc', throwInvalid)).toThrow('invalid');
+		expect(() => requireInt('1abc', throwInvalid)).toThrow('invalid');
+		expect(() => requireInt('1.5', throwInvalid)).toThrow('invalid');
+		expect(() => requireInt('', throwInvalid)).toThrow('invalid');
+	});
+});
+
+describe('requirePositiveInt', () => {
+	it('returns a parsed integer when the value is positive', () => {
+		expect(requirePositiveInt('1', throwInvalid)).toBe(1);
+		expect(requirePositiveInt('24', throwInvalid)).toBe(24);
+	});
+
+	it('rejects zero, negative, and malformed values', () => {
+		expect(() => requirePositiveInt('0', throwInvalid)).toThrow('invalid');
+		expect(() => requirePositiveInt('-1', throwInvalid)).toThrow('invalid');
+		expect(() => requirePositiveInt('abc', throwInvalid)).toThrow('invalid');
+	});
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,10 +49,26 @@ export function requireInt(value: string | null, error: () => never) {
 	if (value == null) {
 		error();
 	}
-	const intValue = parseInt(value, 10);
-	if (isNaN(intValue)) {
+
+	const normalizedValue = value.trim();
+	if (!/^-?\d+$/.test(normalizedValue)) {
 		error();
 	}
+
+	const intValue = Number(normalizedValue);
+	if (!Number.isSafeInteger(intValue)) {
+		error();
+	}
+
+	return intValue;
+}
+
+export function requirePositiveInt(value: string | null, error: () => never) {
+	const intValue = requireInt(value, error);
+	if (intValue < 1) {
+		error();
+	}
+
 	return intValue;
 }
 

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -97,10 +97,10 @@ export const load: PageServerLoad = async ({ fetch, url }) => {
 		redirect(308, `/products/${query}`);
 	}
 
-	const page = requirePositiveInt(url.searchParams.get('page') || '1', () =>
+	const page = requirePositiveInt(url.searchParams.get('page') ?? '1', () =>
 		error(400, 'Invalid page number')
 	);
-	const pageSize = requirePositiveInt(url.searchParams.get('page_size') || '24', () =>
+	const pageSize = requirePositiveInt(url.searchParams.get('page_size') ?? '24', () =>
 		error(400, 'Invalid page size')
 	);
 

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -6,6 +6,7 @@ import { PricesApi, SearchApi, type SearchBody } from '@openfoodfacts/openfoodfa
 import { createSearchApi, type SearchResult } from '$lib/api/search';
 import { createPricesApi, isConfigured as isPricesConfigured } from '$lib/api/prices';
 import { createProductsApi, getBulkProductAttributes } from '$lib/api/product';
+import { requirePositiveInt } from '$lib/utils';
 
 function isValidEAN13(code: string): boolean {
 	if (!/^\d{13}$/.test(code)) {
@@ -96,8 +97,12 @@ export const load: PageServerLoad = async ({ fetch, url }) => {
 		redirect(308, `/products/${query}`);
 	}
 
-	const page = parseInt(url.searchParams.get('page') || '1', 10);
-	const pageSize = parseInt(url.searchParams.get('page_size') || '24', 10);
+	const page = requirePositiveInt(url.searchParams.get('page') || '1', () =>
+		error(400, 'Invalid page number')
+	);
+	const pageSize = requirePositiveInt(url.searchParams.get('page_size') || '24', () =>
+		error(400, 'Invalid page size')
+	);
 
 	const api = createSearchApi(fetch);
 


### PR DESCRIPTION
### Description

Validates the `/search` `page` and `page_size` query parameters as strict positive integers before calling the search API. Invalid, empty, zero, negative, fractional, trailing-character, and unsafe-integer values now produce a clear HTTP 400 response instead of reaching the backend with malformed pagination.

This also tightens `requireInt`, adds `requirePositiveInt`, and adds focused unit coverage for both helpers.

### Screenshot or video

Not applicable: this is server-side validation with no visual UI change.

### Related issue(s) and discussion

- Fixes: #1520

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** OpenAI Codex (GPT-5)
  - **How it was used:** Agentic implementation, review-feedback handling, rebase, test execution, and self-review.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

### Validation

- `pnpm format`
- `pnpm lint`
- `pnpm check` — 0 errors; 2 pre-existing accessibility warnings in `src/routes/products/[barcode]/+page.svelte`
- `pnpm test` — 6 files, 27 tests passed
- `pnpm build`
- `git diff --check origin/main...HEAD`
