### PR TITLE
feat(edit): replace existing image

### DIFF
--- a/src/lib/ui/images/PhotoEditDialog.svelte
+++ b/src/lib/ui/images/PhotoEditDialog.svelte
@@ -14,6 +14,7 @@
 	import IconMdiImageRemove from '@iconify-svelte/mdi/image-remove';
 	import IconMdiFlag from '@iconify-svelte/mdi/flag';
 	import IconMdiCheck from '@iconify-svelte/mdi/check';
+	import IconMdiUpload from '@iconify-svelte/mdi/upload';
 
 	type CropData = {
 		x: number;
@@ -60,10 +61,12 @@
 		reportImageUrl: string;
 		onSave: (data: EditData) => void;
 		onImageUnselected: () => void;
+		onImageReplace?: () => void;
 		onClose?: () => void;
 	};
 
-	let { image, reportImageUrl, onClose, onSave, onImageUnselected }: Props = $props();
+	let { image, reportImageUrl, onClose, onSave, onImageUnselected, onImageReplace }: Props =
+		$props();
 
 	const toast = getToastCtx();
 
@@ -702,6 +705,22 @@
 					<IconMdiImageRemove class="h-4 w-4" aria-hidden="true" />
 					{$_('product.edit.images.unselect_image', { default: 'Unselect Image' })}
 				</button>
+
+				{#if onImageReplace}
+					<button
+						type="button"
+						class="btn btn-outline hover:btn-outline hover:btn-info"
+						onclick={() => {
+							closeModal();
+							onImageReplace?.();
+						}}
+						disabled={!canPerformActions}
+						aria-label="Replace this image"
+					>
+						<IconMdiUpload class="h-4 w-4" aria-hidden="true" />
+						{$_('product.edit.images.replace_image', { default: 'Replace Image' })}
+					</button>
+				{/if}
 
 				{#if reportImageUrl}
 					<a

--- a/src/lib/ui/images/PhotoEditDialog.svelte
+++ b/src/lib/ui/images/PhotoEditDialog.svelte
@@ -714,8 +714,9 @@
 							closeModal();
 							onImageReplace?.();
 						}}
-						disabled={!canPerformActions}
-						aria-label="Replace this image"
+						aria-label={$_('product.edit.images.replace_image_aria', {
+							default: 'Replace this image'
+						})}
 					>
 						<IconMdiUpload class="h-4 w-4" aria-hidden="true" />
 						{$_('product.edit.images.replace_image', { default: 'Replace Image' })}

--- a/src/lib/ui/images/PhotoManager.svelte
+++ b/src/lib/ui/images/PhotoManager.svelte
@@ -466,6 +466,15 @@
 		onClose={closeEditModal}
 		onSave={saveCurrentImage}
 		onImageUnselected={unselectCurrentImage}
+		onImageReplace={() => {
+			if (editingImageData) {
+				const inputId = `${editingImageData.typeId}-${activeLanguageCode}-upload`;
+				const fileInput = document.getElementById(inputId);
+				if (fileInput instanceof HTMLInputElement) {
+					fileInput.click();
+				}
+			}
+		}}
 	/>
 {/if}
 

--- a/src/lib/ui/images/PhotoTypeSection.svelte
+++ b/src/lib/ui/images/PhotoTypeSection.svelte
@@ -86,7 +86,8 @@
 				return;
 			}
 
-			if (uploadResult.data?.status === 'success') {
+			const status = uploadResult.data?.status;
+			if (status === 'success' || status === 'success_with_warnings') {
 				if (onImageUploaded) {
 					// FIXME: The API response typing is incorrect, so we need to cast here
 					// to access the uploaded images
@@ -99,7 +100,20 @@
 						firstImageKey && uploadedImages ? uploadedImages[firstImageKey]?.imgid : null;
 
 					if (imgid) {
-						toast.success($_('product.edit.images.toast.upload_success'));
+						const isDuplicate =
+							uploadResult.data.warnings?.[0]?.message?.id === 'image_already_uploaded';
+
+						if (isDuplicate) {
+							toast.warning(
+								$_('product.edit.images.toast.already_uploaded', {
+									default:
+										'This image was already uploaded; reusing the existing photo to replace the active one.'
+								})
+							);
+						} else {
+							toast.success($_('product.edit.images.toast.upload_success'));
+						}
+
 						trackOffEvent('product', 'upload_image', sectionType.id);
 						onImageUploaded(imgid);
 					} else {
@@ -207,6 +221,17 @@
 				{/if}
 			</button>
 			{#if isStandardType && hasImagesOfType}
+				<button
+					type="button"
+					class="btn btn-xs sm:btn-sm btn-outline w-full sm:w-auto"
+					disabled={isUploading || isUnselecting}
+					onclick={() => triggerFileInput(inputId)}
+				>
+					<IconMdiUpload class="h-3 w-3 sm:h-4 sm:w-4" />
+					<span class="text-xs sm:text-sm"
+						>{$_('product.edit.images.replace', { default: 'Replace' })}</span
+					>
+				</button>
 				<button
 					type="button"
 					class="btn btn-xs sm:btn-sm btn-outline btn-error w-full sm:w-auto"

--- a/src/lib/ui/images/PhotoTypeSection.svelte
+++ b/src/lib/ui/images/PhotoTypeSection.svelte
@@ -202,28 +202,30 @@
 				disabled={isUploading}
 				onchange={(e) => handleImageUpload(e, sectionType.label)}
 			/>
-			<button
-				type="button"
-				class="btn btn-xs sm:btn-sm btn-outline w-full sm:w-auto"
-				class:loading={isUploading}
-				disabled={isUploading}
-				onclick={() => triggerFileInput(inputId)}
-			>
-				{#if isUploading}
-					<span class="loading loading-spinner h-3 w-3 sm:h-4 sm:w-4"></span>
-					<span class="text-xs sm:text-sm"
-						>{$_('product.edit.images.uploading', { default: 'Uploading...' })}</span
-					>
-				{:else}
-					<IconMdiUpload class="h-3 w-3 sm:h-4 sm:w-4" />
-					<span class="text-xs sm:text-sm"
-						>{$_('product.edit.images.upload_type', {
-							values: { type: sectionType.label },
-							default: 'Upload ' + sectionType.label
-						})}</span
-					>
-				{/if}
-			</button>
+			{#if !(isStandardType && hasImagesOfType)}
+				<button
+					type="button"
+					class="btn btn-xs sm:btn-sm btn-outline w-full sm:w-auto"
+					class:loading={isUploading}
+					disabled={isUploading}
+					onclick={() => triggerFileInput(inputId)}
+				>
+					{#if isUploading}
+						<span class="loading loading-spinner h-3 w-3 sm:h-4 sm:w-4"></span>
+						<span class="text-xs sm:text-sm"
+							>{$_('product.edit.images.uploading', { default: 'Uploading...' })}</span
+						>
+					{:else}
+						<IconMdiUpload class="h-3 w-3 sm:h-4 sm:w-4" />
+						<span class="text-xs sm:text-sm"
+							>{$_('product.edit.images.upload_type', {
+								values: { type: sectionType.label },
+								default: 'Upload ' + sectionType.label
+							})}</span
+						>
+					{/if}
+				</button>
+			{/if}
 			{#if isStandardType && hasImagesOfType}
 				<button
 					type="button"

--- a/src/lib/ui/images/PhotoTypeSection.svelte
+++ b/src/lib/ui/images/PhotoTypeSection.svelte
@@ -111,7 +111,11 @@
 								})
 							);
 						} else {
-							toast.success($_('product.edit.images.toast.upload_success'));
+							toast.success(
+								$_('product.edit.images.toast.upload_success', {
+									default: 'Image uploaded successfully.'
+								})
+							);
 						}
 
 						trackOffEvent('product', 'upload_image', sectionType.id);


### PR DESCRIPTION
Closes #1353 

### Screenshot or video



https://github.com/user-attachments/assets/9770da86-9109-49fd-96a8-43bf43f63d62





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added a “Replace Image” workflow for photo sections that already have images, including a dedicated “Replace” button when images exist.
- Extended photo editing so the edit dialog can trigger image replacement from within the modal.

**Improvements / Bug Fixes**
- Improved upload handling by treating `success_with_warnings` as successful.
- Notifications now branch: if the warning indicates the image was already uploaded, the app shows a “reusing existing photo” warning; otherwise it shows the standard upload success message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->