### PR TITLE
feat: add admin tools links to settings

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -149,6 +149,13 @@
 		"github_link": "GitHub",
 		"github_cta": "Help us improve Explorer on GitHub",
 		"github_help_text": "Help us improve Open Food Facts Explorer!",
+		"admin_tools": {
+			"title": "Admin tools",
+			"description": "Useful links for Open Food Facts administrators",
+			"organization_table": "Organization table",
+			"recent_changes": "Recent changes",
+			"top_translators": "Top translators"
+		},
 		"dev_settings_title": "Development Settings",
 		"moderator_mode": "Moderator Mode",
 		"dev_access_denied": "Access Denied",

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -296,8 +296,53 @@
 			role="tabpanel"
 			id="tabpanel-developer"
 			aria-labelledby="tab-developer"
+			class="space-y-6"
 			class:hidden={activeTab !== 'developer'}
 		>
+			{#if permissions.isAdmin}
+				<div class="card bg-base-200 shadow-md">
+					<div class="card-body">
+						<h2 class="card-title flex items-center gap-2">
+							<IconMdiTools class="h-6 w-6" aria-hidden="true" />
+							{$_('settings.admin_tools.title', { default: 'Admin tools' })}
+						</h2>
+
+						<p class="mt-4 text-sm text-base-content/70">
+							{$_('settings.admin_tools.description', {
+								default: 'Useful links for Open Food Facts administrators'
+							})}
+						</p>
+
+						<div class="mt-6 flex flex-wrap gap-3">
+							<a
+								class="btn btn-outline"
+								href="https://world.openfoodfacts.org/cgi/display_org_table.pl"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{$_('settings.admin_tools.organization_table', { default: 'Organization table' })}
+							</a>
+							<a
+								class="btn btn-outline"
+								href="https://world.openfoodfacts.org/cgi/recent_changes.pl"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{$_('settings.admin_tools.recent_changes', { default: 'Recent changes' })}
+							</a>
+							<a
+								class="btn btn-outline"
+								href="https://world.openfoodfacts.org/cgi/top_translators.pl"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{$_('settings.admin_tools.top_translators', { default: 'Top translators' })}
+							</a>
+						</div>
+					</div>
+				</div>
+			{/if}
+
 			{#if permissions.isModerator}
 				<div class="card border-2 border-warning bg-warning/10 shadow-md">
 					<div class="card-body">


### PR DESCRIPTION
### Description

Adds an admin-only Admin tools card to Settings > Developer with links to the organization table, recent changes, and top translators pages.

### Screenshot or video

Not applicable — this is a small settings link change.

### Related issue(s) and discussion

- Fixes: #1728

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (not applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Codex (GPT-5)
  - **How it was used:** agentic (fully automated implementation and validation)
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin tools section to the Developer Settings page.
  * Admins can access links for organization management, recent changes, and top translators.
  * Added English localization for the new settings section.
  * Improved spacing and layout in the Developer Settings tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->