### PR TITLE
refactor: use Metadata component across page routes

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 	import type { ProductAttributeForScoringGroup } from '$lib/api/product';
 
 	import Logo from '$lib/ui/Logo.svelte';
+	import Metadata from '$lib/Metadata.svelte';
 	import ProductGrid from '$lib/ui/ProductGrid.svelte';
 	import PersonalizedSearchToggle from '../lib/ui/PersonalizedSearchToggle.svelte';
 	import CountUp from '$lib/ui/CountUp.svelte';
@@ -76,9 +77,9 @@
 <svelte:head>
 	<!-- Preconnect to static assets -->
 	<link rel="preconnect" href="https://images.openfoodfacts.org" crossorigin="anonymous" />
-
-	<title>{$_('landing.title')}</title>
 </svelte:head>
+
+<Metadata title={$_('landing.title')} description={$_('landing.subtitle')} />
 
 <section
 	class="relative flex min-h-120 flex-col items-center justify-center overflow-hidden px-4 pt-16 pb-12"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -79,7 +79,13 @@
 	<link rel="preconnect" href="https://images.openfoodfacts.org" crossorigin="anonymous" />
 </svelte:head>
 
-<Metadata title={$_('landing.title')} description={$_('landing.subtitle')} />
+<Metadata
+	title={$_('landing.title', { default: 'Open Food Facts Explorer' })}
+	description={$_('landing.subtitle', {
+		default:
+			'A collaborative, free and open database of food products from around the world. Discover, search, and contribute to food transparency for everyone.'
+	})}
+/>
 
 <section
 	class="relative flex min-h-120 flex-col items-center justify-center overflow-hidden px-4 pt-16 pb-12"

--- a/src/routes/compare/+page.svelte
+++ b/src/routes/compare/+page.svelte
@@ -67,7 +67,12 @@
 	}
 </script>
 
-<Metadata title={$_('compare.page_title')} description={$_('compare.page_description')} />
+<Metadata
+	title={$_('compare.page_title', { default: 'Compare Products' })}
+	description={$_('compare.page_description', {
+		default: 'Compare nutritional information of food products'
+	})}
+/>
 
 <div class="mx-4">
 	<Card>

--- a/src/routes/compare/+page.svelte
+++ b/src/routes/compare/+page.svelte
@@ -3,6 +3,7 @@
 	import { resolve } from '$app/paths';
 
 	import Card from '$lib/ui/Card.svelte';
+	import Metadata from '$lib/Metadata.svelte';
 	import { compareStore } from '$lib/stores/compareStore';
 	import ComparisonDisplay from '$lib/ui/ComparisonDisplay.svelte';
 	import { _ } from '$lib/i18n';
@@ -66,10 +67,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{$_('compare.page_title')}</title>
-	<meta name="description" content={$_('compare.page_description')} />
-</svelte:head>
+<Metadata title={$_('compare.page_title')} description={$_('compare.page_description')} />
 
 <div class="mx-4">
 	<Card>

--- a/src/routes/compare/shared/+page.svelte
+++ b/src/routes/compare/shared/+page.svelte
@@ -45,8 +45,8 @@
 </script>
 
 <Metadata
-	title={`${data.title ? `${data.title} - ` : ''}${$_('compare.shared_comparison')}`}
-	description={$_('compare.shared_description')}
+	title={`${data.title ? `${data.title} - ` : ''}${$_('compare.shared_comparison', { default: 'Shared Comparison' })}`}
+	description={$_('compare.shared_description', { default: 'Shared product comparison' })}
 />
 
 <div class="mx-4">

--- a/src/routes/compare/shared/+page.svelte
+++ b/src/routes/compare/shared/+page.svelte
@@ -3,6 +3,7 @@
 	import { resolve } from '$app/paths';
 
 	import Card from '$lib/ui/Card.svelte';
+	import Metadata from '$lib/Metadata.svelte';
 	import ComparisonDisplay from '$lib/ui/ComparisonDisplay.svelte';
 	import { compareStore } from '$lib/stores/compareStore';
 	import IconMdiDownload from '@iconify-svelte/mdi/download';
@@ -43,10 +44,10 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{data.title ? `${data.title} - ` : ''}{$_('compare.shared_comparison')}</title>
-	<meta name="description" content={$_('compare.shared_description')} />
-</svelte:head>
+<Metadata
+	title={`${data.title ? `${data.title} - ` : ''}${$_('compare.shared_comparison')}`}
+	description={$_('compare.shared_description')}
+/>
 
 <div class="mx-4">
 	<Card>

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Logo from '$lib/ui/Logo.svelte';
+	import Metadata from '$lib/Metadata.svelte';
 	import SearchBar from '$lib/ui/SearchBar.svelte';
 	import { _ } from '$lib/i18n';
 	import type { PageProps } from './$types';
@@ -13,6 +14,8 @@
 		goto(`/search?q=${encodeURIComponent(query)}`);
 	}
 </script>
+
+<Metadata title={$_('explore.title')} description={$_('explore.subtitle')} />
 
 <section class="bg-base-100 flex flex-col items-center justify-center px-4 py-12">
 	<Logo />

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -15,7 +15,12 @@
 	}
 </script>
 
-<Metadata title={$_('explore.title')} description={$_('explore.subtitle')} />
+<Metadata
+	title={$_('explore.title', { default: 'Explore Open Food Facts' })}
+	description={$_('explore.subtitle', {
+		default: 'Discover trending products, popular categories, and contribute to food transparency!'
+	})}
+/>
 
 <section class="bg-base-100 flex flex-col items-center justify-center px-4 py-12">
 	<Logo />

--- a/src/routes/users/[user]/+page.svelte
+++ b/src/routes/users/[user]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import WcProductCard from '$lib/ui/WcProductCard.svelte';
+	import Metadata from '$lib/Metadata.svelte';
 	import { _, getNumberFormatter } from 'svelte-i18n';
 	import type { PageProps } from './$types';
 
@@ -31,11 +32,11 @@
 	const formatNumber = (n: number) => getNumberFormatter().format(n);
 </script>
 
-<svelte:head>
-	<title>
-		{$_('dashboard.html_title', { values: { user }, default: 'Dashboard for ' + user })}
-	</title>
-</svelte:head>
+<Metadata
+	title={$_('dashboard.html_title', { values: { user }, default: 'Dashboard for ' + user })}
+	description={$_('dashboard.html_title', { values: { user }, default: 'Dashboard for ' + user })}
+	type="profile"
+/>
 
 <div
 	class="flex items-center justify-between gap-4 max-md:flex-col max-md:items-start max-md:gap-2"


### PR DESCRIPTION
### Description

Refactored pages that previously defined `<title>` tags inline (`/`, `/compare`, `/compare/shared`, `/users/[user]`, and `/explore`) to use the standardized `<Metadata>` component (`src/lib/Metadata.svelte`).

This ensures:
- Full Open Graph and Twitter Card tags are generated for all pages when shared.
- Consistent application of page titles and metadata throughout the app.
- Better maintenance by keeping all metadata handling centralized in `Metadata.svelte`.

### Screenshot or video

N/A (Non-visual structural refactor of page metadata)

### Related issue(s) and discussion

N/A

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Antigravity (Gemini 3.6 Flash)
  - **How it was used:** agentic (fully automated code analysis, refactoring, and validation)
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized page titles and descriptions across landing, comparison, exploration, and user profile pages.
  * Improved social and search preview metadata, including profile-specific metadata.
  * Added localized metadata for supported pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->