### PR TITLE
feat(pwa): add PWA install button in Settings

### DIFF
--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -739,6 +739,14 @@
 			"copy_failed": "Failed to copy link to clipboard."
 		}
 	},
+	"pwa": {
+		"install_label": "Install as app",
+		"install_description": "Install Open Food Facts Explorer on your device for a faster, full-screen experience.",
+		"install_button": "Install app",
+		"install_in_progress": "Installing…",
+		"install_success": "App installed successfully!",
+		"install_error": "Could not install the app. Please try again."
+	},
 	"static_iframe": {
 		"load_failed": "Failed to load content."
 	}

--- a/src/lib/stores/pwa.ts
+++ b/src/lib/stores/pwa.ts
@@ -1,0 +1,27 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Type of the BeforeInstallPromptEvent, which is not (yet) part of the
+ * standard TypeScript DOM typings.
+ */
+export type BeforeInstallPromptEvent = Event & {
+	prompt: () => Promise<void>;
+	userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+};
+
+/**
+ * Holds the deferred `beforeinstallprompt` event so that a UI element
+ * (e.g. the install button in Settings) can trigger it later.
+ *
+ * The browser fires `beforeinstallprompt` once, early in the page life,
+ * if the site is installable. We capture it as soon as possible (root
+ * layout) and store it here, because the user may not open Settings
+ * until much later.
+ */
+const installPrompt = writable<BeforeInstallPromptEvent | null>(null);
+
+export const pwaInstallStore = {
+	subscribe: installPrompt.subscribe,
+	capture: (event: BeforeInstallPromptEvent) => installPrompt.set(event),
+	clear: () => installPrompt.set(null)
+};

--- a/src/lib/ui/PwaInstallButton.svelte
+++ b/src/lib/ui/PwaInstallButton.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import { getToastCtx } from '$lib/stores/toasts';
+	import { pwaInstallStore } from '$lib/stores/pwa';
+	import { _ } from '$lib/i18n';
+	import IconMdiDownload from '@iconify-svelte/mdi/download';
+
+	const toastCtx = getToastCtx();
+
+	// Derived: is there a deferred install prompt waiting?
+	let prompt = $derived($pwaInstallStore);
+
+	let installing = $state(false);
+
+	// Handle `appinstalled` to update UI if the browser reports success
+	function handleAppInstalled() {
+		pwaInstallStore.clear();
+		installing = false;
+		toastCtx.success($_('pwa.install_success'));
+	}
+
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+
+		function onInstalled() {
+			handleAppInstalled();
+		}
+
+		window.addEventListener('appinstalled', onInstalled);
+		return () => {
+			window.removeEventListener('appinstalled', onInstalled);
+		};
+	});
+
+	async function handleInstall() {
+		if (!prompt || installing) return;
+
+		installing = true;
+
+		try {
+			await prompt.prompt();
+			const { outcome } = await prompt.userChoice;
+
+			if (outcome === 'accepted') {
+				toastCtx.success($_('pwa.install_success'));
+			}
+			// Whether accepted or dismissed, clear the stored prompt
+			// — the browser won't fire `beforeinstallprompt` again.
+			pwaInstallStore.clear();
+		} catch (err) {
+			toastCtx.error($_('pwa.install_error'));
+		} finally {
+			installing = false;
+		}
+	}
+</script>
+
+{#if prompt}
+	<button class="btn gap-2 btn-primary" onclick={handleInstall} disabled={installing}>
+		<IconMdiDownload class="h-5 w-5" />
+		<span>
+			{installing ? $_('pwa.install_in_progress') : $_('pwa.install_button')}
+		</span>
+	</button>
+{/if}

--- a/src/lib/ui/PwaInstallButton.svelte
+++ b/src/lib/ui/PwaInstallButton.svelte
@@ -46,7 +46,7 @@
 			// Whether accepted or dismissed, clear the stored prompt
 			// — the browser won't fire `beforeinstallprompt` again.
 			pwaInstallStore.clear();
-		} catch (err) {
+		} catch {
 			toastCtx.error($_('pwa.install_error'));
 		} finally {
 			installing = false;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -47,6 +47,7 @@
 	import { SvelteMap } from 'svelte/reactivity';
 	import { shouldBeContainer } from '$lib/layout';
 	import { resolve } from '$app/paths';
+	import { pwaInstallStore, type BeforeInstallPromptEvent } from '$lib/stores/pwa';
 
 	// == Global website context setup ==
 	let websiteCtx: { flavor: WebsiteFlavor } = $state({
@@ -119,6 +120,24 @@
 
 	onMount(async () => {
 		await import('@openfoodfacts/openfoodfacts-webcomponents');
+	});
+
+	// == PWA install prompt ==
+	// The browser fires `beforeinstallprompt` once, early, when the site is
+	// considered installable (manifest + service worker present). We must
+	// intercept it here (root layout) rather than inside the Settings page,
+	// because the user may not visit Settings until much later.
+	onMount(() => {
+		function handleBeforeInstallPrompt(e: Event) {
+			e.preventDefault(); // prevent the browser's default mini-infobar
+			pwaInstallStore.capture(e as BeforeInstallPromptEvent);
+		}
+
+		window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+
+		return () => {
+			window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+		};
 	});
 
 	// == Global User Permissions Context ==

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -17,6 +17,7 @@
 	import IconMdiCog from '@iconify-svelte/mdi/cog';
 	import IconMdiPencil from '@iconify-svelte/mdi/pencil';
 	import IconMdiHeart from '@iconify-svelte/mdi/heart';
+	import PwaInstallButton from '$lib/ui/PwaInstallButton.svelte';
 
 	import type { PageProps } from './$types';
 
@@ -221,6 +222,16 @@
 							{/each}
 						</select>
 					</div>
+				</div>
+
+				<div class="divider"></div>
+
+				<div>
+					<p class="font-semibold">{$_('pwa.install_label')}</p>
+					<p class="mt-1 mb-3 text-sm text-base-content/70">
+						{$_('pwa.install_description')}
+					</p>
+					<PwaInstallButton />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION

  This PR addresses two related issues:

  1. **Manifest fix (#1726):** Adds `start_url` and `scope` to the
  `site.webmanifest` endpoint, which were defined as optional in
  the TypeScript type but never set. This satisfies Chrome's PWA
  installability checklist and enables the `beforeinstallprompt`
  event.

  2. **Install button (#1725):** Adds an "Install app" button in
  Settings > General that lets users install the Explorer as a PWA.
  The `beforeinstallprompt` event is captured in the root layout
  (early, once) and stored via a small module-level store, so the
  Settings page can trigger it later.

  ### Changes

  - **`site.webmanifest/+server.ts`** — set `start_url: '/'` and `scope: '/'`
  - **`lib/stores/pwa.ts`** *(new)* — writable store holding the deferred install prompt
  - **`+layout.svelte`** — `onMount` listener intercepts `beforeinstallprompt`, calls `preventDefault()` to suppress the default
  infobar, stores the event
  - **`lib/ui/PwaInstallButton.svelte`** *(new)* — reads the store, renders button when prompt is available, calls `prompt()` on
  click, clears store after install
  - **`routes/settings/+page.svelte`** — renders `PwaInstallButton` in the General tab with label + description
  - **`i18n/messages/en.json`** — added `pwa.*` i18n keys

  ### Screenshot

  
<img width="1512" height="982" alt="Screenshot 2026-08-05 at 9 25 48 PM" src="https://github.com/user-attachments/assets/3edd9bea-cd06-47ab-9756-93b88ac7a31f" />




  ### Related issue(s)

  - Fixes #1725
  - Fixes #1726
  ### Checklist: Author Self-Review

  - [x] I have performed a self-review of my own code (including running it).
  - [x] I understand the changes I'm proposing and why they are needed.
  - [x] My changes generate no new warnings or errors (linting, console).
  - [ ] I have made corresponding changes to the documentation (if applicable).

  ## Large Language Models usage disclosure

  - [x] I used an LLM / AI agent — details below:
    - **Agent / tool name and version:** Claude Code (Anthropic)
    - **How it was used:** agentic — explored the codebase, helped me implement the manifest fix, PWA store, install button, layout listener, and draft this PR description
    - **I have reviewed and take full responsibility for all AI-generated code in this PR.**
   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to install the app as a Progressive Web App from Settings.
  * Added localized installation labels, instructions, progress, success, and error messages.
  * Installation status is reflected with user feedback, including success and error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->