### PR TITLE
feat: add Open X Facts flavor landing links

### DIFF
--- a/src/lib/flavor.test.ts
+++ b/src/lib/flavor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { toWebsiteFlavor } from './flavor';
+import { getWebsiteFlavorFromParam, toWebsiteFlavor } from './flavor';
 
 describe('toWebsiteFlavor', () => {
 	it('maps known product types to their website flavor', () => {
@@ -13,5 +13,18 @@ describe('toWebsiteFlavor', () => {
 		expect(toWebsiteFlavor('unknown')).toBe('food');
 		expect(toWebsiteFlavor('all')).toBe('food');
 		expect(toWebsiteFlavor('')).toBe('food');
+	});
+
+	it('maps Open X Facts aliases to website flavors', () => {
+		expect(toWebsiteFlavor('off')).toBe('food');
+		expect(toWebsiteFlavor('obf')).toBe('beauty');
+		expect(toWebsiteFlavor('opff')).toBe('petfood');
+		expect(toWebsiteFlavor('opf')).toBe('product');
+	});
+
+	it('returns no flavor for an unknown query parameter', () => {
+		expect(getWebsiteFlavorFromParam(null)).toBeUndefined();
+		expect(getWebsiteFlavorFromParam('unknown')).toBeUndefined();
+		expect(getWebsiteFlavorFromParam(' OBF ')).toBe('beauty');
 	});
 });

--- a/src/lib/flavor.ts
+++ b/src/lib/flavor.ts
@@ -30,10 +30,24 @@ export const WEBSITE_FLAVOR_METADATA: Record<WebsiteFlavor, WebsiteFlavorMetadat
 	}
 };
 
-export function toWebsiteFlavor(productType: string): WebsiteFlavor {
-	if ((WEBSITE_FLAVORS as readonly string[]).includes(productType)) {
-		return productType as WebsiteFlavor;
-	}
+const WEBSITE_FLAVOR_ALIASES: Record<string, WebsiteFlavor> = {
+	food: 'food',
+	off: 'food',
+	beauty: 'beauty',
+	obf: 'beauty',
+	petfood: 'petfood',
+	opff: 'petfood',
+	product: 'product',
+	opf: 'product'
+};
 
-	return 'food';
+export function toWebsiteFlavor(value: string): WebsiteFlavor {
+	return WEBSITE_FLAVOR_ALIASES[value.trim().toLowerCase()] ?? 'food';
+}
+
+export function getWebsiteFlavorFromParam(flavorParam: string | null): WebsiteFlavor | undefined {
+	if (flavorParam == null || flavorParam.trim() === '') return undefined;
+
+	const flavor = WEBSITE_FLAVOR_ALIASES[flavorParam.trim().toLowerCase()];
+	return flavor;
 }

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -86,6 +86,14 @@
 		"stay_updated": "Stay Updated",
 		"contribute": "Contribute",
 		"discover_title": "Discover our Project",
+		"open_x_facts_title": "Open X Facts",
+		"open_x_facts_description": "Try the temporary landing pages for each Open X Facts project.",
+		"open_x_facts": {
+			"open_food_facts": "Open Food Facts",
+			"open_beauty_facts": "Open Beauty Facts",
+			"open_pet_food_facts": "Open Pet Food Facts",
+			"open_products_facts": "Open Products Facts"
+		},
 		"tagline": "A collaborative, free and open database of food products",
 		"tagline_break": "from around the world.",
 		"decorative_alt": "A decorative graphic",

--- a/src/lib/stores/website.ts
+++ b/src/lib/stores/website.ts
@@ -1,16 +1,22 @@
-import { getContext, setContext } from 'svelte';
+import { createContext } from 'svelte';
+import { writable, type Writable } from 'svelte/store';
 import type { WebsiteFlavor } from '$lib/flavor';
 
-type WebsiteContext = {
+export type WebsiteContext = {
 	flavor: WebsiteFlavor;
+	forcedFlavor: WebsiteFlavor | null;
 };
 
-export function setWebsiteCtx(ctx: () => WebsiteContext) {
-	setContext('website-ctx', ctx);
-}
+export type WebsiteContextStore = Writable<WebsiteContext>;
 
-export function getWebsiteCtx() {
-	const lambda = getContext('website-ctx') as () => WebsiteContext;
-	if (!lambda) throw new Error('Website context not found');
-	return lambda();
+export const [getWebsiteCtx, setWebsiteCtx] = createContext<WebsiteContextStore>();
+
+export function createWebsiteCtx(): WebsiteContextStore {
+	const websiteCtx = writable<WebsiteContext>({
+		flavor: 'food',
+		forcedFlavor: null
+	});
+
+	setWebsiteCtx(websiteCtx);
+	return websiteCtx;
 }

--- a/src/lib/ui/Footer.svelte
+++ b/src/lib/ui/Footer.svelte
@@ -96,6 +96,29 @@
 		}
 	];
 
+	const LINKS_OPEN_X_FACTS = [
+		{
+			flavor: 'off',
+			key: 'footer.open_x_facts.open_food_facts',
+			default: 'Open Food Facts'
+		},
+		{
+			flavor: 'obf',
+			key: 'footer.open_x_facts.open_beauty_facts',
+			default: 'Open Beauty Facts'
+		},
+		{
+			flavor: 'opff',
+			key: 'footer.open_x_facts.open_pet_food_facts',
+			default: 'Open Pet Food Facts'
+		},
+		{
+			flavor: 'opf',
+			key: 'footer.open_x_facts.open_products_facts',
+			default: 'Open Products Facts'
+		}
+	];
+
 	const LINKS_FOOTER = [
 		{ url: '/static/legal', key: 'footer.links.legal' },
 		{ url: '/static/privacy', key: 'footer.links.privacy' },
@@ -143,6 +166,24 @@
 					class="rounded-full bg-secondary-content px-4 py-2 text-primary transition-opacity hover:opacity-80"
 				>
 					{$_(link.key)}
+				</a>
+			{/each}
+		</div>
+		<h2 class="mt-6 text-3xl font-extrabold">
+			{$_('footer.open_x_facts_title', { default: 'Open X Facts' })}
+		</h2>
+		<p class="text-sm text-secondary-content/80">
+			{$_('footer.open_x_facts_description', {
+				default: 'Try the temporary landing pages for each Open X Facts project.'
+			})}
+		</p>
+		<div class="mt-2 flex flex-wrap gap-2">
+			{#each LINKS_OPEN_X_FACTS as link (link.flavor)}
+				<a
+					href={`/?flavor=${link.flavor}`}
+					class="rounded-full bg-secondary-content px-4 py-2 text-primary transition-opacity hover:opacity-80"
+				>
+					{$_(link.key, { default: link.default })}
 				</a>
 			{/each}
 		</div>

--- a/src/lib/ui/Logo.svelte
+++ b/src/lib/ui/Logo.svelte
@@ -4,7 +4,7 @@
 
 	let websiteCtx = getWebsiteCtx();
 
-	let logoSuffix = $derived(WEBSITE_FLAVOR_METADATA[websiteCtx.flavor]?.reportFlavor ?? 'off');
+	let logoSuffix = $derived(WEBSITE_FLAVOR_METADATA[$websiteCtx.flavor]?.reportFlavor ?? 'off');
 	let {
 		class: className = '',
 		mono = false

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,8 +38,8 @@
 	import { extractQuery } from '$lib/facets';
 	import { dev } from '$app/environment';
 	import type { LayoutProps } from './$types';
-	import { setWebsiteCtx } from '$lib/stores/website';
-	import type { WebsiteFlavor } from '$lib/flavor';
+	import { getWebsiteFlavorFromParam } from '$lib/flavor';
+	import { createWebsiteCtx } from '$lib/stores/website';
 	import { setToastCtx, type Toast as ToastType, type ToastContext } from '$lib/stores/toasts';
 	import Shortcuts from './Shortcuts.svelte';
 	import { setShortcutCtx, type Shortcut } from '$lib/stores/shortcuts';
@@ -49,10 +49,22 @@
 	import { resolve } from '$app/paths';
 
 	// == Global website context setup ==
-	let websiteCtx: { flavor: WebsiteFlavor } = $state({
-		flavor: 'food'
+	const websiteCtx = createWebsiteCtx();
+
+	function syncWebsiteFlavor(url: URL) {
+		const landingFlavor = getWebsiteFlavorFromParam(url.searchParams.get('flavor'));
+		websiteCtx.update((ctx) => ({
+			...ctx,
+			flavor: landingFlavor ?? 'food',
+			forcedFlavor: landingFlavor ?? null
+		}));
+	}
+
+	syncWebsiteFlavor(page.url);
+
+	$effect(() => {
+		syncWebsiteFlavor(page.url);
 	});
-	setWebsiteCtx(() => websiteCtx);
 
 	// == Global toast context setup ==
 	let toasts = $state<ToastType[]>([]);

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -33,6 +33,7 @@
 	import type { ProductGroupedAttributes } from './types';
 	import { personalizedSearch } from '$lib/stores/preferencesStore';
 	import { PRODUCT_URL } from '$lib/const';
+	import { toWebsiteFlavor } from '$lib/flavor';
 	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
@@ -63,7 +64,12 @@
 	let websiteCtx = getWebsiteCtx();
 	$effect(() => {
 		// Update website context based on product type
-		if (product.product_type) websiteCtx.flavor = product.product_type;
+		if ($websiteCtx.forcedFlavor == null && product.product_type) {
+			const productFlavor = toWebsiteFlavor(product.product_type);
+			if ($websiteCtx.flavor !== productFlavor) {
+				websiteCtx.update((ctx) => ({ ...ctx, flavor: productFlavor }));
+			}
+		}
 	});
 
 	// Track product score presence (fire once per product page view)


### PR DESCRIPTION
### Description

Adds temporary Open X Facts landing flavors selected through a validated flavor query parameter.

- Adds footer links for Open Food Facts, Open Beauty Facts, Open Pet Food Facts, and Open Products Facts.
- Maps project aliases to typed website flavors.
- Preserves product-derived branding unless the URL explicitly forces a flavor.
- Initializes the selected flavor during SSR and keeps it synchronized during client navigation.
- Adds English localization strings and flavor-mapping tests.

Validation completed:

- pnpm test -- --run
- pnpm check
- pnpm lint
- pnpm build

The two accessibility warnings reported by Svelte predate this change.

### Screenshot or video

Not included. The visible change adds Open X Facts project pills to the existing footer and switches the existing logo according to the selected flavor.

### Related issue(s) and discussion

- Fixes: #1727

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (not applicable; no documentation changes are required).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Codex (GPT-5)
  - **How it was used:** Agentic implementation, validation, and code review.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**