### PR TITLE
feat: Allow click-through to product page from comparison

### DIFF
--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -555,11 +555,17 @@
 								</div>
 							{/if}
 							{#if product.image_front_small_url}
-								<BlurredImageDisplay
-									src={product.image_front_small_url}
-									alt={product.product_name ?? product.code}
-									class="mx-auto mb-2 aspect-square w-8/12 rounded-xl"
-								/>
+								<a
+									href={`/products/${product.code}`}
+									class="contents"
+									aria-label={product.product_name ?? product.code}
+								>
+									<BlurredImageDisplay
+										src={product.image_front_small_url}
+										alt={product.product_name ?? product.code}
+										class="mx-auto mb-2 aspect-square w-8/12 rounded-xl"
+									/>
+								</a>
 							{/if}
 						</div>
 					</th>
@@ -571,7 +577,9 @@
 				<td class="bg-base-100 sticky left-0 w-40 font-semibold">{$_('compare.name')}</td>
 				{#each products as product (product.code)}
 					<td class="text-center text-sm" animate:flip={{ duration: 300 }}>
-						{product.product_name ?? '-'}
+						<a href={`/products/${product.code}`} class="no-underline hover:text-primary">
+							{product.product_name ?? '-'}
+						</a>
 					</td>
 				{/each}
 			</tr>


### PR DESCRIPTION
### Description

Added navigation support for products displayed in Compare mode by making both product images and titles clickable.

Previously, users could only view product information from the comparison view without directly opening the product page. This change improves usability by allowing users to quickly access the full product details while keeping the existing layout and styling intact.

### Screenshot or video

https://github.com/user-attachments/assets/0ba8567e-c5c8-4ac1-9972-91f191d7be65

### Related issue(s) and discussion

- Closes: #1656 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** ChatGPT (GPT-5.5-mini)
  - **How it was used:** Assisted with PR description wording and review.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product images and names in the comparison table are now clickable, providing direct links to each product’s details page.
  * Added accessible labels for product image links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->