### PR TITLE
fix(search): update outdated payload for facets and chart field names

### DIFF
--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -48,11 +48,11 @@ async function compatSearch(
 	// Try the new API first
 	const newParams: SearchBody = {
 		...params,
-		facets: ['brands', 'categories', 'nutrition_grades', 'ecoscore_grade'],
+		facets: ['brands', 'categories', 'nutrition_grades', 'environmental_score_grade'],
 		charts: [
 			{ chart_type: 'DistributionChart', field: 'nutrition_grades' },
-			{ chart_type: 'DistributionChart', field: 'ecoscore_grade' },
-			{ chart_type: 'DistributionChart', field: 'nova_groups' },
+			{ chart_type: 'DistributionChart', field: 'environmental_score_grade' },
+			{ chart_type: 'DistributionChart', field: 'nova_group' },
 			{ chart_type: 'ScatterChart', x: 'nutriscore_score', y: 'nutriments.fiber_100g' }
 		]
 	};
@@ -70,11 +70,11 @@ async function compatSearch(
 
 	const oldParams = {
 		...params,
-		facets: ['nutrition_grades', 'ecoscore_grade'],
+		facets: ['nutrition_grades', 'environmental_score_grade'],
 		charts: [
 			{ chart_type: 'DistributionChartType', field: 'nutrition_grades' },
-			{ chart_type: 'DistributionChartType', field: 'ecoscore_grade' },
-			{ chart_type: 'DistributionChartType', field: 'nova_groups' },
+			{ chart_type: 'DistributionChartType', field: 'environmental_score_grade' },
+			{ chart_type: 'DistributionChartType', field: 'nova_group' },
 			{ chart_type: 'ScatterChartType', x: 'nutriscore_score', y: 'nutriments.fiber_100g' }
 		]
 	};


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description

- Updates the payload in Search API for facets and chart_type for both the newer and older schemas.
   - `ecoscore_grade` -> `environmental_score_grade`
   - `nova_groups` -> `nova_group`
- Fixes the 500 internal server error when searching (e.g. `/search?q=nutella`). 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [x] I did **not** use an LLM or AI tool to write this PR.
- [ ] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** <!-- e.g. GitHub Copilot (GPT-4o), Claude Sonnet 4.5, Cursor -->
  - **How it was used:** <!-- e.g. agentic (fully automated), autocomplete (suggestions accepted), review (checked my code) -->
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**
