### PR TITLE
style(ui): standardize class prop to className across components

### DIFF
--- a/src/lib/ui/BlurredImageDisplay.svelte
+++ b/src/lib/ui/BlurredImageDisplay.svelte
@@ -4,10 +4,10 @@
 		alt?: string;
 		class?: string;
 	};
-	let { src, alt, class: clazz }: Props = $props();
+	let { src, alt, class: className }: Props = $props();
 </script>
 
-<div class={['relative overflow-hidden', clazz]}>
+<div class={['relative overflow-hidden', className]}>
 	<div class="absolute inset-0 overflow-hidden">
 		<img {src} {alt} class="h-full w-full scale-150 object-cover blur-sm" aria-hidden="true" />
 	</div>

--- a/src/lib/ui/TagChips.svelte
+++ b/src/lib/ui/TagChips.svelte
@@ -10,17 +10,17 @@
 		class?: string;
 	};
 
-	let { tags = [], class: clazz = '' }: Props = $props();
+	let { tags = [], class: className = '' }: Props = $props();
 </script>
 
 <div class="flex flex-wrap justify-center gap-1 md:justify-start">
 	{#each tags as tag (tag.id)}
 		{#if tag.href}
-			<a class="badge wrap-break-word {clazz}" href={tag.href}>
+			<a class="badge wrap-break-word {className}" href={tag.href}>
 				{tag.name}
 			</a>
 		{:else}
-			<span class="badge wrap-break-word {clazz}">
+			<span class="badge wrap-break-word {className}">
 				{tag.name}
 			</span>
 		{/if}


### PR DESCRIPTION
### Description

Standardizes prop destructuring of the `class` attribute from `class: clazz` to `class: className` across Svelte 5 components (`BlurredImageDisplay.svelte` and `TagChips.svelte`) for consistent naming conventions across the UI codebase.

### Screenshot or video

N/A (Refactor / Style harmonization)

### Related issue(s) and discussion

N/A (Code cleanliness refactor)

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Antigravity (Gemini 3.1 Pro)
  - **How it was used:** agentic (disclosed AI agent creating refactoring PR)
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**