### PR TITLE
fix(product): link taxonomy chips to their own facets

### DIFF
--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -297,7 +297,6 @@
 	facet: string
 )}
 	{#if tags != null && tags.length > 0}
-		{const href = resolve('/facets/[facet]/[value]', { facet: facet, value: tags[0] })}
 		<div class="mb-2">
 			<div class="mb-2 text-sm font-bold text-secondary">
 				{$_(titleKey, { default: defaultTitle })}
@@ -306,7 +305,7 @@
 				tags={tags.map((tag, idx) => ({
 					id: tag,
 					name: localizedTags && localizedTags[idx] ? localizedTags[idx] : tag,
-					href
+					href: resolve('/facets/[facet]/[value]', { facet, value: tag })
 				}))}
 			/>
 		</div>


### PR DESCRIPTION
### Description

The shared product-page taxonomy renderer assigned every brand, category, label, origin, store, and country chip the URL of the first tag in its section. This fix resolves the facet URL per chip, so each taxonomy link navigates to its own value.

### Screenshot or video

Not applicable; this is a link-target fix with no visual layout change.

### Related issue(s) and discussion

No related issue; this follow-up was identified during product-page verification.

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (not applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Codex, GPT-5
  - **How it was used:** agentic (implemented, validated, committed, and prepared this PR)
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the construction of taxonomy tag links without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->