### PR TITLE
feat: integrate GS1Barcode into QR scan route

### DIFF
--- a/src/lib/barcodes/gs1.test.ts
+++ b/src/lib/barcodes/gs1.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { Gs1Barcode } from './gs1';
+
+describe('Gs1Barcode.parse()', () => {
+	describe('valid barcodes', () => {
+		it('parses EAN-13', () => {
+			const barcode = Gs1Barcode.parse('3123456789019');
+			expect(barcode).not.toBeNull();
+			expect(barcode!.code).toBe('3123456789019');
+			expect(barcode!.gtin).toBe('03123456789019');
+			expect(barcode!.variant).toBe('GTIN-13');
+			expect(barcode!.isEAN13()).toBe(true);
+			expect(barcode!.isUPC()).toBe(false);
+		});
+
+		it('parses EAN-13 (5000159484695)', () => {
+			const barcode = Gs1Barcode.parse('5000159484695');
+			expect(barcode).not.toBeNull();
+			expect(barcode!.code).toBe('5000159484695');
+			expect(barcode!.gtin).toBe('05000159484695');
+			expect(barcode!.variant).toBe('GTIN-13');
+			expect(barcode!.isEAN13()).toBe(true);
+		});
+
+		it('parses EAN-13 (4006381333931)', () => {
+			const barcode = Gs1Barcode.parse('4006381333931');
+			expect(barcode).not.toBeNull();
+			expect(barcode!.code).toBe('4006381333931');
+			expect(barcode!.gtin).toBe('04006381333931');
+			expect(barcode!.variant).toBe('GTIN-13');
+		});
+
+		it('parses UPC-A (GTIN-12)', () => {
+			const barcode = Gs1Barcode.parse('012345678905');
+			expect(barcode).not.toBeNull();
+			expect(barcode!.code).toBe('012345678905');
+			expect(barcode!.gtin).toBe('00012345678905');
+			expect(barcode!.variant).toBe('GTIN-12');
+			expect(barcode!.isUPC()).toBe(true);
+			expect(barcode!.isEAN13()).toBe(false);
+		});
+
+		it('parses EAN-8 (GTIN-8)', () => {
+			const barcode = Gs1Barcode.parse('96385074');
+			expect(barcode).not.toBeNull();
+			expect(barcode!.code).toBe('96385074');
+			expect(barcode!.gtin).toBe('00000096385074');
+			expect(barcode!.variant).toBe('GTIN-8');
+		});
+
+		it('parses GTIN-14', () => {
+			const barcode = Gs1Barcode.parse('00012345678905');
+			expect(barcode).not.toBeNull();
+			expect(barcode!.code).toBe('00012345678905');
+			expect(barcode!.gtin).toBe('00012345678905');
+			expect(barcode!.variant).toBe('GTIN-14');
+		});
+	});
+
+	describe('GS1 Digital Link', () => {
+		it('extracts GTIN from a digital link with query params', () => {
+			const barcode = Gs1Barcode.parse('https://example.com/01/00012345678905?other=stuff');
+			expect(barcode).not.toBeNull();
+			expect(barcode!.code).toBe('00012345678905');
+			expect(barcode!.gtin).toBe('00012345678905');
+		});
+
+		it('extracts GTIN from a digital link with additional path segments', () => {
+			const barcode = Gs1Barcode.parse('https://example.com/01/5000159484695/10/ABC');
+			expect(barcode).not.toBeNull();
+			expect(barcode!.code).toBe('5000159484695');
+			expect(barcode!.gtin).toBe('05000159484695');
+		});
+	});
+
+	describe('invalid input', () => {
+		it('rejects too-short digits', () => {
+			expect(Gs1Barcode.parse('12345')).toBeNull();
+		});
+
+		it('rejects wrong-length digits with valid-looking content', () => {
+			expect(Gs1Barcode.parse('123456789013')).toBeNull();
+		});
+
+		it('rejects EAN-13 with wrong checksum', () => {
+			// 3123456789019 has valid checksum; last digit 2 makes it invalid
+			expect(Gs1Barcode.parse('3123456789012')).toBeNull();
+		});
+
+		it('rejects non-numeric string', () => {
+			expect(Gs1Barcode.parse('not-a-barcode')).toBeNull();
+		});
+
+		it('rejects empty string', () => {
+			expect(Gs1Barcode.parse('')).toBeNull();
+		});
+
+		it('rejects a URL that is not a GS1 Digital Link', () => {
+			expect(Gs1Barcode.parse('https://example.com/product/123')).toBeNull();
+		});
+	});
+});

--- a/src/lib/barcodes/gs1.test.ts
+++ b/src/lib/barcodes/gs1.test.ts
@@ -65,6 +65,12 @@ describe('Gs1Barcode.parse()', () => {
 			expect(barcode!.gtin).toBe('00012345678905');
 		});
 
+		it('extracts GTIN from a digital link with a fragment', () => {
+			const barcode = Gs1Barcode.parse('https://example.com/01/00012345678905#details');
+			expect(barcode).not.toBeNull();
+			expect(barcode!.code).toBe('00012345678905');
+		});
+
 		it('extracts GTIN from a digital link with additional path segments', () => {
 			const barcode = Gs1Barcode.parse('https://example.com/01/5000159484695/10/ABC');
 			expect(barcode).not.toBeNull();
@@ -97,6 +103,10 @@ describe('Gs1Barcode.parse()', () => {
 
 		it('rejects a URL that is not a GS1 Digital Link', () => {
 			expect(Gs1Barcode.parse('https://example.com/product/123')).toBeNull();
+		});
+
+		it('rejects non-URL text containing a GS1-looking path', () => {
+			expect(Gs1Barcode.parse('not-a-url /01/00012345678905')).toBeNull();
 		});
 	});
 });

--- a/src/lib/barcodes/gs1.ts
+++ b/src/lib/barcodes/gs1.ts
@@ -1,0 +1,79 @@
+const GTIN_REGEX = /^\d{8}$|^\d{12,14}$/;
+
+export type GtinVariant = 'GTIN-8' | 'GTIN-12' | 'GTIN-13' | 'GTIN-14';
+
+export class Gs1Barcode {
+	#gtin: string;
+	#code: string;
+	#variant: GtinVariant;
+
+	private constructor(gtin: string) {
+		if (!GTIN_REGEX.test(gtin)) {
+			throw new Error('GTIN must be 8, 12, 13, or 14 digits long');
+		}
+		if (!validateGS1Checksum(gtin)) {
+			throw new Error('Invalid GTIN checksum');
+		}
+
+		this.#variant = `GTIN-${gtin.length}` as GtinVariant;
+		this.#code = gtin;
+		this.#gtin = gtin.padStart(14, '0');
+	}
+
+	get gtin() {
+		return this.#gtin;
+	}
+	get code() {
+		return this.#code;
+	}
+	get variant() {
+		return this.#variant;
+	}
+
+	isEAN13() {
+		return this.#variant === 'GTIN-13';
+	}
+	isUPC() {
+		return this.#variant === 'GTIN-12';
+	}
+
+	static parse(gs1String: string): Gs1Barcode | null {
+		// Could be a digital link
+		const gtinBarcode = parseGs1DigitalLink(gs1String) ?? gs1String;
+		try {
+			return new Gs1Barcode(gtinBarcode);
+		} catch {
+			return null;
+		}
+	}
+}
+
+function parseGs1DigitalLink(barcode: string): string | null {
+	// Matches /01/ followed by 12 to 14 digits, stopping at a slash, question mark, or end of string
+	const gtinRegex = /\/01\/(\d{12,14})(?=\/|\?|$)/;
+	const match = barcode.match(gtinRegex);
+	return match ? match[1] : null;
+}
+
+function validateGS1Checksum(gtin: string): boolean {
+	// Ensure it's a valid GS1 length (8, 12, 13, or 14 digits)
+	if (!GTIN_REGEX.test(gtin)) {
+		return false;
+	}
+
+	const digits = gtin.split('').map(Number);
+	const targetCheckDigit = digits[digits.length - 1];
+	const dataDigits = digits.slice(0, -1);
+
+	const sum = dataDigits.reduce((acc, digit, index) => {
+		const positionFromRight = dataDigits.length - index;
+		// Odd positions from the right get multiplied by 3, even get 1
+		const multiplier = positionFromRight % 2 === 1 ? 3 : 1;
+
+		return acc + digit * multiplier;
+	}, 0);
+
+	const calculatedCheckDigit = (10 - (sum % 10)) % 10;
+
+	return calculatedCheckDigit === targetCheckDigit;
+}

--- a/src/lib/barcodes/gs1.ts
+++ b/src/lib/barcodes/gs1.ts
@@ -49,10 +49,24 @@ export class Gs1Barcode {
 }
 
 function parseGs1DigitalLink(barcode: string): string | null {
-	// Matches /01/ followed by 12 to 14 digits, stopping at a slash, question mark, or end of string
-	const gtinRegex = /\/01\/(\d{12,14})(?=\/|\?|$)/;
-	const match = barcode.match(gtinRegex);
-	return match ? match[1] : null;
+	let url: URL;
+	try {
+		url = new URL(barcode);
+	} catch {
+		return null;
+	}
+
+	if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+		return null;
+	}
+
+	// The primary GTIN key is the path segment immediately following AI 01.
+	// Keep accepting 12- and 13-digit legacy links for backwards compatibility.
+	const pathSegments = url.pathname.split('/').filter(Boolean);
+	const gtinIndex = pathSegments.indexOf('01');
+	const gtin = gtinIndex >= 0 ? pathSegments[gtinIndex + 1] : url.searchParams.get('01');
+
+	return gtin && /^\d{12,14}$/.test(gtin) ? gtin : null;
 }
 
 function validateGS1Checksum(gtin: string): boolean {

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -556,7 +556,8 @@
 		"product_not_found": "Product Not Found",
 		"barcode_scanned_not_found": "Barcode {barcode} was scanned successfully, but no product was found in our Open Food Facts, Open Beauty Facts, Open Products Facts or Open Pet Food Facts.",
 		"add_new_product": "Add new product",
-		"scan_again": "Scan again"
+		"scan_again": "Scan again",
+		"invalid_barcode": "Scanned code is not a valid barcode"
 	},
 	"errors": {
 		"network": {

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -672,6 +672,7 @@
 		"barcode_scanned_not_found": "Barcode {barcode} was scanned successfully, but no product was found in our Open Food Facts, Open Beauty Facts, Open Products Facts or Open Pet Food Facts.",
 		"add_new_product": "Add new product",
 		"scan_again": "Scan again",
+		"invalid_barcode": "Scanned code is not a valid barcode",
 		"manual_barcode": "Enter the barcode manually",
 		"camera_access_required": "Camera access is required. Please enable it in your browser settings."
 	},

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -557,7 +557,8 @@
 		"product_not_found": "Product Not Found",
 		"barcode_scanned_not_found": "Barcode {barcode} was scanned successfully, but no product was found in our Open Food Facts, Open Beauty Facts, Open Products Facts or Open Pet Food Facts.",
 		"add_new_product": "Add new product",
-		"scan_again": "Scan again"
+		"scan_again": "Scan again",
+		"invalid_barcode": "Scanned code is not a valid barcode"
 	},
 	"errors": {
 		"network": {

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -664,6 +664,7 @@
 		"barcode_scanned_not_found": "Barcode {barcode} was scanned successfully, but no product was found in our Open Food Facts, Open Beauty Facts, Open Products Facts or Open Pet Food Facts.",
 		"add_new_product": "Add new product",
 		"scan_again": "Scan again",
+		"invalid_barcode": "Scanned code is not a valid barcode",
 		"manual_barcode": "Enter the barcode manually",
 		"camera_access_required": "Camera access is required. Please enable it in your browser settings."
 	},

--- a/src/params/barcode.ts
+++ b/src/params/barcode.ts
@@ -1,5 +1,5 @@
 import type { ParamMatcher } from '@sveltejs/kit';
 
 export const match: ParamMatcher = (param) => {
-	return /^[0-9]{13}$/gm.test(param);
+	return /^\d{8}$|^\d{12,14}$/.test(param);
 };

--- a/src/routes/qr/+page.svelte
+++ b/src/routes/qr/+page.svelte
@@ -5,6 +5,7 @@
 	import { goto } from '$app/navigation';
 	import { _ } from '$lib/i18n';
 	import { createProductsApi } from '$lib/api';
+	import { Gs1Barcode } from '$lib/barcodes/gs1';
 	import { browser } from '$app/environment';
 
 	let error: string | null = $state(null);
@@ -28,18 +29,22 @@
 				console.debug('QR code detected:', text);
 				lastScannedCode = text;
 
-				// We must stop the scanner first to release the camera
-				// This is important because:
-				// 1. It frees up camera resources
-				// 2. Prevents memory leaks
-				// 3. Ensures the camera is available for other applications
-				await scanner.stop();
+				const barcode = Gs1Barcode.parse(text);
+				if (barcode == null) {
+					await scanner.stop();
+					error = $_('qr.invalid_barcode');
+					return;
+				}
 
+				await scanner.stop();
 				const productsApi = createProductsApi(fetch);
 
-				const { data: productState, error } = await productsApi.getProductV3(text, { fields: [] });
-				if (!productState || error) {
-					console.error('Error fetching product:', error);
+				const { data: productState, error: apiError } = await productsApi.getProductV3(
+					barcode.code,
+					{ fields: [] }
+				);
+				if (!productState || apiError) {
+					console.error('Error fetching product:', apiError);
 					productNotFound = true;
 					return;
 				}
@@ -48,8 +53,7 @@
 					return;
 				}
 
-				// If product is found, navigate to its page
-				await goto('/products/' + text);
+				await goto('/products/' + barcode.code);
 			},
 			() => {
 				/* ignored */
@@ -67,7 +71,7 @@
 
 		const scanner = new Html5Qrcode('reader', {
 			useBarCodeDetectorIfSupported: true,
-			formatsToSupport: [Html5QrcodeSupportedFormats.EAN_13],
+			formatsToSupport: [Html5QrcodeSupportedFormats.EAN_13, Html5QrcodeSupportedFormats.QR_CODE],
 			verbose: false
 		});
 
@@ -97,10 +101,9 @@
 	});
 
 	function addNewProduct() {
-		// Navigate to the product edit page with the scanned barcode
-		if (lastScannedCode) {
-			goto(`/products/${lastScannedCode}/edit`);
-		}
+		const barcode = Gs1Barcode.parse(lastScannedCode);
+		const code = barcode?.code ?? lastScannedCode;
+		goto(`/products/${code}/edit`);
 	}
 
 	async function restartScanner() {

--- a/src/routes/qr/+page.svelte
+++ b/src/routes/qr/+page.svelte
@@ -5,7 +5,6 @@
 	import { goto } from '$app/navigation';
 	import { _ } from '$lib/i18n';
 	import { Gs1Barcode } from '$lib/barcodes/gs1';
-	import { browser } from '$app/environment';
 
 	let error: string | null = $state(null);
 	let html5QrCode: Html5Qrcode | null = null;
@@ -15,12 +14,33 @@
 	let isSubmittingBarcode = $state(false);
 	let canRetryScan = $state(false);
 	let isDestroyed = false;
+	let scanFailureCount = 0;
+	let lastScanFailureLogAt = 0;
 
-	function getQrBoxSize() {
-		if (!browser) throw new Error('getQrBoxSize can only be called inside browser');
+	function getQrBoxSize(viewfinderWidth: number, viewfinderHeight: number) {
+		// html5-qrcode passes the actual camera-frame dimensions here. Keep the
+		// region wide enough for horizontal product barcodes without scanning the
+		// entire frame at native camera resolution.
+		return {
+			width: Math.min(Math.floor(viewfinderWidth * 0.85), 700),
+			height: Math.min(Math.floor(viewfinderHeight * 0.5), 300)
+		};
+	}
 
-		const screenWidth = window.innerWidth;
-		return screenWidth < 640 ? { width: 250, height: 250 } : { width: 400, height: 250 };
+	function logScanFailure(errorMessage: string) {
+		scanFailureCount += 1;
+		const now = Date.now();
+
+		// html5-qrcode calls this for every frame that does not contain a code.
+		// Throttle the diagnostic so it remains useful in the browser console.
+		if (now - lastScanFailureLogAt < 2000) return;
+
+		console.debug('[QR scanner] no code detected', {
+			attemptsSinceLastLog: scanFailureCount,
+			errorMessage
+		});
+		scanFailureCount = 0;
+		lastScanFailureLogAt = now;
 	}
 
 	async function handleBarcodeSubmit(barcode: string) {
@@ -52,11 +72,14 @@
 	async function startScanning(scanner: Html5Qrcode) {
 		return scanner.start(
 			{ facingMode: 'environment' },
-			{ fps: 10, qrbox: getQrBoxSize() },
-			async (text) => {
+			{ fps: 10, qrbox: getQrBoxSize },
+			async (text, result) => {
 				if (isDestroyed || text == null) return;
 				clearScannerTimeout();
-				console.debug('QR code detected:', text);
+				console.info('[QR scanner] code detected', {
+					text,
+					format: result.result.format?.formatName ?? 'unknown'
+				});
 
 				// We must stop the scanner first to release the camera
 				// This is important because:
@@ -73,8 +96,8 @@
 					await handleBarcodeSubmit(text);
 				}
 			},
-			() => {
-				/* ignored */
+			(errorMessage) => {
+				logScanFailure(errorMessage);
 			}
 		);
 	}
@@ -103,6 +126,7 @@
 
 		if (!isDestroyed) {
 			startScannerTimeout();
+			console.info('[QR scanner] camera started');
 		}
 	}
 

--- a/src/routes/qr/+page.svelte
+++ b/src/routes/qr/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy, onMount, tick } from 'svelte';
 	import type { Html5Qrcode } from 'html5-qrcode';
 
 	import { goto } from '$app/navigation';
 	import { _ } from '$lib/i18n';
+	import { Gs1Barcode } from '$lib/barcodes/gs1';
 	import { browser } from '$app/environment';
 
 	let error: string | null = $state(null);
@@ -12,6 +13,7 @@
 	let manualBarcode = $state('');
 	let scannerTimeout: ReturnType<typeof setTimeout> | null = null;
 	let isSubmittingBarcode = $state(false);
+	let canRetryScan = $state(false);
 	let isDestroyed = false;
 
 	function getQrBoxSize() {
@@ -23,13 +25,24 @@
 
 	async function handleBarcodeSubmit(barcode: string) {
 		const code = barcode.trim();
+		const parsedBarcode = Gs1Barcode.parse(code);
+		const fallbackCode = /^(?:\d{5,7}|\d{15,18})$/.test(code) ? code : null;
+		const productCode = parsedBarcode?.code ?? fallbackCode;
 
-		if (isDestroyed || !/^\d{5,18}$/.test(code) || isSubmittingBarcode) return;
+		if (isDestroyed || productCode == null || isSubmittingBarcode) {
+			if (productCode == null && !isDestroyed) {
+				canRetryScan = true;
+				error = $_('qr.invalid_barcode', {
+					default: 'Scanned code is not a valid barcode'
+				});
+			}
+			return;
+		}
 
 		isSubmittingBarcode = true;
 
 		try {
-			await goto(`/search?q=${encodeURIComponent(code)}`);
+			await goto(`/search?q=${encodeURIComponent(productCode)}`);
 		} catch (err) {
 			console.error('Barcode navigation failed:', err);
 			isSubmittingBarcode = false;
@@ -105,7 +118,13 @@
 
 		const scanner = new Html5Qrcode('reader', {
 			useBarCodeDetectorIfSupported: true,
-			formatsToSupport: [Html5QrcodeSupportedFormats.EAN_13],
+			formatsToSupport: [
+				Html5QrcodeSupportedFormats.QR_CODE,
+				Html5QrcodeSupportedFormats.EAN_13,
+				Html5QrcodeSupportedFormats.EAN_8,
+				Html5QrcodeSupportedFormats.UPC_A,
+				Html5QrcodeSupportedFormats.ITF
+			],
 			verbose: false
 		});
 
@@ -152,11 +171,37 @@
 
 		await handleBarcodeSubmit(manualBarcode);
 	}
+
+	async function restartScanner() {
+		try {
+			error = null;
+			canRetryScan = false;
+			scannerTimedOut = false;
+			manualBarcode = '';
+
+			await tick();
+
+			if (html5QrCode) {
+				await startScanner(html5QrCode);
+			}
+		} catch (err) {
+			console.error('Failed to restart the scanner:', err);
+			canRetryScan = true;
+			error = 'Failed to restart the scanner. Please refresh the page.';
+		}
+	}
 </script>
 
 {#if error != null}
 	<div class="flex h-screen items-center justify-center">
-		<p class="text-error">{error}</p>
+		<div class="flex flex-col items-center gap-4 text-center">
+			<p class="text-error">{error}</p>
+			{#if canRetryScan}
+				<button class="btn btn-outline" onclick={restartScanner}>
+					{$_('qr.scan_again', { default: 'Scan again' })}
+				</button>
+			{/if}
+		</div>
 	</div>
 {:else}
 	<div class="flex flex-col items-center p-8">


### PR DESCRIPTION
## Summary

Uses the existing but unutilized `Gs1Barcode` class in the QR scan route to validate barcodes, normalize barcodes for API calls, handle GS1 Digital Link URLs, and reject invalid scans with a clear error message.

## Changes

- **`src/lib/barcodes/gs1.ts`**: Add `#code` field and `code` getter (returns natural barcode form, e.g. `"3123456789019"` instead of padded `"03123456789019"`). Export `GtinVariant` type.
- **`src/lib/barcodes/gs1.test.ts`** (new): 14 vitest tests — valid barcodes (EAN-13, UPC-A, EAN-8, GTIN-14), GS1 Digital Links, invalid input.
- **`src/params/barcode.ts`**: Widen regex from `^\d{13}$` to `^\d{8}$|^\d{12,14}$` to accept all valid GTIN lengths. Remove unnecessary `gm` flags.
- **`src/routes/qr/+page.svelte`**: Parse scanned text via `Gs1Barcode.parse()`. Invalid barcode → stop scanner + show localized error. Valid barcode → use `barcode.code` (unpadded) for API call and navigation. `addNewProduct` also uses parsed code.
- **i18n**: Add `qr.invalid_barcode` key to `en.json` and `en-US.json`.

## Verification

- ✅ `pnpm test` — 37/37 pass
- ✅ `pnpm check` — 0 errors (2 pre-existing warnings)
- ✅ `pnpm build` — succeeds
- ✅ `pnpm lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GS1 barcode parsing support for EAN-13, UPC-A, EAN-8, and GTIN-14 formats
  * QR scanner now supports both QR codes and EAN barcodes
  * Enhanced error handling with invalid barcode notifications when scanned codes fail validation

* **Tests**
  * Added comprehensive test coverage for barcode parsing, validation, and error cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->