### PR TITLE
feat: move origin and traceability to a dedicated accordion

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -282,6 +282,7 @@
 			"info": {
 				"images": "Upload clear images of the product, ingredients, and nutrition facts to help others identify the product.",
 				"basic_info": "Provide the main details about the product, such as quantity, packaging, and manufacturer.",
+				"origin_traceability": "Provide origin and traceability information, such as manufacturing places, origins of ingredients, and traceability codes.",
 				"languages": "Add product names and descriptions in different languages to make the product accessible to more users.",
 				"ingredients": "List all the ingredients present in the product. This helps users with allergies or dietary preferences.",
 				"nutrition": "Enter nutritional values per 100g/ml as shown on the packaging. This helps users compare products.",
@@ -439,6 +440,7 @@
 			"sections": {
 				"images": "Photos",
 				"basic_info": "Basic Information",
+				"origin_traceability": "Traceability & Origins",
 				"languages": "Languages & Product Names",
 				"ingredients": "Ingredients",
 				"nutrition": "Nutritional Information",

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -282,6 +282,7 @@
 			"info": {
 				"images": "Upload clear images of the product, ingredients, and nutrition facts to help others identify the product.",
 				"basic_info": "Provide the main details about the product, such as quantity, packaging, and manufacturer.",
+				"origin_traceability": "Provide origin and traceability information, such as manufacturing places, origins of ingredients, and traceability codes.",
 				"languages": "Add product names and descriptions in different languages to make the product accessible to more users.",
 				"ingredients": "List all the ingredients present in the product. This helps users with allergies or dietary preferences.",
 				"nutrition": "Enter nutritional values per 100g/ml as shown on the packaging. This helps users compare products.",
@@ -440,6 +441,7 @@
 			"sections": {
 				"images": "Photos",
 				"basic_info": "Basic Information",
+				"origin_traceability": "Traceability & Origins",
 				"languages": "Languages & Product Names",
 				"ingredients": "Ingredients",
 				"nutrition": "Nutritional Information",

--- a/src/lib/ui/AddProductForm.svelte
+++ b/src/lib/ui/AddProductForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ImagesStep from './edit-product-steps/ImagesStep.svelte';
 	import BasicInfoStep from './edit-product-steps/BasicInfoStep.svelte';
+	import OriginTraceabilityStep from './edit-product-steps/OriginTraceabilityStep.svelte';
 	import LanguagesStep from './edit-product-steps/LanguagesStep.svelte';
 	import IngredientsStep from './edit-product-steps/IngredientsStep.svelte';
 	import NutritionStep from './edit-product-steps/NutritionStep.svelte';
@@ -24,6 +25,7 @@
 	const STEPS = $derived([
 		$_('product.edit.sections.images'),
 		$_('product.edit.sections.basic_info'),
+		$_('product.edit.sections.origin_traceability'),
 		$_('product.edit.sections.languages'),
 		$_('product.edit.sections.ingredients'),
 		$_('product.edit.sections.nutrition'),
@@ -151,18 +153,19 @@
 		{labelNames}
 		{brandNames}
 		{storeNames}
-		{originNames}
 		{countriesNames}
 	/>
 {:else if currentStep === 2}
-	<LanguagesStep bind:product codes={languages} {addLanguage} />
+	<OriginTraceabilityStep bind:product {originNames} />
 {:else if currentStep === 3}
-	<IngredientsStep bind:product {getIngredientsImage} {allergenNames} />
+	<LanguagesStep bind:product codes={languages} {addLanguage} />
 {:else if currentStep === 4}
-	<NutritionStep bind:product {units} {getNutritionImage} {handleNutrimentInput} />
+	<IngredientsStep bind:product {getIngredientsImage} {allergenNames} />
 {:else if currentStep === 5}
-	<PackagingStep bind:product {getPackagingImage} />
+	<NutritionStep bind:product {units} {getNutritionImage} {handleNutrimentInput} />
 {:else if currentStep === 6}
+	<PackagingStep bind:product {getPackagingImage} />
+{:else if currentStep === 7}
 	<CommentStep bind:comment />
 {/if}
 

--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import ImagesStep from './edit-product-steps/ImagesStep.svelte';
 	import BasicInfoStep from './edit-product-steps/BasicInfoStep.svelte';
+	import OriginTraceabilityStep from './edit-product-steps/OriginTraceabilityStep.svelte';
 	import LanguagesStep from './edit-product-steps/LanguagesStep.svelte';
 	import IngredientsStep from './edit-product-steps/IngredientsStep.svelte';
 	import NutritionStep from './edit-product-steps/NutritionStep.svelte';
@@ -19,6 +20,7 @@
 	import IconMdiShieldAccount from '@iconify-svelte/mdi/shield-account';
 	import IconMdiTagMultiple from '@iconify-svelte/mdi/tag-multiple';
 	import IconMdiOpenInNew from '@iconify-svelte/mdi/open-in-new';
+	import IconMdiEarth from '@iconify-svelte/mdi/earth';
 
 	import type { Product } from '$lib/api';
 	import { _ } from '$lib/i18n';
@@ -167,10 +169,27 @@
 					{categoryNames}
 					{countriesNames}
 					{labelNames}
-					{originNames}
 					{storeNames}
 					editMode
 				/>
+			</div>
+		</div>
+
+		<!-- Traceability & Origins Section -->
+		<div id="origin-traceability" class="collapse-arrow bg-base-200 collapse shadow-md">
+			<input
+				type="checkbox"
+				checked={isMobile ? false : $preferences.editing.expandAllSections}
+				onchange={(e) => {
+					if (e.isTrusted) handleCollapseToggle('origin-traceability');
+				}}
+			/>
+			<div class="collapse-title flex items-center text-sm font-bold sm:text-base">
+				<IconMdiEarth class="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+				{$_('product.edit.sections.origin_traceability')}
+			</div>
+			<div class="collapse-content">
+				<OriginTraceabilityStep bind:product {originNames} editMode />
 			</div>
 		</div>
 

--- a/src/lib/ui/EditProductSidebar.svelte
+++ b/src/lib/ui/EditProductSidebar.svelte
@@ -13,6 +13,7 @@
 	import IconMdiPackageVariant from '@iconify-svelte/mdi/package-variant';
 	import IconMdiCommentText from '@iconify-svelte/mdi/comment-text';
 	import IconMdiShieldAccount from '@iconify-svelte/mdi/shield-account';
+	import IconMdiEarth from '@iconify-svelte/mdi/earth';
 
 	const permissions = getPermissionsCtx();
 
@@ -60,6 +61,13 @@
 				id: 'basic-info',
 				label: $_('product.edit.sections.basic_info', { default: 'Basic Info' }),
 				icon: IconMdiInformation
+			},
+			{
+				id: 'origin-traceability',
+				label: $_('product.edit.sections.origin_traceability', {
+					default: 'Traceability & Origins'
+				}),
+				icon: IconMdiEarth
 			},
 			{
 				id: 'ingredients',

--- a/src/lib/ui/edit-product-steps/BasicInfoStep.svelte
+++ b/src/lib/ui/edit-product-steps/BasicInfoStep.svelte
@@ -21,7 +21,6 @@
 		labelNames?: string[];
 		brandNames?: string[];
 		storeNames?: string[];
-		originNames?: string[];
 		countriesNames?: string[];
 		editMode?: boolean;
 	};
@@ -32,7 +31,6 @@
 		labelNames,
 		brandNames,
 		storeNames,
-		originNames,
 		countriesNames,
 		editMode = false
 	}: Props = $props();
@@ -132,46 +130,24 @@
 		</div>
 	{/if}
 
-	<!-- Primary Fields Grid -->
-	<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-		<div class="form-control w-full">
-			<label class="label" for="quantity">
-				<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
-					{$_('product.edit.quantity')}
-					<InfoTooltip text={$_('product.edit.tooltips.quantity')} />
-				</span>
-			</label>
-			<input
-				id="quantity"
-				type="text"
-				class="input focus:border-primary w-full text-sm focus:outline-none sm:text-base"
-				value={product.quantity ?? ''}
-				oninput={(e) => {
-					product = { ...product, quantity: (e.currentTarget as HTMLInputElement).value };
-				}}
-				placeholder="e.g., 250g, 1L, 500ml"
-			/>
-		</div>
-		<div class="form-control w-full">
-			<label class="label" for="manufacturing_places">
-				<span class="label-text text-sm font-medium sm:text-base"
-					>{$_('product.edit.manufacturing_places')}</span
-				>
-			</label>
-			<input
-				id="manufacturing_places"
-				type="text"
-				class="input focus:border-primary w-full text-sm focus:outline-none sm:text-base"
-				value={product.manufacturing_places ?? ''}
-				oninput={(e) => {
-					product = {
-						...product,
-						manufacturing_places: (e.currentTarget as HTMLInputElement).value
-					};
-				}}
-				placeholder="e.g., France, Italy"
-			/>
-		</div>
+	<!-- Quantity -->
+	<div class="form-control w-full">
+		<label class="label" for="quantity">
+			<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
+				{$_('product.edit.quantity')}
+				<InfoTooltip text={$_('product.edit.tooltips.quantity')} />
+			</span>
+		</label>
+		<input
+			id="quantity"
+			type="text"
+			class="input focus:border-primary w-full text-sm focus:outline-none sm:text-base"
+			value={product.quantity ?? ''}
+			oninput={(e) => {
+				product = { ...product, quantity: (e.currentTarget as HTMLInputElement).value };
+			}}
+			placeholder="e.g., 250g, 1L, 500ml"
+		/>
 	</div>
 	<div class="form-control w-full">
 		<label class="label" for="website_url">
@@ -255,21 +231,7 @@
 				}}
 			/>
 		</div>
-		<div class="form-control w-full">
-			<label class="label" for="origins-input">
-				<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
-					{$_('product.edit.origins')}
-					<InfoTooltip text={$_('product.edit.tooltips.origins')} />
-				</span>
-			</label>
-			<TagsString
-				tagsString={product.origins ?? ''}
-				autocomplete={originNames}
-				onChange={(v) => {
-					product = { ...product, origins: v };
-				}}
-			/>
-		</div>
+
 		<div class="form-control w-full">
 			<label class="label" for="countries-input">
 				<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
@@ -284,35 +246,6 @@
 					product = { ...product, countries: v };
 				}}
 			/>
-		</div>
-		<div class="form-control w-full">
-			<label class="label" for="traceability-codes">
-				<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
-					{$_('product.edit.emb_code')}
-					<InfoTooltip text={$_('product.edit.tooltips.traceability_code')} />
-				</span>
-			</label>
-			<TagsString
-				tagsString={product.emb_codes ?? ''}
-				autocomplete={[]}
-				onChange={(v) => {
-					product = { ...product, emb_codes: v };
-				}}
-			/>
-			<div class="mt-1 text-xs text-base-content/60">
-				<p>Examples: FR 38.012.001 CE, ES 12.03456/B CE, IT 1234 L CE</p>
-				<p>
-					More info:
-					<a
-						href="https://wiki.openfoodfacts.org/Food_Traceability_Codes/EU_Food_establishments"
-						target="_blank"
-						rel="noopener noreferrer"
-						class="link"
-					>
-						Food Traceability Codes Wiki
-					</a>
-				</p>
-			</div>
 		</div>
 	</div>
 </div>

--- a/src/lib/ui/edit-product-steps/OriginTraceabilityStep.svelte
+++ b/src/lib/ui/edit-product-steps/OriginTraceabilityStep.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	import { _ } from '$lib/i18n';
+	import type { Product } from '$lib/api';
+
+	import TagsString from '../../../routes/products/[barcode]/edit/TagsString.svelte';
+	import InfoTooltip from '../InfoTooltip.svelte';
+	import IconMdiInformation from '@iconify-svelte/mdi/information';
+	import IconMdiHelpCircleOutline from '@iconify-svelte/mdi/help-circle-outline';
+	import IconMdiClose from '@iconify-svelte/mdi/close';
+	import IconMdiInformationOutline from '@iconify-svelte/mdi/information';
+
+	type Props = {
+		product: Product;
+		originNames?: string[];
+		editMode?: boolean;
+	};
+
+	let { product = $bindable(), originNames, editMode = false }: Props = $props();
+
+	let showInfo = $state(false);
+
+	function toggleInfo() {
+		showInfo = !showInfo;
+	}
+</script>
+
+{#if !editMode}
+	<h2
+		class="text-primary mb-6 items-center justify-center gap-2 text-center text-base font-bold md:text-lg lg:text-xl xl:text-2xl"
+	>
+		<IconMdiInformation class="mr-1 h-6 w-6 align-middle" />
+		{$_('product.edit.sections.origin_traceability', { default: 'Traceability & Origins' })}
+		<button type="button" class="ml-2 align-middle" aria-label="Info" onclick={toggleInfo}>
+			<IconMdiHelpCircleOutline
+				class="hover:text-primary/70 text-primary ml-4 h-6 w-6 hover:cursor-pointer"
+			/>
+		</button>
+	</h2>
+	{#if showInfo}
+		<div
+			class="border-primary/30 bg-primary/5 text-primary-content relative mb-4 flex items-center gap-2 rounded-lg border p-4 text-sm shadow-sm"
+		>
+			<button
+				type="button"
+				class="hover:bg-primary/10 absolute top-2 right-2 m-2 rounded p-1"
+				aria-label="Close"
+				onclick={toggleInfo}
+			>
+				<IconMdiClose class="text-primary h-5 w-5" />
+			</button>
+			<IconMdiInformationOutline class="text-primary mt-0.5 h-6 w-6 flex-shrink-0" />
+			<span class="text-base-content/80 p-6 text-sm sm:text-base">
+				{$_('product.edit.info.origin_traceability', {
+					default:
+						'Provide origin and traceability information, such as manufacturing places, origins of ingredients, and traceability codes.'
+				})}
+			</span>
+		</div>
+	{/if}
+{/if}
+
+<div class="space-y-6">
+	<!-- Manufacturing Places -->
+	<div class="form-control w-full">
+		<label class="label" for="manufacturing_places">
+			<span class="label-text text-sm font-medium sm:text-base"
+				>{$_('product.edit.manufacturing_places')}</span
+			>
+		</label>
+		<input
+			id="manufacturing_places"
+			type="text"
+			class="input focus:border-primary w-full text-sm focus:outline-none sm:text-base"
+			value={product.manufacturing_places ?? ''}
+			oninput={(e) => {
+				product = {
+					...product,
+					manufacturing_places: (e.currentTarget as HTMLInputElement).value
+				};
+			}}
+			placeholder="e.g., France, Italy"
+		/>
+	</div>
+
+	<!-- Origins -->
+	<div class="form-control w-full">
+		<label class="label" for="origins-input">
+			<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
+				{$_('product.edit.origins')}
+				<InfoTooltip text={$_('product.edit.tooltips.origins')} />
+			</span>
+		</label>
+		<TagsString
+			tagsString={product.origins ?? ''}
+			autocomplete={originNames}
+			onChange={(v) => {
+				product = { ...product, origins: v };
+			}}
+		/>
+	</div>
+
+	<!-- Traceability Codes -->
+	<div class="form-control w-full">
+		<label class="label" for="traceability-codes">
+			<span class="label-text flex items-center gap-2 text-sm font-medium sm:text-base">
+				{$_('product.edit.emb_code')}
+				<InfoTooltip text={$_('product.edit.tooltips.traceability_code')} />
+			</span>
+		</label>
+		<TagsString
+			tagsString={product.emb_codes ?? ''}
+			autocomplete={[]}
+			onChange={(v) => {
+				product = { ...product, emb_codes: v };
+			}}
+		/>
+		<div class="mt-1 text-xs text-base-content/60">
+			<p>Examples: FR 38.012.001 CE, ES 12.03456/B CE, IT 1234 L CE</p>
+			<p>
+				More info:
+				<a
+					href="https://wiki.openfoodfacts.org/Food_Traceability_Codes/EU_Food_establishments"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="link"
+				>
+					Food Traceability Codes Wiki
+				</a>
+			</p>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
### Description

Moved "Origin", "Manufacturing Places", and "Traceability" fields from the Basic Info section to a dedicated "Origin & Traceability" section/step. This applies to both the product addition form and the product edit form. The "Basic Info" section now only contains core product details.

### Related issue(s) and discussion

- Fixes: #1362

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Antigravity (Gemini 3.5 Flash)
  - **How it was used:** agentic (fully automated)
  - [x] I have reviewed and take full responsibility for all AI-generated code in this PR.
