### PR TITLE
fix(product): request localized facet fields directly and remove taxonomy loading

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -210,7 +210,7 @@
 		</div>
 	{/if}
 
-	<ProductHeader {product} />
+	<ProductHeader {product} lc={data.lc} />
 
 	{#if showBarcode && product.code != null}
 		<BarcodeInfo code={product.code} />

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -210,7 +210,7 @@
 		</div>
 	{/if}
 
-	<ProductHeader {product} taxonomies={data.taxo} />
+	<ProductHeader {product} />
 
 	{#if showBarcode && product.code != null}
 		<BarcodeInfo code={product.code} />

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -126,6 +126,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
 
 	return {
 		state,
+		lc,
 		defaultProductPreferences: await defaultPreferences,
 		tags: await folksonomyTags,
 		keys: await folksonomyKeys,

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -3,17 +3,10 @@ import type { PageLoad } from './$types';
 
 import { PricesApi } from '@openfoodfacts/openfoodfacts-nodejs';
 
-import {
-	type Brand,
-	type Label,
-	getTaxo,
-	type Store,
-	type Category,
-	type Origin,
-	type Country,
-	createProductsApi
-} from '$lib/api';
+import { createProductsApi } from '$lib/api';
 
+import { get } from 'svelte/store';
+import { preferences } from '$lib/settings';
 import { createFolksonomyApi, isConfigured as isFolksonomyConfigured } from '$lib/api/folksonomy';
 import { createPricesApi, isConfigured as isPriceConfigured } from '$lib/api/prices';
 import { attributesToDefaultPreferences, type AttributeGroup } from '$lib/stores/preferencesStore';
@@ -75,11 +68,24 @@ export const load: PageLoad = async ({ params, fetch }) => {
 	const productsApi = createProductsApi(fetch);
 	const folkApi = createFolksonomyApi(fetch);
 
+	const userLang = get(preferences).lang;
+	const lc = userLang || 'en';
+
 	const { data: state, error: apiErrorWrapped } = await productsApi.getProductV3(params.barcode, {
 		product_type: 'all',
-		fields: ['all', 'knowledge_panels'],
+		fields: [
+			'all',
+			'knowledge_panels',
+			`categories_tags_${lc}`,
+			`brands_tags_${lc}`,
+			`labels_tags_${lc}`,
+			`origins_tags_${lc}`,
+			`stores_tags_${lc}`,
+			`countries_tags_${lc}`
+		],
 		// @ts-expect-error - This is a temporary workaround until the SDK supports this parameter.
-		knowledge_panels_client: 'web'
+		knowledge_panels_client: 'web',
+		lc
 	});
 
 	handleProductApiError(apiErrorWrapped);
@@ -97,16 +103,6 @@ export const load: PageLoad = async ({ params, fetch }) => {
 			errors: state.errors
 		});
 	}
-
-	// TODO: switch to SDK
-	const productType = state.product.product_type;
-
-	const categories = getTaxo<Category>('categories', fetch, productType);
-	const labels = getTaxo<Label>('labels', fetch, productType);
-	const stores = getTaxo<Store>('stores', fetch, productType);
-	const brands = getTaxo<Brand>('brands', fetch, productType);
-	const origins = getTaxo<Origin>('origins', fetch, productType);
-	const countries = getTaxo<Country>('countries', fetch, productType);
 
 	const folksonomyTags = isFolksonomyConfigured()
 		? folkApi.getProductTags(params.barcode).then((it) => it.data ?? [])
@@ -133,14 +129,6 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		defaultProductPreferences: await defaultPreferences,
 		tags: await folksonomyTags,
 		keys: await folksonomyKeys,
-		taxo: {
-			categories,
-			labels,
-			stores,
-			brands,
-			countries,
-			origins
-		},
 		prices: await pricesResponse
 	};
 };

--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -4,17 +4,7 @@
 	import { shareContent } from '$lib/utils/webShare';
 
 	import { navigating } from '$app/state';
-	import {
-		type Brand,
-		type Category,
-		type Country,
-		type Label,
-		type Origin,
-		type Store,
-		type Taxonomy,
-		type TaxoNode,
-		getOrDefault
-	} from '$lib/api';
+
 	import { preferences } from '$lib/settings';
 	import { PRODUCT_REPORT_URL, PRODUCT_WEBSITE_URL, TRACEABILITY_CODES_URL } from '$lib/const';
 	import TagChipList from '$lib/ui/TagChips.svelte';
@@ -32,18 +22,27 @@
 	import { resolve } from '$app/paths';
 	type Props = {
 		product: Product;
-		taxonomies: {
-			brands: Promise<Taxonomy<Brand>>;
-			categories: Promise<Taxonomy<Category>>;
-			stores: Promise<Taxonomy<Store>>;
-			labels: Promise<Taxonomy<Label>>;
-			countries: Promise<Taxonomy<Country>>;
-			origins: Promise<Taxonomy<Origin>>;
-		};
 	};
-	let { product, taxonomies }: Props = $props();
+	let { product }: Props = $props();
 
 	let { lang } = $derived($preferences);
+
+	function getLocalizedTags(facet: string): string[] | undefined {
+		const rawProduct = product as unknown as Record<string, unknown>;
+		// Prioritize specific language suffix fields (e.g. categories_tags_fr, brands_tags_fr)
+		if (lang) {
+			const langKey = `${facet}_tags_${lang.toLowerCase()}`;
+			const langTags = rawProduct[langKey];
+			if (Array.isArray(langTags) && langTags.length > 0) return langTags as string[];
+		}
+
+		// Fallback to English language suffix if available
+		const enKey = `${facet}_tags_en`;
+		const enTags = rawProduct[enKey];
+		if (Array.isArray(enTags) && enTags.length > 0) return enTags as string[];
+
+		return undefined;
+	}
 
 	let toastCtx = getToastCtx();
 	function addToCalculator() {
@@ -184,8 +183,8 @@
 					'product.header.brands',
 					'Brands',
 					product.brands_tags,
-					'brands',
-					taxonomies.brands
+					getLocalizedTags('brands'),
+					'brands'
 				)}
 
 				<!-- Categories -->
@@ -193,8 +192,8 @@
 					'product.header.categories',
 					'Categories',
 					product.categories_tags,
-					'categories',
-					taxonomies.categories
+					getLocalizedTags('categories'),
+					'categories'
 				)}
 
 				<!-- Labels -->
@@ -202,8 +201,8 @@
 					'product.header.labels',
 					'Labels',
 					product.labels_tags,
-					'labels',
-					taxonomies.labels
+					getLocalizedTags('labels'),
+					'labels'
 				)}
 
 				<!-- Origins -->
@@ -211,8 +210,8 @@
 					'product.header.origins',
 					'Origins',
 					product.origins_tags as unknown as string[],
-					'origins',
-					taxonomies.origins
+					getLocalizedTags('origins'),
+					'origins'
 				)}
 
 				<!-- Traceability Codes -->
@@ -263,8 +262,8 @@
 					'product.header.stores',
 					'Stores',
 					product.stores_tags,
-					'stores',
-					taxonomies.stores
+					getLocalizedTags('stores'),
+					'stores'
 				)}
 
 				<!-- Countries -->
@@ -272,8 +271,8 @@
 					'product.header.countries',
 					'Countries',
 					product.countries_tags,
-					'countries',
-					taxonomies.countries
+					getLocalizedTags('countries'),
+					'countries'
 				)}
 			</div>
 		</div>
@@ -284,8 +283,8 @@
 	titleKey: string,
 	defaultTitle: string,
 	tags: string[] | undefined,
-	facet: string,
-	taxoPromise: Promise<Taxonomy<TaxoNode>>
+	localizedTags: string[] | undefined,
+	facet: string
 )}
 	{#if tags != null && tags.length > 0}
 		{const href = resolve('/facets/[facet]/[value]', { facet: facet, value: tags[0] })}
@@ -293,18 +292,13 @@
 			<div class="text-secondary mb-2 text-sm font-bold">
 				{$_(titleKey, { default: defaultTitle })}
 			</div>
-			{#await taxoPromise}
-				<div class="skeleton h-6 w-full"></div>
-			{:then taxonomy}
-				<TagChipList
-					tags={tags.map((tag) => {
-						const name = (taxonomy[tag] ? getOrDefault(taxonomy[tag].name, lang) : tag) ?? tag;
-						return { id: tag, name, href };
-					})}
-				/>
-			{:catch}
-				<TagChipList tags={tags.map((tag) => ({ id: tag, name: tag, href }))} />
-			{/await}
+			<TagChipList
+				tags={tags.map((tag, idx) => ({
+					id: tag,
+					name: localizedTags && localizedTags[idx] ? localizedTags[idx] : tag,
+					href
+				}))}
+			/>
 		</div>
 	{/if}
 {/snippet}

--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -22,16 +22,18 @@
 	import { resolve } from '$app/paths';
 	type Props = {
 		product: Product;
+		lc?: string;
 	};
-	let { product }: Props = $props();
+	let { product, lc }: Props = $props();
 
 	let { lang } = $derived($preferences);
 
 	function getLocalizedTags(facet: string): string[] | undefined {
 		const rawProduct = product as unknown as Record<string, unknown>;
+		const activeLang = lc || lang;
 		// Prioritize specific language suffix fields (e.g. categories_tags_fr, brands_tags_fr)
-		if (lang) {
-			const langKey = `${facet}_tags_${lang.toLowerCase()}`;
+		if (activeLang) {
+			const langKey = `${facet}_tags_${activeLang.toLowerCase()}`;
 			const langTags = rawProduct[langKey];
 			if (Array.isArray(langTags) && langTags.length > 0) return langTags as string[];
 		}


### PR DESCRIPTION
## Description

Requests localized facet fields directly in `getProductV3` API calls (e.g. `categories_tags_${lc}`, `brands_tags_${lc}`, etc.) based on user language preferences. This completely removes the requirement to fetch full taxonomy JSON files on product page loads, reducing load times and preventing facet tags from appearing delayed one-by-one.

## LLM Disclosure
- **Agent Name**: Antigravity
- **Model Version**: Gemini 3.6 Flash (Low)
- **Usage**: Fully agentic mode (code exploration, refactoring, pre-PR validation, branching and PR creation)

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm check`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product taxonomy labels (categories, brands, labels, origins, stores, countries) now render using the user’s selected language when localized data is available.
  * Product pages now request locale-specific taxonomy tag fields to drive the localized label display.

* **Bug Fixes**
  * When localized names aren’t available, taxonomy chips now reliably fall back to the original tag value.
  * Removed taxonomy-related loading and error states, simplifying the label rendering flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->