### PR TITLE
fix: Update Green-Score image and Eco-Score references

### DIFF
--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -243,7 +243,7 @@
 	}
 
 	function getGreenScoreImage(grade: string | null | undefined) {
-		return KP_ATTRIBUTE_IMG('greenscore-' + (grade ?? 'unknown') + '.svg');
+		return KP_ATTRIBUTE_IMG('green-score-' + (grade ?? 'unknown') + '.svg');
 	}
 
 	// Number formatters

--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -641,7 +641,7 @@
 						{#if product.ecoscore_grade}
 							{@render scoreImage(
 								getGreenScoreImage(product.ecoscore_grade),
-								`Eco-Score ${product.ecoscore_grade.toUpperCase()}`,
+								`Green-Score ${product.ecoscore_grade.toUpperCase()}`,
 								comparison.isBest
 							)}
 						{:else}


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description
Fix the Green-Score image in Compare mode by updating the asset filename to match the current static asset.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

### Screenshot or video

<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- Fixes: #1653 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [x] I did **not** use an LLM or AI tool to write this PR.
- [ ] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** <!-- e.g. GitHub Copilot (GPT-4o), Claude Sonnet 4.5, Cursor -->
  - **How it was used:** <!-- e.g. agentic (fully automated), autocomplete (suggestions accepted), review (checked my code) -->
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Green-Score image loading in the comparison display.
  - Updated image labels and hover text to consistently use “Green-Score.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->