### PR TITLE
refactor(api): centralize SDK type overrides into sdk-overrides

### DIFF
--- a/src/lib/api/permissions.ts
+++ b/src/lib/api/permissions.ts
@@ -1,18 +1,5 @@
-// TODO: switch to SDK
-export type CurrentUserPermissions = {
-	status: 'success' | 'failure';
-	result?: { id: string };
-	user?: {
-		userid: string;
-		name: string;
-		moderator: 0 | 1;
-		admin: 0 | 1;
-	};
-	errors?: Array<{
-		message?: { id: string };
-		impact?: { id: string };
-	}>;
-};
+import type { CurrentUserPermissions } from '$lib/types/sdk-overrides';
+export type { CurrentUserPermissions };
 
 export async function fetchCurrentUserPermissions(
 	fetch: typeof globalThis.fetch,

--- a/src/lib/api/product.ts
+++ b/src/lib/api/product.ts
@@ -6,21 +6,8 @@ import { preferences } from '$lib/settings';
 import { type ProductV3, OpenFoodFacts } from '@openfoodfacts/openfoodfacts-nodejs';
 import { wrapFetchWithAuth } from '$lib/stores/auth';
 
-// TODO: switch to SDK once it is updated
-export type PackagingTaxonomyTag = {
-	id?: string;
-	lc_name?: string;
-};
-
-// TODO: switch to SDK once it is updated
-export type PackagingComponent = {
-	number_of_units?: number;
-	shape?: PackagingTaxonomyTag;
-	material?: PackagingTaxonomyTag;
-	recycling?: PackagingTaxonomyTag;
-	quantity_per_unit?: string;
-	weight_measured?: number;
-};
+import type { PackagingTaxonomyTag, PackagingComponent } from '$lib/types/sdk-overrides';
+export type { PackagingTaxonomyTag, PackagingComponent };
 
 export function createProductsApi(fetch: typeof window.fetch) {
 	const fetchToUse = wrapFetchWithAuth(fetch);

--- a/src/lib/stores/preferencesStore.ts
+++ b/src/lib/stores/preferencesStore.ts
@@ -1,26 +1,7 @@
-import type { AttributeGroupV2 } from '@openfoodfacts/openfoodfacts-nodejs';
 import { persisted } from 'svelte-local-storage-store';
 
-export type AttributeParameters = { type: 'tags'; id: string; name: string; tagtype: string };
-
-// FIXME: Remove this type when we fix all type errors in SDK
-// - `parameters` field missing
-// - `values` field missing
-// - `id` field should not be optional
-export type Attribute = Omit<NonNullable<AttributeGroupV2[number]['attributes']>[number], 'id'> & {
-	id: string;
-	parameters: AttributeParameters[];
-	values: string[];
-	description?: string;
-};
-
-// FIXME: Remove this type when we fix all type errors in SDK
-// - [number] should not be necessary. The API should return a single object, not an array.
-export type AttributeGroup = Omit<AttributeGroupV2[number], 'attributes' | 'id'> & {
-	id: string;
-	warning?: string;
-	attributes?: Attribute[];
-};
+import type { AttributeParameters, Attribute, AttributeGroup } from '$lib/types/sdk-overrides';
+export type { AttributeParameters, Attribute, AttributeGroup };
 
 type BaseUserPreference = {
 	groupId: string;

--- a/src/lib/types/sdk-overrides.ts
+++ b/src/lib/types/sdk-overrides.ts
@@ -1,0 +1,49 @@
+import type { AttributeGroupV2 } from '@openfoodfacts/openfoodfacts-nodejs';
+
+/**
+ * Temporary SDK type overrides until @openfoodfacts/openfoodfacts-nodejs package exports are complete.
+ */
+
+export type PackagingTaxonomyTag = {
+	id?: string;
+	lc_name?: string;
+};
+
+export type PackagingComponent = {
+	number_of_units?: number;
+	shape?: PackagingTaxonomyTag;
+	material?: PackagingTaxonomyTag;
+	recycling?: PackagingTaxonomyTag;
+	quantity_per_unit?: string;
+	weight_measured?: number;
+};
+
+export type AttributeParameters = { type: 'tags'; id: string; name: string; tagtype: string };
+
+export type Attribute = Omit<NonNullable<AttributeGroupV2[number]['attributes']>[number], 'id'> & {
+	id: string;
+	parameters: AttributeParameters[];
+	values: string[];
+	description?: string;
+};
+
+export type AttributeGroup = Omit<AttributeGroupV2[number], 'attributes' | 'id'> & {
+	id: string;
+	warning?: string;
+	attributes?: Attribute[];
+};
+
+export type CurrentUserPermissions = {
+	status: 'success' | 'failure';
+	result?: { id: string };
+	user?: {
+		userid: string;
+		name: string;
+		moderator: 0 | 1;
+		admin: 0 | 1;
+	};
+	errors?: Array<{
+		message?: { id: string };
+		impact?: { id: string };
+	}>;
+};


### PR DESCRIPTION
### Description

Centralizes temporary SDK type overrides (`Attribute`, `AttributeGroup`, `PackagingTaxonomyTag`, `PackagingComponent`, `CurrentUserPermissions`) into a dedicated `src/lib/types/sdk-overrides.ts` file.

This eliminates duplicated inline type definitions across `product.ts`, `preferencesStore.ts`, and `permissions.ts`, providing a clean, single location for tracking upstream SDK type extension requirements.

### Screenshot or video

N/A (Refactor / Type safety improvements)

### Related issue(s) and discussion

N/A (Code cleanliness refactor)

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Antigravity (Gemini 3.1 Pro)
  - **How it was used:** agentic (disclosed AI agent creating refactoring PR)
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and standardized product packaging type handling across product and permissions flows.
  * Standardized preference attribute type handling for more consistent attribute/group data.
  * Improved account permissions type consistency for returned permission results, reducing type-related issues across the affected features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->