### PR TITLE
chore: replace pnpm action setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
-        with:
-          node-version: 22
-
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # ratchet:pnpm/action-setup@v6
+      - uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # ratchet:pnpm/setup@v2
         with:
           cache: true
-
-      - run: pnpm install --frozen-lockfile
+          runtime: node@22
 
       - name: Copy .env.example to .env
         run: cp .env.example .env


### PR DESCRIPTION
### Description

Replace the separate Node.js and pnpm setup actions in CI with the Ratchet-pinned `pnpm/setup@v2` action. It installs pnpm, Node.js 22, cached dependencies, and the project dependencies in one step using the existing pnpm 11 package-manager declaration.

### Screenshot or video

Not applicable — this is a CI workflow-only change.

### Related issue(s) and discussion

No related issue; this is a maintenance update to the CI setup.

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (not applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Codex (GPT-5)
  - **How it was used:** Agentic implementation and validation.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration environment to use Node.js 22.
  * Improved package manager setup and dependency caching for automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->