### PR TITLE
fix: hide duplicate section headers in edit mode

### DIFF
--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -127,7 +127,7 @@
 				{$_('product.edit.sections.languages')}
 			</div>
 			<div class="collapse-content">
-				<LanguagesStep bind:product {addLanguage} codes={languages} />
+				<LanguagesStep bind:product {addLanguage} codes={languages} editMode />
 			</div>
 		</div>
 
@@ -145,7 +145,7 @@
 				{$_('product.edit.sections.images')}
 			</div>
 			<div class="collapse-content">
-				<ImagesStep bind:product />
+				<ImagesStep bind:product editMode />
 			</div>
 		</div>
 
@@ -171,6 +171,7 @@
 					{labelNames}
 					{originNames}
 					{storeNames}
+					editMode
 				/>
 			</div>
 		</div>
@@ -189,7 +190,7 @@
 				{$_('product.edit.sections.ingredients')}
 			</div>
 			<div class="collapse-content">
-				<IngredientsStep bind:product {getIngredientsImage} {allergenNames} />
+				<IngredientsStep bind:product {getIngredientsImage} {allergenNames} editMode />
 			</div>
 		</div>
 
@@ -208,7 +209,7 @@
 				{$_('product.edit.sections.nutrition')}
 			</div>
 			<div class="collapse-content">
-				<NutritionStep bind:product {units} {getNutritionImage} {handleNutrimentInput} />
+				<NutritionStep bind:product {units} {getNutritionImage} {handleNutrimentInput} editMode />
 			</div>
 		</div>
 
@@ -257,7 +258,7 @@
 				{$_('product.edit.sections.packaging')}
 			</div>
 			<div class="collapse-content">
-				<PackagingStep bind:product {getPackagingImage} />
+				<PackagingStep bind:product {getPackagingImage} editMode />
 			</div>
 		</div>
 
@@ -275,7 +276,7 @@
 				{$_('product.edit.sections.comment')}
 			</div>
 			<div class="collapse-content">
-				<CommentStep bind:comment />
+				<CommentStep bind:comment editMode />
 			</div>
 		</div>
 

--- a/src/lib/ui/edit-product-steps/BasicInfoStep.svelte
+++ b/src/lib/ui/edit-product-steps/BasicInfoStep.svelte
@@ -24,6 +24,7 @@
 		storeNames?: string[];
 		originNames?: string[];
 		countriesNames?: string[];
+		editMode?: boolean;
 	};
 
 	let {
@@ -33,7 +34,8 @@
 		brandNames,
 		storeNames,
 		originNames,
-		countriesNames
+		countriesNames,
+		editMode = false
 	}: Props = $props();
 
 	let showInfo = $state(false);
@@ -72,34 +74,36 @@
 	});
 </script>
 
-<h2
-	class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
->
-	<IconMdiInformation class="mr-1 h-6 w-6 align-middle" />
-	{$_('product.edit.sections.basic_info', { default: 'Basic Information' })}
-	<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
-		<IconMdiHelpCircleOutline
-			class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
-		/>
-	</button>
-</h2>
-{#if showInfo}
-	<div
-		class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+{#if !editMode}
+	<h2
+		class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
 	>
-		<button
-			type="button"
-			class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
-			aria-label="Close"
-			onclick={toggleInfo}
-		>
-			<IconMdiClose class="text-primary h-5 w-5" />
+		<IconMdiInformation class="mr-1 h-6 w-6 align-middle" />
+		{$_('product.edit.sections.basic_info', { default: 'Basic Information' })}
+		<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
+			<IconMdiHelpCircleOutline
+				class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
+			/>
 		</button>
-		<IconMdiInformationOutline class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
-		<span class="text-base-content/80 p-6 text-sm sm:text-base">
-			{$_('product.edit.info.basic_info')}
-		</span>
-	</div>
+	</h2>
+	{#if showInfo}
+		<div
+			class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+		>
+			<button
+				type="button"
+				class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
+				aria-label="Close"
+				onclick={toggleInfo}
+			>
+				<IconMdiClose class="text-primary h-5 w-5" />
+			</button>
+			<IconMdiInformationOutline class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
+			<span class="text-base-content/80 p-6 text-sm sm:text-base">
+				{$_('product.edit.info.basic_info')}
+			</span>
+		</div>
+	{/if}
 {/if}
 <div class="space-y-6">
 	<!-- Product Type (Moderators Only) -->

--- a/src/lib/ui/edit-product-steps/CommentStep.svelte
+++ b/src/lib/ui/edit-product-steps/CommentStep.svelte
@@ -5,8 +5,8 @@
 	import IconMdiClose from '@iconify-svelte/mdi/close';
 	import IconMdiInformation from '@iconify-svelte/mdi/information';
 
-	type Props = { comment: string };
-	let { comment = $bindable() }: Props = $props();
+	type Props = { comment: string; editMode?: boolean };
+	let { comment = $bindable(), editMode = false }: Props = $props();
 
 	let showInfo = $state(false);
 	function toggleInfo() {
@@ -14,34 +14,36 @@
 	}
 </script>
 
-<h2
-	class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
->
-	<IconMdiCommentText class="mr-1 h-6 w-6 align-middle" />
-	{$_('product.edit.sections.comment')}
-	<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
-		<IconMdiHelpCircleOutline
-			class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
-		/>
-	</button>
-</h2>
-{#if showInfo}
-	<div
-		class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+{#if !editMode}
+	<h2
+		class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
 	>
-		<button
-			type="button"
-			class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
-			aria-label="Close"
-			onclick={toggleInfo}
-		>
-			<IconMdiClose class="text-primary h-5 w-5" />
+		<IconMdiCommentText class="mr-1 h-6 w-6 align-middle" />
+		{$_('product.edit.sections.comment')}
+		<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
+			<IconMdiHelpCircleOutline
+				class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
+			/>
 		</button>
-		<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
-		<span class="text-base-content/80 p-6 text-sm sm:text-base"
-			>{$_('product.edit.info.comment')}</span
+	</h2>
+	{#if showInfo}
+		<div
+			class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
 		>
-	</div>
+			<button
+				type="button"
+				class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
+				aria-label="Close"
+				onclick={toggleInfo}
+			>
+				<IconMdiClose class="text-primary h-5 w-5" />
+			</button>
+			<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
+			<span class="text-base-content/80 p-6 text-sm sm:text-base"
+				>{$_('product.edit.info.comment')}</span
+			>
+		</div>
+	{/if}
 {/if}
 <div class="space-y-6">
 	<div class="mb-6 text-center">

--- a/src/lib/ui/edit-product-steps/ImagesStep.svelte
+++ b/src/lib/ui/edit-product-steps/ImagesStep.svelte
@@ -10,8 +10,8 @@
 	import IconMdiInformation from '@iconify-svelte/mdi/information';
 	import IconMdiAlertCircle from '@iconify-svelte/mdi/alert-circle';
 
-	type Props = { product: Product };
-	let { product = $bindable() }: Props = $props();
+	type Props = { product: Product; editMode?: boolean };
+	let { product = $bindable(), editMode = false }: Props = $props();
 
 	let showInfo = $state(false);
 	const toggleInfo = () => {
@@ -19,34 +19,36 @@
 	};
 </script>
 
-<h2
-	class="text-primary mb-6 flex items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
->
-	<IconMdiImageMultiple class="mr-1 h-6 w-6 align-middle" />
-	{$_('product.edit.sections.images')}
-	<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
-		<IconMdiHelpCircleOutline
-			class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
-		/>
-	</button>
-</h2>
-{#if showInfo}
-	<div
-		class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+{#if !editMode}
+	<h2
+		class="text-primary mb-6 flex items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
 	>
-		<button
-			type="button"
-			class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
-			aria-label="Close"
-			onclick={toggleInfo}
-		>
-			<IconMdiClose class="text-primary h-5 w-5" />
+		<IconMdiImageMultiple class="mr-1 h-6 w-6 align-middle" />
+		{$_('product.edit.sections.images')}
+		<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
+			<IconMdiHelpCircleOutline
+				class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
+			/>
 		</button>
-		<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
-		<span class="text-base-content/80 p-6 text-sm sm:text-base">
-			{$_('product.edit.info.images')}
-		</span>
-	</div>
+	</h2>
+	{#if showInfo}
+		<div
+			class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+		>
+			<button
+				type="button"
+				class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
+				aria-label="Close"
+				onclick={toggleInfo}
+			>
+				<IconMdiClose class="text-primary h-5 w-5" />
+			</button>
+			<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
+			<span class="text-base-content/80 p-6 text-sm sm:text-base">
+				{$_('product.edit.info.images')}
+			</span>
+		</div>
+	{/if}
 {/if}
 
 <!-- Legal warning about photo copyright -->

--- a/src/lib/ui/edit-product-steps/IngredientsStep.svelte
+++ b/src/lib/ui/edit-product-steps/IngredientsStep.svelte
@@ -30,9 +30,15 @@
 		product: Product;
 		getIngredientsImage: (language: string) => string | null;
 		allergenNames?: string[];
+		editMode?: boolean;
 	};
 
-	let { product = $bindable(), getIngredientsImage, allergenNames = [] }: Props = $props();
+	let {
+		product = $bindable(),
+		getIngredientsImage,
+		allergenNames = [],
+		editMode = false
+	}: Props = $props();
 
 	let showInfo = $state(false);
 	let ocrLoading = $state(false);
@@ -96,34 +102,36 @@
 	});
 </script>
 
-<h2
-	class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
->
-	<IconMdiFormatListBulleted class="mr-1 h-6 w-6 align-middle" />
-	{$_('product.edit.sections.ingredients')}
-	<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
-		<IconMdiHelpCircleOutline
-			class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
-		/>
-	</button>
-</h2>
-{#if showInfo}
-	<div
-		class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+{#if !editMode}
+	<h2
+		class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
 	>
-		<button
-			type="button"
-			class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
-			aria-label="Close"
-			onclick={toggleInfo}
-		>
-			<IconMdiClose class="text-primary h-5 w-5" />
+		<IconMdiFormatListBulleted class="mr-1 h-6 w-6 align-middle" />
+		{$_('product.edit.sections.ingredients')}
+		<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
+			<IconMdiHelpCircleOutline
+				class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
+			/>
 		</button>
-		<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
-		<span class="text-base-content/80 p-6 text-sm sm:text-base">
-			{$_('product.edit.info.ingredients')}
-		</span>
-	</div>
+	</h2>
+	{#if showInfo}
+		<div
+			class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+		>
+			<button
+				type="button"
+				class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
+				aria-label="Close"
+				onclick={toggleInfo}
+			>
+				<IconMdiClose class="text-primary h-5 w-5" />
+			</button>
+			<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
+			<span class="text-base-content/80 p-6 text-sm sm:text-base">
+				{$_('product.edit.info.ingredients')}
+			</span>
+		</div>
+	{/if}
 {/if}
 <div class="tabs tabs-box">
 	{#each Object.keys(product.languages_codes ?? {}) as code (code)}

--- a/src/lib/ui/edit-product-steps/LanguagesStep.svelte
+++ b/src/lib/ui/edit-product-steps/LanguagesStep.svelte
@@ -15,11 +15,12 @@
 	type Props = {
 		product: Product;
 		codes: string[];
+		editMode?: boolean;
 
 		addLanguage: (code: string) => void;
 	};
 
-	let { product = $bindable(), codes, addLanguage }: Props = $props();
+	let { product = $bindable(), codes, addLanguage, editMode = false }: Props = $props();
 
 	let languageNames = $derived(
 		codes.map((code) => {
@@ -55,34 +56,36 @@
 	});
 </script>
 
-<h2
-	class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
->
-	<IconMdiTranslate class="mr-1 h-6 w-6 align-middle" />
-	{$_('product.edit.sections.languages')}
-	<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
-		<IconMdiHelpCircleOutline
-			class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
-		/>
-	</button>
-</h2>
-{#if showInfo}
-	<div
-		class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+{#if !editMode}
+	<h2
+		class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
 	>
-		<button
-			type="button"
-			class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
-			aria-label="Close"
-			onclick={toggleInfo}
-		>
-			<IconMdiClose class="text-primary h-5 w-5" />
+		<IconMdiTranslate class="mr-1 h-6 w-6 align-middle" />
+		{$_('product.edit.sections.languages')}
+		<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
+			<IconMdiHelpCircleOutline
+				class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
+			/>
 		</button>
-		<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
-		<span class="text-base-content/80 p-6 text-sm sm:text-base">
-			{$_('product.edit.info.languages')}
-		</span>
-	</div>
+	</h2>
+	{#if showInfo}
+		<div
+			class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+		>
+			<button
+				type="button"
+				class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
+				aria-label="Close"
+				onclick={toggleInfo}
+			>
+				<IconMdiClose class="text-primary h-5 w-5" />
+			</button>
+			<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
+			<span class="text-base-content/80 p-6 text-sm sm:text-base">
+				{$_('product.edit.info.languages')}
+			</span>
+		</div>
+	{/if}
 {/if}
 
 <fieldset class="fieldset">

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -32,9 +32,16 @@
 		units: string[];
 		getNutritionImage: (language: string) => string | null;
 		handleNutrimentInput: (e: Event, key: string) => void;
+		editMode?: boolean;
 	};
 
-	let { product = $bindable(), units, getNutritionImage, handleNutrimentInput }: Props = $props();
+	let {
+		product = $bindable(),
+		units,
+		getNutritionImage,
+		handleNutrimentInput,
+		editMode = false
+	}: Props = $props();
 
 	const IGNORE_NUTRIENTS: NutrientKey[] = ['energy-kj', 'energy-kcal', 'energy'];
 	const DEFAULT_SHOWN: NutrientKey[] = [
@@ -246,34 +253,36 @@
 	</div>
 {/snippet}
 
-<h2
-	class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
->
-	<IconMdiNutrition class="mr-1 h-6 w-6 align-middle" />
-	{$_('product.edit.sections.nutrition')}
-	<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
-		<IconMdiHelpCircleOutline
-			class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
-		/>
-	</button>
-</h2>
-{#if showInfo}
-	<div
-		class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+{#if !editMode}
+	<h2
+		class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
 	>
-		<button
-			type="button"
-			class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
-			aria-label="Close"
-			onclick={toggleInfo}
-		>
-			<IconMdiClose class="text-primary h-5 w-5" />
+		<IconMdiNutrition class="mr-1 h-6 w-6 align-middle" />
+		{$_('product.edit.sections.nutrition')}
+		<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
+			<IconMdiHelpCircleOutline
+				class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
+			/>
 		</button>
-		<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
-		<span class="text-base-content/80 p-6 text-sm sm:text-base"
-			>{$_('product.edit.info.nutrition')}</span
+	</h2>
+	{#if showInfo}
+		<div
+			class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
 		>
-	</div>
+			<button
+				type="button"
+				class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
+				aria-label="Close"
+				onclick={toggleInfo}
+			>
+				<IconMdiClose class="text-primary h-5 w-5" />
+			</button>
+			<IconMdiInformation class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
+			<span class="text-base-content/80 p-6 text-sm sm:text-base"
+				>{$_('product.edit.info.nutrition')}</span
+			>
+		</div>
+	{/if}
 {/if}
 <div class="gap-4 max-md:flex max-md:flex-col-reverse lg:grid lg:grid-cols-2">
 	<div>

--- a/src/lib/ui/edit-product-steps/PackagingStep.svelte
+++ b/src/lib/ui/edit-product-steps/PackagingStep.svelte
@@ -15,9 +15,10 @@
 	type Props = {
 		product: Product;
 		getPackagingImage: (language: string) => string | null;
+		editMode?: boolean;
 	};
 
-	let { product = $bindable(), getPackagingImage }: Props = $props();
+	let { product = $bindable(), getPackagingImage, editMode = false }: Props = $props();
 
 	let showInfo = $state(false);
 	function toggleInfo() {
@@ -25,34 +26,36 @@
 	}
 </script>
 
-<h2
-	class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
->
-	<IconMdiPackageVariant class="mr-1 h-6 w-6 align-middle" />
-	{$_('product.edit.sections.packaging', { default: 'Packaging' })}
-	<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
-		<IconMdiHelpCircleOutline
-			class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
-		/>
-	</button>
-</h2>
-{#if showInfo}
-	<div
-		class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+{#if !editMode}
+	<h2
+		class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
 	>
-		<button
-			type="button"
-			class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
-			aria-label="Close"
-			onclick={toggleInfo}
-		>
-			<IconMdiClose class="text-primary h-5 w-5" />
+		<IconMdiPackageVariant class="mr-1 h-6 w-6 align-middle" />
+		{$_('product.edit.sections.packaging', { default: 'Packaging' })}
+		<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
+			<IconMdiHelpCircleOutline
+				class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
+			/>
 		</button>
-		<IconMdiInformationOutline class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
-		<span class="text-base-content/80 p-6 text-sm sm:text-base">
-			{$_('product.edit.info.packaging')}
-		</span>
-	</div>
+	</h2>
+	{#if showInfo}
+		<div
+			class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+		>
+			<button
+				type="button"
+				class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
+				aria-label="Close"
+				onclick={toggleInfo}
+			>
+				<IconMdiClose class="text-primary h-5 w-5" />
+			</button>
+			<IconMdiInformationOutline class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
+			<span class="text-base-content/80 p-6 text-sm sm:text-base">
+				{$_('product.edit.info.packaging')}
+			</span>
+		</div>
+	{/if}
 {/if}
 
 <PackagingImage


### PR DESCRIPTION
Each step component (LanguagesStep, ImagesStep, BasicInfoStep, IngredientsStep, NutritionStep, PackagingStep, CommentStep) renders its own `<h2>` with icon + title + help button. In edit mode, the collapse section in `EditProductForm.svelte` already provides the same header, creating visual duplicates.

Added an optional `editMode` prop to all 7 step components. When `true`, the `<h2>` and info banner are skipped — only the collapse section header remains visible. In add mode (default), step components render their own headers as before.

**Files changed:**
- `src/lib/ui/edit-product-steps/*.svelte` — added `editMode` prop + `{#if !editMode}` guard
- `src/lib/ui/EditProductForm.svelte` — passes `editMode` to all 7 step components