### PR TITLE
refactor(api): simplify fetchCurrentUserPermissions signature and return result object

### DIFF
--- a/src/lib/api/permissions.ts
+++ b/src/lib/api/permissions.ts
@@ -1,21 +1,21 @@
+import { API_HOST } from '$lib/const';
 import type { CurrentUserPermissions } from '$lib/types/sdk-overrides';
 export type { CurrentUserPermissions };
 
 export async function fetchCurrentUserPermissions(
-	fetch: typeof globalThis.fetch,
-	url: string
-): Promise<CurrentUserPermissions | null> {
+	fetch: typeof globalThis.fetch
+): Promise<{ data?: CurrentUserPermissions; error?: string }> {
 	try {
-		const response = await fetch(url);
+		const targetUrl = `${API_HOST}/api/v3/current-user/permissions`;
+		const response = await fetch(targetUrl);
 
 		if (!response.ok) {
-			console.error(`Failed to fetch user permissions: HTTP ${response.status}`);
-			return null;
+			return { error: `Failed to fetch user permissions: HTTP ${response.status}` };
 		}
 
-		return (await response.json()) as CurrentUserPermissions;
+		const data = (await response.json()) as CurrentUserPermissions;
+		return { data };
 	} catch (error) {
-		console.error('Network error fetching user permissions:', error);
-		return null;
+		return { error: error instanceof Error ? error.message : String(error) };
 	}
 }

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -22,7 +22,6 @@ export const STATIC_HOST = 'https://static.openfoodfacts.org';
 export const API_HOST = publicEnv.PUBLIC_OFF_BASE_URL || 'https://world.openfoodfacts.org';
 export const SEARCH_URL = `${API_HOST}/api/v2/search`;
 export const PRODUCT_EDIT_URL = `${API_HOST}/product/`;
-export const CURRENT_USER_PERMISSIONS_URL = `${API_HOST}/api/v3/current-user/permissions`;
 
 export const TRACEABILITY_CODES_URL =
 	'https://wiki.openfoodfacts.org/Food_Traceability_Codes/EU_Food_establishments';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -125,7 +125,6 @@
 
 	import { setPermissionsCtx, type UserPermissionsContext } from '$lib/stores/user';
 	import { fetchCurrentUserPermissions } from '$lib/api/permissions';
-	import { CURRENT_USER_PERMISSIONS_URL } from '$lib/const';
 	import { wrapFetchWithAuth } from '$lib/stores/auth';
 
 	let permissionsCtx = $state<UserPermissionsContext>({
@@ -139,17 +138,15 @@
 		// Runs whenever the derived $userInfo changes (i.e. user logs in or logs out)
 		if ($userInfo && $userInfo.preferred_username) {
 			const authFetch = wrapFetchWithAuth(globalThis.fetch);
-			fetchCurrentUserPermissions(authFetch, CURRENT_USER_PERMISSIONS_URL).then(
-				(permissionsData) => {
-					if (permissionsData && permissionsData.status === 'success' && permissionsData.user) {
-						permissionsCtx.isAdmin = permissionsData.user.admin === 1;
-						permissionsCtx.isModerator = permissionsData.user.moderator === 1;
-					} else {
-						permissionsCtx.isAdmin = false;
-						permissionsCtx.isModerator = false;
-					}
+			fetchCurrentUserPermissions(authFetch).then(({ data }) => {
+				if (data && data.status === 'success' && data.user) {
+					permissionsCtx.isAdmin = data.user.admin === 1;
+					permissionsCtx.isModerator = data.user.moderator === 1;
+				} else {
+					permissionsCtx.isAdmin = false;
+					permissionsCtx.isModerator = false;
 				}
-			);
+			});
 		} else {
 			// Clear roles when logged out
 			permissionsCtx.isAdmin = false;


### PR DESCRIPTION
### Description

Simplifies `fetchCurrentUserPermissions` by hardcoding `API_HOST` internally instead of requiring callers to pass the full URL, standardizes its return type to `{ data?: CurrentUserPermissions; error?: string }`, and removes the unused `CURRENT_USER_PERMISSIONS_URL` constant.

### Screenshot or video

N/A (Refactor / API Signature Simplification)

### Related issue(s) and discussion

N/A (Code cleanliness refactor)

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Antigravity (Gemini 3.1 Pro)
  - **How it was used:** agentic (disclosed AI agent creating refactoring PR)
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**