### PR TITLE
feat: pull Docker image before stopping container

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -145,6 +145,9 @@ jobs:
           script: |
             set -e
             cd ${{ matrix.env }}
+            # Pull new image while old container still serves traffic
+            docker compose pull
+            # Stop old, start new
             docker compose down || true
             docker compose up -d --wait
 


### PR DESCRIPTION
Add 'docker compose pull' before 'docker compose down' to hide image pull time behind the running old container.