### PR TITLE
fix: prevent duplicate image crop saves

### DIFF
--- a/src/lib/ui/images/PhotoEditDialog.svelte
+++ b/src/lib/ui/images/PhotoEditDialog.svelte
@@ -59,14 +59,22 @@
 	type Props = {
 		image: ProductImage;
 		reportImageUrl: string;
+		isSaving: boolean;
 		onSave: (data: EditData) => void;
 		onImageUnselected: () => void;
 		onImageReplace?: () => void;
 		onClose?: () => void;
 	};
 
-	let { image, reportImageUrl, onClose, onSave, onImageUnselected, onImageReplace }: Props =
-		$props();
+	let {
+		image,
+		reportImageUrl,
+		isSaving,
+		onClose,
+		onSave,
+		onImageUnselected,
+		onImageReplace
+	}: Props = $props();
 
 	const toast = getToastCtx();
 
@@ -749,6 +757,7 @@
 				<button
 					type="button"
 					class="btn btn-primary"
+					class:loading={isSaving}
 					onclick={handleSave}
 					disabled={!canPerformActions}
 					aria-label="Save changes and close modal"

--- a/src/lib/ui/images/PhotoManager.svelte
+++ b/src/lib/ui/images/PhotoManager.svelte
@@ -488,6 +488,7 @@
 		image={editingImageData}
 		onClose={closeEditModal}
 		onSave={saveCurrentImage}
+		isSaving={isSavingImage}
 		onImageUnselected={unselectCurrentImage}
 		onImageReplace={() => {
 			if (editingImageData) {

--- a/src/lib/ui/images/PhotoManager.svelte
+++ b/src/lib/ui/images/PhotoManager.svelte
@@ -173,6 +173,7 @@
 
 	let editingImageData: ProductImage | undefined = $state();
 	let editingImageModal: PhotoEditDialog | undefined = $state();
+	let isSavingImage = $state(false);
 
 	const additionalImageTypes = $derived.by(() => {
 		const standardTypes = new Set(photoTypes.map((pt) => pt.label));
@@ -270,24 +271,37 @@
 	}
 
 	async function saveCurrentImage(data: ImageEditData) {
-		if (!editingImageData) {
+		if (isSavingImage) return;
+
+		const imageData = editingImageData;
+
+		if (!imageData) {
 			console.error('No image data available for editing');
 			return;
 		}
 
+		isSavingImage = true;
+
 		try {
 			const { cropData, rotationAngle } = data;
-			await saveImageWithSelectAndCrop(editingImageData, cropData, rotationAngle);
+
+			await saveImageWithSelectAndCrop(imageData, cropData, rotationAngle);
 
 			toast.success($_('product.edit.images.toast.save_success'));
-			trackOffEvent('product', 'crop_save_image', editingImageData.typeId);
+			trackOffEvent('product', 'crop_save_image', imageData.typeId);
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
 			console.error('Error processing image:', error);
+
 			toast.error(
-				$_('product.edit.images.toast.process_error', { values: { error: errorMessage } })
+				$_('product.edit.images.toast.process_error', {
+					values: { error: errorMessage }
+				})
 			);
 		} finally {
+			isSavingImage = false;
+
 			await invalidateAll();
 			closeEditModal();
 		}


### PR DESCRIPTION
### Description

Fixes an issue where saving a cropped image multiple times could trigger duplicate save operations and cause: 
```text
Error processing image: Cannot read properties of undefined (reading 'typeId')
```
The issue happened because multiple save operations could continue while the edit modal state was being cleared, causing `editingImageData` to become undefined before accessing `typeId`.

Changes made:
- Added a saving guard to prevent duplicate image save operations from running concurrently.
- Stored the current image data in a local variable before async operations to avoid accessing stale reactive state after `await`.

### Screenshot or video
Added a short video demonstrating that repeatedly clicking the Save button now results in a single successful save without duplicate notifications or errors.

https://github.com/user-attachments/assets/6404a4d1-e3a8-47dd-a338-3f332bd94d6a

### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- Closes: #1629 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** ChatGPT (GPT-5.5-mini)
  - **How it was used:** Used for debugging assistance, understanding the root cause, and reviewing the proposed fix. All code changes were reviewed and verified manually.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate or overlapping image save operations.
  * Improved handling when image data is unavailable during saving.
  * Ensured the save-in-progress state resets after every save attempt.
  * Preserved navigation updates and editor closing behavior after saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->