### PR TITLE
fix: fallback unsupported webcomponent locales

### DIFF
--- a/src/lib/webcomponents.test.ts
+++ b/src/lib/webcomponents.test.ts
@@ -1,9 +1,36 @@
+import { readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
 	getPrimaryLanguageCode,
 	getSupportedWebcomponentsLanguageCode,
+	SUPPORTED_WEBCOMPONENTS_LANGUAGE_CODES,
 	setWebcomponentsLanguageCode
 } from './webcomponents';
+
+const require = createRequire(import.meta.url);
+
+function getPackagedWebcomponentsLanguageCodes(): string[] {
+	const webcomponentsBundlePath = require.resolve('@openfoodfacts/openfoodfacts-webcomponents');
+	const webcomponentsLangDirectory = join(dirname(webcomponentsBundlePath), 'lang');
+
+	return [
+		...new Set(
+			readdirSync(webcomponentsLangDirectory)
+				.map((fileName) => fileName.match(/^([a-z]+)-/)?.[1])
+				.filter((languageCode): languageCode is string => languageCode != null)
+		)
+	].sort();
+}
+
+describe('SUPPORTED_WEBCOMPONENTS_LANGUAGE_CODES', () => {
+	it('matches the packaged webcomponents locales', () => {
+		expect([...SUPPORTED_WEBCOMPONENTS_LANGUAGE_CODES].sort()).toEqual(
+			getPackagedWebcomponentsLanguageCodes()
+		);
+	});
+});
 
 describe('getPrimaryLanguageCode', () => {
 	it('normalizes locale identifiers to primary language codes', () => {

--- a/src/lib/webcomponents.test.ts
+++ b/src/lib/webcomponents.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { getPrimaryLanguageCode, setWebcomponentsLanguageCode } from './webcomponents';
+
+describe('getPrimaryLanguageCode', () => {
+	it('normalizes locale identifiers to primary language codes', () => {
+		expect(getPrimaryLanguageCode('fr-FR')).toBe('fr');
+		expect(getPrimaryLanguageCode('zh_CN')).toBe('zh');
+		expect(getPrimaryLanguageCode('AB')).toBe('ab');
+	});
+
+	it('falls back to English when the language code is missing', () => {
+		expect(getPrimaryLanguageCode(undefined)).toBe('en');
+		expect(getPrimaryLanguageCode(null)).toBe('en');
+		expect(getPrimaryLanguageCode('')).toBe('en');
+	});
+});
+
+describe('setWebcomponentsLanguageCode', () => {
+	it('uses the normalized language code when the webcomponents package accepts it', () => {
+		const attributes: [string, string][] = [];
+		const config = {
+			setAttribute(name: string, value: string) {
+				attributes.push([name, value]);
+			}
+		};
+
+		expect(setWebcomponentsLanguageCode(config, 'fr-FR')).toBe('fr');
+		expect(attributes).toEqual([['language-code', 'fr']]);
+	});
+
+	it('falls back to English when the webcomponents package rejects a valid OFF language', () => {
+		const attributes: [string, string][] = [];
+		const config = {
+			setAttribute(name: string, value: string) {
+				attributes.push([name, value]);
+				if (value === 'ab') {
+					throw new Error('Invalid language code: ab');
+				}
+			}
+		};
+
+		expect(setWebcomponentsLanguageCode(config, 'ab')).toBe('en');
+		expect(attributes).toEqual([
+			['language-code', 'ab'],
+			['language-code', 'en']
+		]);
+	});
+});

--- a/src/lib/webcomponents.test.ts
+++ b/src/lib/webcomponents.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getPrimaryLanguageCode, setWebcomponentsLanguageCode } from './webcomponents';
+import {
+	getPrimaryLanguageCode,
+	getSupportedWebcomponentsLanguageCode,
+	setWebcomponentsLanguageCode
+} from './webcomponents';
 
 describe('getPrimaryLanguageCode', () => {
 	it('normalizes locale identifiers to primary language codes', () => {
@@ -12,6 +16,17 @@ describe('getPrimaryLanguageCode', () => {
 		expect(getPrimaryLanguageCode(undefined)).toBe('en');
 		expect(getPrimaryLanguageCode(null)).toBe('en');
 		expect(getPrimaryLanguageCode('')).toBe('en');
+	});
+});
+
+describe('getSupportedWebcomponentsLanguageCode', () => {
+	it('uses the normalized language code when webcomponents support it', () => {
+		expect(getSupportedWebcomponentsLanguageCode('fr-FR')).toBe('fr');
+		expect(getSupportedWebcomponentsLanguageCode('pt_BR')).toBe('pt');
+	});
+
+	it('falls back to English when webcomponents do not support the language code', () => {
+		expect(getSupportedWebcomponentsLanguageCode('ab')).toBe('en');
 	});
 });
 
@@ -28,7 +43,7 @@ describe('setWebcomponentsLanguageCode', () => {
 		expect(attributes).toEqual([['language-code', 'fr']]);
 	});
 
-	it('falls back to English when the webcomponents package rejects a valid OFF language', () => {
+	it('falls back to English before setting an unsupported webcomponents language', () => {
 		const attributes: [string, string][] = [];
 		const config = {
 			setAttribute(name: string, value: string) {
@@ -40,9 +55,6 @@ describe('setWebcomponentsLanguageCode', () => {
 		};
 
 		expect(setWebcomponentsLanguageCode(config, 'ab')).toBe('en');
-		expect(attributes).toEqual([
-			['language-code', 'ab'],
-			['language-code', 'en']
-		]);
+		expect(attributes).toEqual([['language-code', 'en']]);
 	});
 });

--- a/src/lib/webcomponents.ts
+++ b/src/lib/webcomponents.ts
@@ -1,0 +1,33 @@
+const FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE = 'en';
+
+/**
+ * Converts browser locale identifiers into the primary language code expected by webcomponents.
+ */
+export function getPrimaryLanguageCode(languageCode: string | null | undefined): string {
+	return (
+		languageCode?.replace('_', '-').split('-')[0]?.toLowerCase() ||
+		FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE
+	);
+}
+
+/**
+ * Applies the language code without letting unsupported webcomponent locales crash the app.
+ */
+export function setWebcomponentsLanguageCode(
+	config: Pick<HTMLElement, 'setAttribute'>,
+	languageCode: string | null | undefined
+): string {
+	const primaryLanguageCode = getPrimaryLanguageCode(languageCode);
+
+	try {
+		config.setAttribute('language-code', primaryLanguageCode);
+		return primaryLanguageCode;
+	} catch (error) {
+		if (primaryLanguageCode === FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE) {
+			throw error;
+		}
+
+		config.setAttribute('language-code', FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE);
+		return FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE;
+	}
+}

--- a/src/lib/webcomponents.ts
+++ b/src/lib/webcomponents.ts
@@ -1,5 +1,120 @@
 const FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE = 'en';
 
+// Keep in sync with @openfoodfacts/openfoodfacts-webcomponents targetLocales.
+const SUPPORTED_WEBCOMPONENTS_LANGUAGE_CODES: ReadonlySet<string> = new Set([
+	'af',
+	'am',
+	'ar',
+	'ay',
+	'az',
+	'be',
+	'bg',
+	'bi',
+	'bn',
+	'bs',
+	'ca',
+	'ch',
+	'cs',
+	'cy',
+	'da',
+	'de',
+	'dv',
+	'dz',
+	'el',
+	'en',
+	'es',
+	'et',
+	'eu',
+	'fa',
+	'fi',
+	'fj',
+	'fr',
+	'ga',
+	'gd',
+	'gl',
+	'gn',
+	'gv',
+	'he',
+	'hi',
+	'ho',
+	'hr',
+	'ht',
+	'hu',
+	'hy',
+	'id',
+	'is',
+	'it',
+	'ja',
+	'ka',
+	'kk',
+	'kl',
+	'km',
+	'ko',
+	'ku',
+	'ky',
+	'la',
+	'lb',
+	'lo',
+	'lt',
+	'lv',
+	'mg',
+	'mh',
+	'mi',
+	'mk',
+	'mn',
+	'ms',
+	'mt',
+	'my',
+	'na',
+	'nb',
+	'nd',
+	'ne',
+	'nl',
+	'nr',
+	'ny',
+	'pap',
+	'pl',
+	'prs',
+	'ps',
+	'pt',
+	'qu',
+	'rn',
+	'ro',
+	'ru',
+	'rw',
+	'sg',
+	'si',
+	'sk',
+	'sl',
+	'sm',
+	'sn',
+	'so',
+	'sq',
+	'sr',
+	'ss',
+	'st',
+	'sv',
+	'sw',
+	'ta',
+	'tg',
+	'th',
+	'ti',
+	'tk',
+	'tl',
+	'tn',
+	'to',
+	'tr',
+	'ts',
+	'uk',
+	'ur',
+	'uz',
+	've',
+	'vi',
+	'xh',
+	'zh',
+	'zu'
+]);
+
 /**
  * Converts browser locale identifiers into the primary language code expected by webcomponents.
  */
@@ -11,23 +126,29 @@ export function getPrimaryLanguageCode(languageCode: string | null | undefined):
 }
 
 /**
+ * Returns a webcomponents-supported language code, falling back to English otherwise.
+ */
+export function getSupportedWebcomponentsLanguageCode(
+	languageCode: string | null | undefined
+): string {
+	const primaryLanguageCode = getPrimaryLanguageCode(languageCode);
+
+	if (SUPPORTED_WEBCOMPONENTS_LANGUAGE_CODES.has(primaryLanguageCode)) {
+		return primaryLanguageCode;
+	}
+
+	return FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE;
+}
+
+/**
  * Applies the language code without letting unsupported webcomponent locales crash the app.
  */
 export function setWebcomponentsLanguageCode(
 	config: Pick<HTMLElement, 'setAttribute'>,
 	languageCode: string | null | undefined
 ): string {
-	const primaryLanguageCode = getPrimaryLanguageCode(languageCode);
+	const webcomponentsLanguageCode = getSupportedWebcomponentsLanguageCode(languageCode);
 
-	try {
-		config.setAttribute('language-code', primaryLanguageCode);
-		return primaryLanguageCode;
-	} catch (error) {
-		if (primaryLanguageCode === FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE) {
-			throw error;
-		}
-
-		config.setAttribute('language-code', FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE);
-		return FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE;
-	}
+	config.setAttribute('language-code', webcomponentsLanguageCode);
+	return webcomponentsLanguageCode;
 }

--- a/src/lib/webcomponents.ts
+++ b/src/lib/webcomponents.ts
@@ -1,7 +1,7 @@
 const FALLBACK_WEBCOMPONENTS_LANGUAGE_CODE = 'en';
 
 // Keep in sync with @openfoodfacts/openfoodfacts-webcomponents targetLocales.
-const SUPPORTED_WEBCOMPONENTS_LANGUAGE_CODES: ReadonlySet<string> = new Set([
+export const SUPPORTED_WEBCOMPONENTS_LANGUAGE_CODES: ReadonlySet<string> = new Set([
 	'af',
 	'am',
 	'ar',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -218,7 +218,9 @@
 			});
 		}
 
-		void initializeWebcomponents();
+		void initializeWebcomponents().catch(() => {
+			// Keep the default "en" configuration if webcomponents fail to load.
+		});
 
 		return () => {
 			mounted = false;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 	import IconMdiAccountCircle from '@iconify-svelte/mdi/account-circle';
 	import CompareFloatingButton from '$lib/ui/CompareFloatingButton.svelte';
 
-	import { _, getLocale, locale } from '$lib/i18n';
+	import { _, locale } from '$lib/i18n';
 	import {
 		IMAGE_HOST,
 		MATOMO_HOST,
@@ -43,10 +43,11 @@
 	import { setToastCtx, type Toast as ToastType, type ToastContext } from '$lib/stores/toasts';
 	import Shortcuts from './Shortcuts.svelte';
 	import { setShortcutCtx, type Shortcut } from '$lib/stores/shortcuts';
-	import { preferences, runPreferencesMigrations } from '$lib/settings';
+	import { runPreferencesMigrations } from '$lib/settings';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { shouldBeContainer } from '$lib/layout';
 	import { resolve } from '$app/paths';
+	import { setWebcomponentsLanguageCode } from '$lib/webcomponents';
 
 	// == Global website context setup ==
 	let websiteCtx: { flavor: WebsiteFlavor } = $state({
@@ -205,9 +206,7 @@
 	onMount(() => {
 		runPreferencesMigrations();
 		const unsubscribe = locale.subscribe((locale) => {
-			const lang = locale?.split('-')[0]?.toLowerCase();
-
-			config.setAttribute('language-code', lang ?? 'en');
+			setWebcomponentsLanguageCode(config, locale);
 		});
 		return () => {
 			unsubscribe();
@@ -247,7 +246,7 @@
 	<!-- Global OpenFoodFacts Web Components Configuration -->
 	<off-webcomponents-configuration
 		bind:this={config}
-		language-code={$preferences.lang ?? getLocale()?.split('-')[0]?.toLowerCase() ?? 'en'}
+		language-code="en"
 		assets-images-path="/assets/webcomponents"
 		robotoff-configuration={JSON.stringify({
 			dryRun: dev,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -116,11 +116,7 @@
 
 	setShortcutCtx(() => shortcuts);
 
-	// Load OpenFoodFacts Web Components
-
-	onMount(async () => {
-		await import('@openfoodfacts/openfoodfacts-webcomponents');
-	});
+	const WEBCOMPONENTS_CONFIGURATION_ELEMENT = 'off-webcomponents-configuration';
 
 	// == Global User Permissions Context ==
 
@@ -205,11 +201,28 @@
 
 	onMount(() => {
 		runPreferencesMigrations();
-		const unsubscribe = locale.subscribe((locale) => {
-			setWebcomponentsLanguageCode(config, locale);
-		});
+
+		let mounted = true;
+		let unsubscribe: (() => void) | undefined;
+
+		async function initializeWebcomponents() {
+			await import('@openfoodfacts/openfoodfacts-webcomponents');
+			await customElements.whenDefined(WEBCOMPONENTS_CONFIGURATION_ELEMENT);
+
+			if (!mounted) {
+				return;
+			}
+
+			unsubscribe = locale.subscribe((locale) => {
+				setWebcomponentsLanguageCode(config, locale);
+			});
+		}
+
+		void initializeWebcomponents();
+
 		return () => {
-			unsubscribe();
+			mounted = false;
+			unsubscribe?.();
 		};
 	});
 


### PR DESCRIPTION
### Description

Fixes a crash when Explorer tries to configure Open Food Facts webcomponents with a valid Open Food Facts language code that the webcomponents package does not currently support, such as `ab`.

The layout now initializes webcomponents with `en`, then applies locale changes through a small helper that normalizes locale identifiers and falls back to `en` if the webcomponents package rejects the language code.

### Screenshot or video

Not applicable; this is a crash-prevention logic change with no intentional UI change.

### Related issue(s) and discussion

- Fixes: #1416

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Codex (GPT-5)
  - **How it was used:** Agentic implementation, testing, and PR preparation.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

Validation run locally:

- `npx pnpm@11.7.0 lint`
- `npx pnpm@11.7.0 check`
- `npx pnpm@11.7.0 test`
- `npx pnpm@11.7.0 build`

Notes:

- Local Node is `v25.9.0`, while the repository engine range is `>=20.0.0 <25`; commands passed despite the engine warning.
- `pnpm check` still reports the pre-existing a11y warnings in `src/routes/products/[barcode]/+page.svelte` for `<robotoff-contribution-message>`, outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved web-components language handling by normalizing locale values to their primary language and using English when the value is missing or unsupported.
  * Web-components now initialize in English and automatically update their language when the selected locale changes.

* **Tests**
  * Added Vitest coverage for locale normalization, supported-language selection, and correct setting of the web-components language-code (including fallback to English for invalid inputs).

* **Chores**
  * Refreshed i18n wiring to consume the locale store directly, with safer async initialization and unmount cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->