### PR TITLE
fix: Add icon to classic view button

### DIFF
--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -19,6 +19,7 @@
 	import IconMdiFlag from '@iconify-svelte/mdi/flag';
 	import IconMdiCalculator from '@iconify-svelte/mdi/calculator';
 	import IconMdiCompare from '@iconify-svelte/mdi/compare';
+	import IconMdiOpenInNew from '@iconify-svelte/mdi/open-in-new';
 	import { resolve } from '$app/paths';
 	type Props = {
 		product: Product;
@@ -122,7 +123,8 @@
 						rel="noopener noreferrer"
 						class="btn btn-secondary btn-sm md:btn-md"
 					>
-						{$_('product.buttons.classic_view')}
+						<IconMdiOpenInNew class="h-5 w-5" />
+						<span class="hidden md:block">{$_('product.buttons.classic_view')}</span>
 					</a>
 
 					<a

--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -124,7 +124,7 @@
 						class="btn btn-secondary btn-sm md:btn-md"
 					>
 						<IconMdiOpenInNew class="h-5 w-5" />
-						<span class="hidden md:block">{$_('product.buttons.classic_view')}</span>
+						<span>{$_('product.buttons.classic_view')}</span>
 					</a>
 
 					<a


### PR DESCRIPTION
### Description

Adds an icon to the Classic view action button on the product page.

## Changes

- Added the external link icon to the Classic view button
- Updated the button layout to match existing product action buttons

### Screenshot or video

<img width="176" height="105" alt="image" src="https://github.com/user-attachments/assets/a408f9b5-4505-447a-9778-652847e6b8b5" />

### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- Part of #1558 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Antigravity CLI 1.1.6 (Gemini 3.6 Flash)
  - **How it was used:** Used for codebase investigation
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the “Classic view” action to include an open-in-new icon alongside its label.
  * Improved visual clarity while preserving the existing localized text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->