### PR TITLE
fix: clarify NOVA label in compare mode

### DIFF
--- a/src/lib/i18n/messages/compare.test.ts
+++ b/src/lib/i18n/messages/compare.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import enUS from './en-US.json';
+import en from './en.json';
+
+describe('Compare mode labels', () => {
+	it('uses clear English terminology for the NOVA classification', () => {
+		expect(enUS.compare.nova_group).toBe('Ultra-processed level');
+		expect(en.compare.nova_group).toBe('Ultra-processed level');
+	});
+});

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -720,7 +720,7 @@
 		"code_barcode": "Code (Barcode)",
 		"brand": "Brand",
 		"quantity": "Quantity",
-		"nova_group": "Nova Group",
+		"nova_group": "Ultra-processed level",
 		"num_additives": "N. of additives",
 		"nutritional_values_per_100g": "Nutritional Values (per 100g)",
 		"fruits_vegetables_nuts": "Fruits/Vegetables/Nuts",

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -721,7 +721,7 @@
 		"code_barcode": "Code (Barcode)",
 		"brand": "Brand",
 		"quantity": "Quantity",
-		"nova_group": "Nova Group",
+		"nova_group": "Ultra-processed level",
 		"num_additives": "N. of additives",
 		"nutritional_values_per_100g": "Nutritional Values (per 100g)",
 		"fruits_vegetables_nuts": "Fruits/Vegetables/Nuts",

--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -242,6 +242,10 @@
 			: KP_ATTRIBUTE_IMG('nova-group-unknown.svg');
 	}
 
+	function getNovaAltText(group: string | number): string {
+		return `${$_('compare.nova_group', { default: 'Ultra-processed level' })} ${group}`;
+	}
+
 	function getGreenScoreImage(grade: string | null | undefined) {
 		return KP_ATTRIBUTE_IMG('greenscore-' + (grade ?? 'unknown') + '.svg');
 	}
@@ -458,7 +462,7 @@
 								{@const comparison = getNovaComparison(product.nova_group, products)}
 								{@render scoreImage(
 									getNovaImage(product.nova_group),
-									`Ultra-processing level ${product.nova_group}`,
+									getNovaAltText(product.nova_group),
 									comparison.isBest
 								)}
 							{/if}
@@ -617,14 +621,16 @@
 				{/each}
 			</tr>
 			<tr>
-				<td class="bg-base-100 sticky left-0 w-40 font-semibold">{$_('compare.nova_group')}</td>
+				<td class="bg-base-100 sticky left-0 w-40 font-semibold"
+					>{$_('compare.nova_group', { default: 'Ultra-processed level' })}</td
+				>
 				{#each products as product (product.code)}
 					{@const comparison = getNovaComparison(product.nova_group, products)}
 					<td animate:flip={{ duration: 300 }}>
 						{#if product.nova_group}
 							{@render scoreImage(
 								getNovaImage(product.nova_group),
-								`Nova Group ${product.nova_group}`,
+								getNovaAltText(product.nova_group),
 								comparison.isBest
 							)}
 						{:else}


### PR DESCRIPTION
### Description

This updates Compare mode to use the clearer label **“Ultra-processed level”** instead of “NOVA Group”.

It also makes the mobile and desktop NOVA image descriptions use the same translated label, replacing two inconsistent hard-coded alternatives (“Ultra-processing level” and “Nova Group”). The English Crowdin source and current English runtime locale are updated, with a focused regression test to keep them aligned.

### Screenshot or video

Not included: this is a terminology-only change with no layout or styling changes. I manually rendered a shared comparison containing two products and verified the new heading and image descriptions in the generated page.

### Related issue(s) and discussion

- Fixes: #1657

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

Validation completed:

- `pnpm format`
- `pnpm lint`
- `pnpm check` — 0 errors; two pre-existing accessibility warnings in `src/routes/products/[barcode]/+page.svelte`
- `pnpm test` — 24 tests passed across 6 files
- `pnpm build`
- Rendered `/compare/shared` with two live products: 9 occurrences of “Ultra-processed level” and no occurrences of either replaced phrase

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** ChatGPT — GPT-5.6 Thinking
  - **How it was used:** Agentic investigation, implementation, testing, self-review, and PR preparation under Patricia's direction. The agent was disclosed before work began on issue #1657.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved localized alternative text for Nova classification images in comparison views.
* **UI Improvements**
  * Updated the Nova comparison label to “Ultra-processed level” across English locales.
  * Applied the updated label consistently in mobile and desktop comparison views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->