### PR TITLE
fix: Add tooltips to product action buttons

### DIFF
--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -121,6 +121,8 @@
 						target="_blank"
 						rel="noopener noreferrer"
 						class="btn btn-secondary btn-sm md:btn-md"
+						title={$_('product.buttons.classic_view', { default: 'Classic view' })}
+						aria-label={$_('product.buttons.classic_view', { default: 'Classic view' })}
 					>
 						{$_('product.buttons.classic_view')}
 					</a>
@@ -129,6 +131,8 @@
 						href={`/products/${product.code}/edit`}
 						class="btn btn-secondary btn-sm md:btn-md"
 						class:pointer-events-none={navigating.to}
+						title={$_('product.buttons.edit', { default: 'Edit' })}
+						aria-label={$_('product.buttons.edit', { default: 'Edit' })}
 					>
 						<IconMdiPencil class="h-5 w-5" />
 						<span class="hidden md:block"> {$_('product.buttons.edit')} </span>
@@ -137,6 +141,8 @@
 					<button
 						class="btn btn-secondary btn-sm md:btn-md flex items-center gap-2"
 						onclick={sharePage}
+						title={$_('product.buttons.share', { default: 'Share' })}
+						aria-label={$_('product.buttons.share', { default: 'Share' })}
 					>
 						<IconMdiShareVariant class="h-5 w-5" />
 						<span class="hidden md:block">{$_('product.buttons.share')}</span>


### PR DESCRIPTION
### Description

Added `title` tooltips and `aria-label` attributes for the Classic view, Edit, and Share actions on the product page.

This improves discoverability on hover and accessibility for assistive technologies.

### Screenshot or video

Added screenshots showing the tooltips appearing on hover for:
- Classic view
<img width="1280" height="622" alt="classic view tootip" src="https://github.com/user-attachments/assets/300e3975-b446-4659-a1a6-fadc44bf62a0" />

- Edit
<img width="1280" height="650" alt="edit tooltip" src="https://github.com/user-attachments/assets/81fbca75-178c-499a-9cab-3d55ab868493" />

- Share
<img width="1280" height="661" alt="share tooltip" src="https://github.com/user-attachments/assets/ce4c9082-c37a-45e6-8ca4-a38efddd6737" />


### Related issue(s) and discussion

- Part of #1558 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** ChatGPT
  - **How it was used:** review (checked my code) 
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added localized labels and titles to the classic view, edit, and share controls for clearer navigation and improved assistive technology support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->