### PR TITLE
feat: improve facets page layout with responsive grid

### DIFF
--- a/src/routes/facets/+page.svelte
+++ b/src/routes/facets/+page.svelte
@@ -7,7 +7,7 @@
 <h2 class="text-3xl font-bold">Exploring Facets</h2>
 
 <div class="mt-8">
-	<ul class="grid justify-center gap-4 sm:grid-cols-2 lg:grid-cols-3">
+	<ul class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
 		{#each data.facets as { taxo, icon: IconComponent, name } (taxo)}
 			<li class="flex">
 				<a
@@ -15,7 +15,7 @@
 					class="flex min-h-24 w-full items-center rounded-lg border p-4 text-xl font-semibold transition hover:bg-base-200"
 				>
 					<IconComponent class="me-4 h-5 w-5 shrink-0"></IconComponent>
-					<span class="line-clamp-2 leading-tight">{name}</span>
+					<span class="line-clamp-2 leading-tight" title={name}>{name}</span>
 				</a>
 			</li>
 		{/each}

--- a/src/routes/facets/+page.svelte
+++ b/src/routes/facets/+page.svelte
@@ -7,12 +7,15 @@
 <h2 class="text-3xl font-bold">Exploring Facets</h2>
 
 <div class="mt-8">
-	<ul class="menu w-full gap-2">
+	<ul class="grid justify-center gap-4 sm:grid-cols-2 lg:grid-cols-3">
 		{#each data.facets as { taxo, icon: IconComponent, name } (taxo)}
-			<li class="w-full">
-				<a href={`/facets/${taxo}`} class="flex items-center text-xl font-semibold">
-					<IconComponent class="me-4 h-5 w-5"></IconComponent>
-					<span> {name} </span>
+			<li class="flex">
+				<a
+					href={`/facets/${taxo}`}
+					class="flex min-h-24 w-full items-center rounded-lg border p-4 text-xl font-semibold transition hover:bg-base-200"
+				>
+					<IconComponent class="me-4 h-5 w-5 shrink-0"></IconComponent>
+					<span class="line-clamp-2 leading-tight">{name}</span>
 				</a>
 			</li>
 		{/each}

--- a/src/routes/facets/+page.svelte
+++ b/src/routes/facets/+page.svelte
@@ -12,7 +12,7 @@
 			<li class="flex">
 				<a
 					href={`/facets/${taxo}`}
-					class="flex min-h-24 w-full items-center rounded-lg border p-4 text-xl font-semibold transition hover:bg-base-200"
+					class="flex min-h-20 w-full items-center rounded-lg border p-4 text-xl font-semibold transition hover:bg-base-200"
 				>
 					<IconComponent class="me-4 h-5 w-5 shrink-0"></IconComponent>
 					<span class="line-clamp-2 leading-tight" title={name}>{name}</span>


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description

This PR improves the Facets page layout by replacing the current long vertical list with a responsive grid layout.

The goal is to make facets easier to scan and improve the use of available screen space while keeping all existing navigation and functionality unchanged.

Changes:
- Converted the facet list into a responsive grid layout
- Added consistent card sizing for better alignment
- Improved handling of longer facet names
- Kept existing facet routes and behavior unchanged

### Screenshot or video

Before:
- Facets were displayed as a single vertical list.
<img width="1366" height="768" alt="Screenshot (197)" src="https://github.com/user-attachments/assets/9547e687-e841-4bc5-8d90-2dd5490bcc90" />


After:
- Facets are displayed as a responsive grid with clickable cards.
<img width="1366" height="768" alt="Screenshot (198)" src="https://github.com/user-attachments/assets/bf14e698-b172-4b6e-ac37-e4e1f69c2ad7" />


### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- closes #1624
---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:**  OpenAI ChatGPT (GPT-5.5-mini)
  - **How it was used:**  Review and PR preparation
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the facets page with a responsive grid layout.
  * Improved facet link spacing, sizing, borders, hover states, and typography.
  * Enhanced icon alignment and sizing.
  * Long facet names are now truncated with the full name available on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->