### PR TITLE
fix: add missing translations in product page

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -527,7 +527,9 @@
 			"action": {
 				"add_packaging_components": "Add packaging components",
 				"add_origins": "Add origins",
-				"add_ingredients_text": "Add ingredients text"
+				"add_ingredients_text": "Add ingredients text",
+				"edit_product":"Edit product",
+  			    "report_product_to_nutripatrol": "Report product to Nutripatrol"
 			}
 		},
 		"moderator": {

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -527,7 +527,9 @@
 			"action": {
 				"add_packaging_components": "Take a photo of the recycling information",
 				"add_origins": "Add origins",
-				"add_ingredients_text": "Add ingredients text"
+				"add_ingredients_text": "Add ingredients text",
+				"edit_product":"Edit product",
+  			    "report_product_to_nutripatrol": "Report product to Nutripatrol"
 			}
 		},
 		"moderator": {

--- a/src/lib/i18n/messages/en_AU.json
+++ b/src/lib/i18n/messages/en_AU.json
@@ -527,7 +527,9 @@
 			"action": {
 				"add_packaging_components": "Take a photo of the recycling information",
 				"add_origins": "Add origins",
-				"add_ingredients_text": "Add ingredients text"
+				"add_ingredients_text": "Add ingredients text",
+				"edit_product":"Edit product",
+  			    "report_product_to_nutripatrol": "Report product to Nutripatrol"
 			}
 		},
 		"moderator": {

--- a/src/lib/i18n/messages/en_GB.json
+++ b/src/lib/i18n/messages/en_GB.json
@@ -527,7 +527,9 @@
 			"action": {
 				"add_packaging_components": "Take a photo of the recycling information",
 				"add_origins": "Add origins",
-				"add_ingredients_text": "Add ingredients text"
+				"add_ingredients_text": "Add ingredients text",
+				"edit_product":"Edit product",
+  			    "report_product_to_nutripatrol": "Report product to Nutripatrol"
 			}
 		},
 		"moderator": {


### PR DESCRIPTION
### Description

 Add translations for missing strings in product page in view mode.

### Screenshot or video
Before: 
<img width="1264" height="427" alt="599973711-31076727-47cb-4722-af1a-2c1353a690a5" src="https://github.com/user-attachments/assets/1bed27a4-3dde-455c-8324-a280327a2ffb" />


After:
<img width="1500" height="581" alt="Screenshot 2026-07-14 213907" src="https://github.com/user-attachments/assets/660bed14-d8d0-4571-97c1-eb58b0d9e77b" />


### Related issue(s) and discussion

- related to: #1486 

---

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [x] I did **not** use an LLM or AI tool to write this PR.
- [ ] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** <!-- e.g. GitHub Copilot (GPT-4o), Claude Sonnet 4.5, Cursor -->
  - **How it was used:** <!-- e.g. agentic (fully automated), autocomplete (suggestions accepted), review (checked my code) -->
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized labels for editing products.
  * Added localized labels for reporting products to Nutripatrol across supported English variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->