### PR TITLE
fix(compare): compact mobile product header to save vertical space

### DIFF
--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -418,24 +418,28 @@
 					</button>
 				{/if}
 
-				<div class="flex flex-col items-center pt-4">
+				<div class="flex items-center gap-3 pt-2">
 					{#if product.image_front_small_url}
 						<img
 							src={product.image_front_small_url}
 							alt={product.product_name ?? product.code}
-							class="mb-2 h-24 object-contain"
+							class="h-16 w-16 shrink-0 rounded-lg object-contain"
 						/>
 					{/if}
-					<h3 class="mt-2 text-center font-semibold">
-						<a href={`/products/${product.code}`} class="link">
-							{product.product_name ?? product.code}
-						</a>
-					</h3>
-					<p class="mt-1 text-center text-sm text-base-content/70">
-						{product.brands ?? ''}
-						{#if product.brands && product.quantity},{/if}
-						{product.quantity ?? ''}
-					</p>
+					<div class="min-w-0">
+						<h3 class="line-clamp-2 leading-snug font-semibold">
+							<a href={`/products/${product.code}`} class="link">
+								{product.product_name ?? product.code}
+							</a>
+						</h3>
+						{#if product.brands || product.quantity}
+							<p class="mt-0.5 text-sm text-base-content/70">
+								{product.brands ?? ''}
+								{#if product.brands && product.quantity},{/if}
+								{product.quantity ?? ''}
+							</p>
+						{/if}
+					</div>
 				</div>
 
 				{#if product.nutriscore_grade || product.nova_group || product.ecoscore_grade}


### PR DESCRIPTION

  Makes the product header in the mobile comparison card view more compact
  by combining the thumbnail, product name, and brand/quantity into a single
  horizontal row instead of stacking them vertically.

  The previous layout consumed extra vertical space on small screens (image
  stacked above name, brand/quantity below). This rework keeps all the same
  information but in a tighter, more readable row.

  **Changes:**
  - Image resized from `h-24` (stacked) to `h-16 w-16 shrink-0 rounded-lg` (left-aligned)
  - Parent changed from `flex-col items-center` to `flex items-center gap-3`
  - Product name wrapped in a `min-w-0` column with `line-clamp-2` to prevent overflow
  - Brand/quantity subtitle now conditionally rendered — only when present
  - Vertical padding reduced from `pt-4` to `pt-2`

  ### Screenshot or video

<img width="373" height="670" alt="Screenshot 2026-08-05 at 1 14 17 PM" src="https://github.com/user-attachments/assets/cc7a04b2-ca3a-4ea0-9062-b7731d8f4247" />



  - Fixes: #1659

  ### Checklist: Author Self-Review

  - [x] I have performed a self-review of my own code (including running it).
  - [x] I understand the changes I'm proposing and why they are needed.
  - [x] My changes generate no new warnings or errors (linting, console).
  - [ ] I have made corresponding changes to the documentation (if applicable).

  ## Large Language Models usage disclosure

  - [x] I used an LLM / AI agent — details below:
    - **Agent / tool name and version:** Claude Code (Anthropic)
    - **How it was used:** agentic — explored the codebase, helped me implement the layout change and drafting this PR description


    - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the mobile comparison card header to place the product image beside the name and details.
  * Limited product titles to two lines for a cleaner layout.
  * Hidden empty brand/quantity information when those values aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->