### PR TITLE
feat(search): update callout title for sql.openfoodfacts.org

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -40,6 +40,7 @@
 		"advanced_search_classic": "Advanced Search for {term} (classic version)",
 		"superset_query": "Start a query",
 		"superset_discover": "Discover dashboards",
+		"superset_promo_title": "Query OFF with SQL",
 		"superset_promo_desc": "Unlock the power of open data! Explore the full Open Food Facts database using SQL queries, custom charts, and shared dashboards.",
 		"prices_badge": "{count} prices",
 		"creation_date": "Creation date",

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -135,7 +135,9 @@
 	</div>
 	<div class="flex items-center gap-3">
 		<div class="text-sm">
-			<div class="text-primary font-bold">sql.openfoodfacts.org:</div>
+			<div class="text-primary font-bold">
+				{$_('search.superset_promo_title', { default: 'Query OFF with SQL' })}
+			</div>
 			<span class="text-base-content/90">
 				{$_('search.superset_promo_desc', {
 					default:


### PR DESCRIPTION
## Description

Updates the title of the `sql.openfoodfacts.org` callout banner in `/search` from `sql.openfoodfacts.org:` to **"Query OFF with SQL"** using internationalization support via `svelte-i18n`.

## Type of Change

- [x] ✨ Feature / UI Improvement

## LLM Disclosure

- **Agent:** Antigravity (Google DeepMind)
- **Model:** Gemini 3.6 Flash
- **Mode:** Agentic (autonomous coding and validation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a localized title for the Superset SQL promotional banner, improving translation support while preserving the existing banner content.

- **Improvements**
  - Updated search development configuration to use the current request setup, supporting more consistent search behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->