### PR TITLE
fix: Handle empty productCodes array in getBulkProductAttributes

### DIFF
--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -31,6 +31,10 @@ export async function getBulkProductAttributes(
 	fetch: typeof window.fetch,
 	productCodes: string[]
 ): Promise<Record<string, ProductAttributeForScoringGroup[]>> {
+	if (productCodes.length === 0) {
+		return {};
+	}
+
 	const off = createProductsApi(fetch);
 
 	const params = new URLSearchParams({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of requests with no product codes by returning an empty result immediately.
  * Prevented unnecessary API calls when there are no products to look up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->