### PR TITLE
feat(landing): add temporary landing pages for Open X Facts

### DIFF
--- a/src/lib/flavor.ts
+++ b/src/lib/flavor.ts
@@ -37,3 +37,17 @@ export function toWebsiteFlavor(productType: string): WebsiteFlavor {
 
 	return 'food';
 }
+
+// Maps the `?landing=` query parameter (used for temporary landing pages) to
+// the corresponding website flavor. e.g. `?landing=obf` -> 'beauty'.
+const LANDING_PARAM_TO_FLAVOR: Record<string, WebsiteFlavor> = {
+	off: 'food',
+	obf: 'beauty',
+	opff: 'petfood',
+	opf: 'product'
+};
+
+export function flavorFromLandingParam(param: string | null | undefined): WebsiteFlavor | null {
+	if (param == null) return null;
+	return LANDING_PARAM_TO_FLAVOR[param] ?? null;
+}

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -118,6 +118,12 @@
 			"partners": "Partners",
 			"faq": "FAQ",
 			"press": "Press"
+		},
+		"open_xfacts": {
+			"title": "Open X Facts",
+			"open_beauty_facts": "Open Beauty Facts",
+			"open_pet_food_facts": "Open Pet Food Facts",
+			"open_products_facts": "Open Products Facts"
 		}
 	},
 	"settings": {
@@ -661,7 +667,11 @@
 		"contributors_count": "Contributors",
 		"open_data": "Open Data",
 		"help_improve_title": "Help Improve Open Food Facts",
-		"help_improve_desc": "Help us improve Open Food Facts by editing or answering questions about these products."
+		"help_improve_desc": "Help us improve Open Food Facts by editing or answering questions about these products.",
+		"xfacts_title": "{name} Explorer",
+		"xfacts_coming_soon": "The dedicated Explorer for {name} is coming soon.",
+		"xfacts_visit": "Visit {name}",
+		"xfacts_description": "A free and open database for {name} from around the world."
 	},
 	"dashboard": {
 		"products_created": "Products created",

--- a/src/lib/ui/Footer.svelte
+++ b/src/lib/ui/Footer.svelte
@@ -96,6 +96,12 @@
 		}
 	];
 
+	const LINKS_OPEN_XFACTS = [
+		{ url: '/?landing=obf', key: 'footer.open_xfacts.open_beauty_facts' },
+		{ url: '/?landing=opff', key: 'footer.open_xfacts.open_pet_food_facts' },
+		{ url: '/?landing=opf', key: 'footer.open_xfacts.open_products_facts' }
+	];
+
 	const LINKS_FOOTER = [
 		{ url: '/static/legal', key: 'footer.links.legal' },
 		{ url: '/static/privacy', key: 'footer.links.privacy' },
@@ -138,6 +144,18 @@
 		<h2 class="text-3xl font-extrabold">{$_('footer.discover_title')}</h2>
 		<div class="mt-2 flex flex-wrap gap-2">
 			{#each LINKS_DISCOVER_PROJECTS as link (link.url)}
+				<a
+					href={link.url}
+					class="rounded-full bg-secondary-content px-4 py-2 text-primary transition-opacity hover:opacity-80"
+				>
+					{$_(link.key)}
+				</a>
+			{/each}
+		</div>
+
+		<h2 class="mt-3 text-3xl font-extrabold">{$_('footer.open_xfacts.title')}</h2>
+		<div class="mt-2 flex flex-wrap gap-2">
+			{#each LINKS_OPEN_XFACTS as link (link.url)}
 				<a
 					href={link.url}
 					class="rounded-full bg-secondary-content px-4 py-2 text-primary transition-opacity hover:opacity-80"

--- a/src/lib/ui/LandingScaffold.svelte
+++ b/src/lib/ui/LandingScaffold.svelte
@@ -3,6 +3,7 @@
 	import { WEBSITE_FLAVOR_METADATA } from '$lib/flavor';
 	import { _ } from '$lib/i18n';
 	import Metadata from '$lib/Metadata.svelte';
+	import Logo from '$lib/ui/Logo.svelte';
 	import IconMdiOpenInNew from '@iconify-svelte/mdi/open-in-new';
 
 	let { flavor }: { flavor: WebsiteFlavor } = $props();
@@ -19,7 +20,9 @@
 	<div
 		class="flex w-full max-w-2xl flex-col items-center rounded-3xl border border-base-200/40 bg-white/90 p-8 shadow-xl backdrop-blur-md dark:bg-base-300/90"
 	>
-		<h1 class="text-3xl font-bold md:text-4xl">{$_('landing.xfacts_title', name)}</h1>
+		<div class="mb-4 h-14 w-full scale-100 px-4 drop-shadow-lg md:h-20 lg:scale-110 lg:px-16">
+			<Logo {flavor} class="h-full w-full" />
+		</div>
 
 		<p class="mt-4 max-w-lg text-center text-lg text-base-content/70">
 			{$_('landing.xfacts_coming_soon', name)}

--- a/src/lib/ui/LandingScaffold.svelte
+++ b/src/lib/ui/LandingScaffold.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { WebsiteFlavor } from '$lib/flavor';
+	import { WEBSITE_FLAVOR_METADATA } from '$lib/flavor';
+	import { _ } from '$lib/i18n';
+	import Metadata from '$lib/Metadata.svelte';
+	import IconMdiOpenInNew from '@iconify-svelte/mdi/open-in-new';
+
+	let { flavor }: { flavor: WebsiteFlavor } = $props();
+	const meta = $derived(WEBSITE_FLAVOR_METADATA[flavor]);
+	const name = $derived({ values: { name: meta.displayName } });
+</script>
+
+<Metadata
+	title={$_('landing.xfacts_title', name)}
+	description={$_('landing.xfacts_description', name)}
+/>
+
+<section class="flex min-h-120 flex-col items-center justify-center px-4 pt-16 pb-12">
+	<div
+		class="flex w-full max-w-2xl flex-col items-center rounded-3xl border border-base-200/40 bg-white/90 p-8 shadow-xl backdrop-blur-md dark:bg-base-300/90"
+	>
+		<h1 class="text-3xl font-bold md:text-4xl">{$_('landing.xfacts_title', name)}</h1>
+
+		<p class="mt-4 max-w-lg text-center text-lg text-base-content/70">
+			{$_('landing.xfacts_coming_soon', name)}
+		</p>
+
+		<a
+			href={meta.apiBaseUrl}
+			target="_blank"
+			rel="noopener noreferrer"
+			class="btn mt-8 gap-2 shadow-md transition-transform btn-primary hover:scale-105"
+		>
+			{$_('landing.xfacts_visit', name)}
+			<IconMdiOpenInNew class="h-5 w-5" />
+		</a>
+	</div>
+</section>

--- a/src/lib/ui/Logo.svelte
+++ b/src/lib/ui/Logo.svelte
@@ -1,17 +1,25 @@
 <script lang="ts">
 	import { getWebsiteCtx } from '$lib/stores/website';
-	import { WEBSITE_FLAVOR_METADATA } from '$lib/flavor';
+	import { WEBSITE_FLAVOR_METADATA, type WebsiteFlavor } from '$lib/flavor';
 
 	let websiteCtx = getWebsiteCtx();
 
-	let logoSuffix = $derived(WEBSITE_FLAVOR_METADATA[websiteCtx.flavor]?.reportFlavor ?? 'off');
 	let {
 		class: className = '',
-		mono = false
+		mono = false,
+		flavor
 	}: {
 		mono?: boolean;
 		class?: string;
+		flavor?: WebsiteFlavor;
 	} = $props();
+
+	// `flavor` prop overrides the global website context flavor, so callers can
+	// render a specific product-type logo (e.g. on landing pages) without
+	// mutating the shared context — the same lookup the product page relies on.
+	let logoSuffix = $derived(
+		WEBSITE_FLAVOR_METADATA[flavor ?? websiteCtx.flavor]?.reportFlavor ?? 'off'
+	);
 </script>
 
 <picture class={className}>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,7 @@
 	import Logo from '$lib/ui/Logo.svelte';
 	import Metadata from '$lib/Metadata.svelte';
 	import ProductGrid from '$lib/ui/ProductGrid.svelte';
+	import LandingScaffold from '$lib/ui/LandingScaffold.svelte';
 	import PersonalizedSearchToggle from '../lib/ui/PersonalizedSearchToggle.svelte';
 	import CountUp from '$lib/ui/CountUp.svelte';
 
@@ -79,148 +80,157 @@
 	<link rel="preconnect" href="https://images.openfoodfacts.org" crossorigin="anonymous" />
 </svelte:head>
 
-<Metadata
-	title={$_('landing.title', { default: 'Open Food Facts Explorer' })}
-	description={$_('landing.subtitle', {
-		default:
-			'A collaborative, free and open database of food products from around the world. Discover, search, and contribute to food transparency for everyone.'
-	})}
-/>
-
-<section
-	class="relative flex min-h-120 flex-col items-center justify-center overflow-hidden px-4 pt-16 pb-12"
->
-	<!-- Decorative SVG assets -->
-	<img src={heroIcons[0]} alt="" aria-hidden="true" class="decorative-svg -top-10 -left-10 w-40" />
-	<img
-		src={heroIcons[1]}
-		alt=""
-		aria-hidden="true"
-		class="decorative-svg -right-10 -bottom-10 w-40"
+{#if data.landingFlavor}
+	<LandingScaffold flavor={data.landingFlavor} />
+{:else}
+	<Metadata
+		title={$_('landing.title', { default: 'Open Food Facts Explorer' })}
+		description={$_('landing.subtitle', {
+			default:
+				'A collaborative, free and open database of food products from around the world. Discover, search, and contribute to food transparency for everyone.'
+		})}
 	/>
 
-	<div
-		class="flex w-full max-w-2xl flex-col items-center rounded-3xl border border-base-200/40 bg-white/90 p-6 shadow-xl backdrop-blur-md lg:p-8 dark:bg-base-300/90"
+	<section
+		class="relative flex min-h-120 flex-col items-center justify-center overflow-hidden px-4 pt-16 pb-12"
 	>
-		<div class="mb-4 h-14 w-full scale-100 px-4 drop-shadow-lg md:h-20 lg:scale-110 lg:px-16">
-			<Logo class="h-full w-full" />
-		</div>
+		<!-- Decorative SVG assets -->
+		<img
+			src={heroIcons[0]}
+			alt=""
+			aria-hidden="true"
+			class="decorative-svg -top-10 -left-10 w-40"
+		/>
+		<img
+			src={heroIcons[1]}
+			alt=""
+			aria-hidden="true"
+			class="decorative-svg -right-10 -bottom-10 w-40"
+		/>
 
-		<p class="mb-6 max-w-xl text-center text-lg font-medium text-base-content/80 md:text-xl">
-			{$_('landing.subtitle')}
-		</p>
-		<div class="flex w-full flex-wrap justify-center gap-4">
-			<a
-				href={resolve('/explore')}
-				class="btn flex w-full items-center gap-2 px-4 shadow-md transition-transform btn-md btn-primary hover:scale-105 sm:w-auto lg:px-6 lg:btn-lg"
-			>
-				<IconMdiCompassOutline class="h-5 w-5" />
-				{$_('landing.explore_products')}
-			</a>
-			<a
-				href={resolve('/static/[id]', { id: 'discover' })}
-				class="btn flex w-full items-center gap-2 px-4 shadow-md transition-transform btn-md btn-secondary hover:scale-105 sm:w-auto lg:px-6 lg:btn-lg"
-			>
-				<IconMdiLightbulbOnOutline class="h-5 w-5" />
-				{$_('landing.discover_project')}
-			</a>
-			<a
-				href={resolve('/static/[id]', { id: 'contribute' })}
-				class="btn flex w-full items-center gap-2 btn-outline px-4 shadow-md transition-transform btn-md hover:scale-105 sm:w-auto lg:px-6 lg:btn-lg"
-			>
-				<IconMdiAccountHeartOutline class="h-5 w-5" />
-				{$_('landing.contribute')}
-			</a>
-		</div>
-	</div>
-</section>
-
-<div class="mx-auto mt-16 grid max-w-7xl grid-cols-1 gap-6 px-4 md:grid-cols-3">
-	<a
-		href={resolve('/explore')}
-		class="flex flex-col items-center rounded-lg border border-secondary p-6 text-center transition outline-none hover:bg-base-200 focus:bg-base-200 focus:ring-2 focus:ring-primary"
-	>
-		<IconMdiDatabase class="mb-4 h-12 w-12 text-primary" />
-		<h2 class="text-xl font-bold">
-			{#await data.productCount}
-				<span class="h-6 w-16 skeleton rounded"></span>
-			{:then productCount}
-				<CountUp value={productCount} />
-			{:catch}
-				<span class="text-base-content/70">--</span>
-			{/await}
-		</h2>
-		<p class="text-base-content/70">{$_('landing.products_count')}</p>
-	</a>
-	<a
-		href={resolve('/facets/[facet]', { facet: 'contributors' })}
-		class="flex flex-col items-center rounded-lg border border-secondary p-6 text-center transition outline-none hover:bg-base-200 focus:bg-base-200 focus:ring-2 focus:ring-primary"
-	>
-		<IconMdiAccountGroup class="mb-4 h-12 w-12 text-primary" />
-		<h2 class="text-xl font-bold">
-			{#await data.contributorCount}
-				<span class="h-6 w-16 skeleton rounded"></span>
-			{:then contributorCount}
-				<CountUp value={contributorCount} />
-			{:catch}
-				<span class="text-base-content/70">--</span>
-			{/await}
-		</h2>
-		<p class="text-base-content/70">{$_('landing.contributors_count')}</p>
-	</a>
-	<a
-		href={resolve('/static/[id]', { id: 'data' })}
-		class="flex flex-col items-center rounded-lg border border-secondary p-6 text-center transition outline-none hover:bg-base-200 focus:bg-base-200 focus:ring-2 focus:ring-primary"
-	>
-		<IconMdiLicense class="mb-4 h-12 w-12 text-primary" />
-		<h2 class="text-xl font-bold">
-			<CountUp value={100} suffix="%" />
-		</h2>
-		<p class="text-base-content/70">{$_('landing.open_data')}</p>
-	</a>
-</div>
-
-<div class="xl:max-w-8xl container mx-auto mt-16 px-4">
-	<donation-banner></donation-banner>
-</div>
-<div class="xl:max-w-8xl container mx-auto mt-16 px-4">
-	<mobile-badges></mobile-badges>
-</div>
-
-<section class="container mx-auto mt-16 w-full max-w-7xl px-4">
-	<div class="mb-6 text-center">
-		<h2 class="mb-2 text-2xl font-bold text-primary">
-			{$_('landing.help_improve_title')}
-		</h2>
-		<p class="mx-auto max-w-2xl text-base text-base-content/70">
-			{$_('landing.help_improve_desc')}
-		</p>
-		<div class="mx-auto mt-4 mb-2 h-1 w-16 rounded bg-primary/30"></div>
-	</div>
-
-	<!-- Preferences Collapsible Section -->
-	<div class="mx-auto mb-4 w-full max-w-2xl">
-		<PersonalizedSearchToggle></PersonalizedSearchToggle>
-	</div>
-
-	<div class="flex w-full">
-		{#await Promise.all([products, attributesByCode])}
-			<div
-				class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-2 xl:grid-cols-3"
-			>
-				{#each Array(SKELETON_COUNT) as _, index (index)}
-					<div class="h-36 w-full skeleton rounded-lg"></div>
-				{/each}
+		<div
+			class="flex w-full max-w-2xl flex-col items-center rounded-3xl border border-base-200/40 bg-white/90 p-6 shadow-xl backdrop-blur-md lg:p-8 dark:bg-base-300/90"
+		>
+			<div class="mb-4 h-14 w-full scale-100 px-4 drop-shadow-lg md:h-20 lg:scale-110 lg:px-16">
+				<Logo class="h-full w-full" />
 			</div>
-		{:then [resolvedProducts, attributes]}
-			<ProductGrid
-				products={resolvedProducts}
-				{attributes}
-				sortByScore={$personalizedSearch.classifyProductsEnabled}
-			/>
-		{/await}
+
+			<p class="mb-6 max-w-xl text-center text-lg font-medium text-base-content/80 md:text-xl">
+				{$_('landing.subtitle')}
+			</p>
+			<div class="flex w-full flex-wrap justify-center gap-4">
+				<a
+					href={resolve('/explore')}
+					class="btn flex w-full items-center gap-2 px-4 shadow-md transition-transform btn-md btn-primary hover:scale-105 sm:w-auto lg:px-6 lg:btn-lg"
+				>
+					<IconMdiCompassOutline class="h-5 w-5" />
+					{$_('landing.explore_products')}
+				</a>
+				<a
+					href={resolve('/static/[id]', { id: 'discover' })}
+					class="btn flex w-full items-center gap-2 px-4 shadow-md transition-transform btn-md btn-secondary hover:scale-105 sm:w-auto lg:px-6 lg:btn-lg"
+				>
+					<IconMdiLightbulbOnOutline class="h-5 w-5" />
+					{$_('landing.discover_project')}
+				</a>
+				<a
+					href={resolve('/static/[id]', { id: 'contribute' })}
+					class="btn flex w-full items-center gap-2 btn-outline px-4 shadow-md transition-transform btn-md hover:scale-105 sm:w-auto lg:px-6 lg:btn-lg"
+				>
+					<IconMdiAccountHeartOutline class="h-5 w-5" />
+					{$_('landing.contribute')}
+				</a>
+			</div>
+		</div>
+	</section>
+
+	<div class="mx-auto mt-16 grid max-w-7xl grid-cols-1 gap-6 px-4 md:grid-cols-3">
+		<a
+			href={resolve('/explore')}
+			class="flex flex-col items-center rounded-lg border border-secondary p-6 text-center transition outline-none hover:bg-base-200 focus:bg-base-200 focus:ring-2 focus:ring-primary"
+		>
+			<IconMdiDatabase class="mb-4 h-12 w-12 text-primary" />
+			<h2 class="text-xl font-bold">
+				{#await data.productCount}
+					<span class="h-6 w-16 skeleton rounded"></span>
+				{:then productCount}
+					<CountUp value={productCount} />
+				{:catch}
+					<span class="text-base-content/70">--</span>
+				{/await}
+			</h2>
+			<p class="text-base-content/70">{$_('landing.products_count')}</p>
+		</a>
+		<a
+			href={resolve('/facets/[facet]', { facet: 'contributors' })}
+			class="flex flex-col items-center rounded-lg border border-secondary p-6 text-center transition outline-none hover:bg-base-200 focus:bg-base-200 focus:ring-2 focus:ring-primary"
+		>
+			<IconMdiAccountGroup class="mb-4 h-12 w-12 text-primary" />
+			<h2 class="text-xl font-bold">
+				{#await data.contributorCount}
+					<span class="h-6 w-16 skeleton rounded"></span>
+				{:then contributorCount}
+					<CountUp value={contributorCount} />
+				{:catch}
+					<span class="text-base-content/70">--</span>
+				{/await}
+			</h2>
+			<p class="text-base-content/70">{$_('landing.contributors_count')}</p>
+		</a>
+		<a
+			href={resolve('/static/[id]', { id: 'data' })}
+			class="flex flex-col items-center rounded-lg border border-secondary p-6 text-center transition outline-none hover:bg-base-200 focus:bg-base-200 focus:ring-2 focus:ring-primary"
+		>
+			<IconMdiLicense class="mb-4 h-12 w-12 text-primary" />
+			<h2 class="text-xl font-bold">
+				<CountUp value={100} suffix="%" />
+			</h2>
+			<p class="text-base-content/70">{$_('landing.open_data')}</p>
+		</a>
 	</div>
-</section>
+
+	<div class="xl:max-w-8xl container mx-auto mt-16 px-4">
+		<donation-banner></donation-banner>
+	</div>
+	<div class="xl:max-w-8xl container mx-auto mt-16 px-4">
+		<mobile-badges></mobile-badges>
+	</div>
+
+	<section class="container mx-auto mt-16 w-full max-w-7xl px-4">
+		<div class="mb-6 text-center">
+			<h2 class="mb-2 text-2xl font-bold text-primary">
+				{$_('landing.help_improve_title')}
+			</h2>
+			<p class="mx-auto max-w-2xl text-base text-base-content/70">
+				{$_('landing.help_improve_desc')}
+			</p>
+			<div class="mx-auto mt-4 mb-2 h-1 w-16 rounded bg-primary/30"></div>
+		</div>
+
+		<!-- Preferences Collapsible Section -->
+		<div class="mx-auto mb-4 w-full max-w-2xl">
+			<PersonalizedSearchToggle></PersonalizedSearchToggle>
+		</div>
+
+		<div class="flex w-full">
+			{#await Promise.all([products, attributesByCode])}
+				<div
+					class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-2 xl:grid-cols-3"
+				>
+					{#each Array(SKELETON_COUNT) as _, index (index)}
+						<div class="h-36 w-full skeleton rounded-lg"></div>
+					{/each}
+				</div>
+			{:then [resolvedProducts, attributes]}
+				<ProductGrid
+					products={resolvedProducts}
+					{attributes}
+					sortByScore={$personalizedSearch.classifyProductsEnabled}
+				/>
+			{/await}
+		</div>
+	</section>
+{/if}
 
 <style>
 	@keyframes gentleFloat {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,8 +22,17 @@
 	import IconMdiAccountGroup from '@iconify-svelte/mdi/account-group';
 	import IconMdiLicense from '@iconify-svelte/mdi/license';
 
+	import { getWebsiteCtx } from '$lib/stores/website';
+
 	import type { PageProps } from './$types';
 	let { data }: PageProps = $props();
+
+	// Propagate the landing flavor to the global website context so the header
+	// logo switches to the matching brand (e.g. "open BEAUTY facts" for obf).
+	const websiteCtx = getWebsiteCtx();
+	$effect(() => {
+		websiteCtx.flavor = data.landingFlavor ?? 'food';
+	});
 
 	type ReducedState = Awaited<ReturnType<typeof getProducts>>[number];
 	let products: Promise<ReducedState[]> = $state(Promise.resolve([]));

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,6 +1,7 @@
 import { createProductsApi } from '$lib/api';
 import { API_HOST } from '$lib/const';
 import { fetchRequired } from '$lib/promises';
+import { flavorFromLandingParam, type WebsiteFlavor } from '$lib/flavor';
 import type { PageLoad } from './$types';
 
 async function getNumberOfProducts(fetch: typeof window.fetch): Promise<number> {
@@ -25,11 +26,15 @@ async function getNumberOfContributors(fetch: typeof window.fetch): Promise<numb
 	return data.count;
 }
 
-export const load: PageLoad = async ({ fetch }) => {
+export const load: PageLoad = async ({ fetch, url }) => {
+	const landingFlavor: WebsiteFlavor | null = flavorFromLandingParam(
+		url.searchParams.get('landing')
+	);
 	const productCount = getNumberOfProducts(fetch);
 	const contributorCount = getNumberOfContributors(fetch);
 	return {
 		productCount,
-		contributorCount
+		contributorCount,
+		landingFlavor
 	};
 };


### PR DESCRIPTION
Adds temporary branded landing pages for Open Beauty Facts, Open Pet
  Food Facts, and Open Products Facts, accessible via a `?landing=` query
  parameter (`?landing=obf`, `?landing=opff`, `?landing=opf`).

  These serve as a bridge while the dedicated platforms are still in
  development, as requested in #1727.

  ### What changed

  - **`lib/flavor.ts`** — added `flavorFromLandingParam()` to map the
    query param (`obf`/`opff`/`opf`/`off`) to the corresponding
    `WebsiteFlavor`.
  - **`routes/+page.ts`** — reads `?landing` from the URL and passes
    the resolved flavor as a page prop.
  - **`lib/ui/LandingScaffold.svelte`** *(new)* — renders the branded
    scaffold: brand name, 'coming soon' message, and a link to the
    live platform (via `WEBSITE_FLAVOR_METADATA`).
  - **`routes/+page.svelte`** — branches on `data.landingFlavor`:
    renders the scaffold when present, falls back to the normal OFF
    home page otherwise.
  - **`lib/ui/Footer.svelte`** — adds Open X Facts links in the
    Discover section so the landing pages are discoverable.
  - **`i18n/messages/en.json`** — added `landing.xfacts_*` and
    `footer.open_xfacts.*` i18n keys.

  ### Screenshot or video
<img width="1512" height="857" alt="Screenshot 2026-08-06 at 12 49 26 PM" src="https://github.com/user-attachments/assets/f2233f4f-36bc-495e-a2e1-2ed6afa80fde" />
<img width="1512" height="857" alt="Screenshot 2026-08-06 at 12 49 13 PM" src="https://github.com/user-attachments/assets/d2b855ed-588f-43b1-9b25-7ffe2244377d" />

<img width="1512" height="857" alt="Screenshot 2026-08-06 at 12 48 50 PM" src="https://github.com/user-attachments/assets/817e3524-c916-4e34-b2b2-880effc3dd35" />


  ### Related issue(s) and discussion

  - Fixes: #1727

### Checklist: Author Self-Review

  - [x] I have performed a self-review of my own code (including running it).
  - [x] I understand the changes I'm proposing and why they are needed.
  - [x] My changes generate no new warnings or errors (linting, console).
  - [ ] I have made corresponding changes to the documentation (if applicable).

  [x] I used an LLM / AI agent — details below:
    -- **Agent / tool name and version:** Claude Code (Anthropic)
    - **How it was used:** agentic — Claude explored the codebase, designed the implementation
      (flavor-based landing pages), wrote the code, and drafted this PR description. I
      reviewed each change with Claude, ran the app locally to verify the landing pages
      render correctly, and take full responsibility for the code submitted.
    - **I have reviewed and take full responsibility for all AI-generated code in this PR.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flavored landing pages for supported site variants, including localized page metadata and a “coming soon” panel with each flavor’s API link.
  * Added a flavor-aware logo option for landing pages.
  * Added footer “Open Xfacts” link group (Open Beauty Facts, Open Pet Food Facts, Open Products Facts).
* **Improvements**
  * Landing pages are driven by the `landing` URL parameter and now localize Explorer messaging (titles, descriptions, and availability/coming-soon text).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->