### PR TITLE
fix: avoid eager fetch during SSR for product attributes

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -37,6 +37,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { trackOffEvent } from '$lib/analytics';
+	import { browser } from '$app/environment';
 
 	let { data }: PageProps = $props();
 	let { state: productState } = $derived(data);
@@ -172,7 +173,12 @@
 		return prodData.product.attribute_groups_en as unknown as ProductGroupedAttributes[];
 	}
 
-	let productAttributes = $derived(getProductAttributes(product.code));
+	let productAttributes = $derived.by(() => {
+		if (product.code && browser) {
+			return getProductAttributes(product.code);
+		}
+		return new Promise<ProductGroupedAttributes[]>(() => {});
+	});
 </script>
 
 <Metadata


### PR DESCRIPTION
### Description

Avoid calling `fetch` eagerly during server-side rendering (SSR) for product attributes.

In Svelte 5, using a `$derived(...)` block at the component top-level to fetch product attributes executes eagerly during server-side rendering. By wrapping the fetch in `$derived.by(...)` with a check for `browser && product.code`, we guarantee that the `fetch` only executes on the client-side.

*Note: This PR was created by the AI coding assistant **Antigravity**.*

### Screenshot or video

N/A (Performance/SSR fix, no visual changes).

### Related issue(s) and discussion

- Fixes:

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Antigravity (Gemini 3.5 Flash)
  - **How it was used:** agentic (fully automated)
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product page loading so attribute groups are only fetched in the browser when a product code is available.
  * Prevented the product details view from completing its loading state prematurely in non-browser contexts, reducing rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->