### PR TITLE
feat(product): add preferences shortcut to product page

### DIFF
--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -247,10 +247,17 @@
 	{/await}
 
 	<div class="collapse-arrow collapse border border-base-300 bg-base-100">
-		<input type="checkbox" bind:checked={showPreferences} />
-		<div class="collapse-title flex items-center gap-2 text-sm font-medium">
+		<input
+			type="checkbox"
+			bind:checked={showPreferences}
+			aria-labelledby="preferences-collapse-title"
+		/>
+		<div
+			id="preferences-collapse-title"
+			class="collapse-title flex items-center gap-2 text-sm font-medium"
+		>
 			<IconMdiCog class="h-4 w-4" />
-			{$_('preferences.edit_preferences')}
+			{$_('preferences.edit_preferences', { default: 'Edit Preferences' })}
 		</div>
 		<div class="collapse-content">
 			<PreferencesForm

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -16,13 +16,16 @@
 	import Gs1Country from './GS1Country.svelte';
 	import ProductHeader from './ProductHeader.svelte';
 	import BarcodeInfo from '$lib/ui/BarcodeInfo.svelte';
+	import PreferencesForm from '$lib/ui/preferences/PreferencesForm.svelte';
 	import Prices from './Prices.svelte';
 
 	import type { PageProps } from './$types';
 	import { userInfo } from '$lib/stores/user';
 	import { userAuthTokens } from '$lib/stores/auth';
 	import { getWebsiteCtx } from '$lib/stores/website';
+	import type { AttributeGroup } from '$lib/stores/preferencesStore';
 
+	import IconMdiCog from '@iconify-svelte/mdi/cog';
 	import IconMdiWarning from '@iconify-svelte/mdi/warning';
 
 	import { OpenFoodFacts, type Product } from '@openfoodfacts/openfoodfacts-nodejs';
@@ -91,6 +94,8 @@
 	let useWCFolksonomyEditor = $state(false);
 
 	let showBarcode = $state(false);
+
+	let showPreferences = $state(false);
 
 	const shortcutCtx = getShortcutCtx();
 
@@ -240,6 +245,20 @@
 			</div>
 		{/if}
 	{/await}
+
+	<div class="collapse-arrow collapse border border-base-300 bg-base-100">
+		<input type="checkbox" bind:checked={showPreferences} />
+		<div class="collapse-title flex items-center gap-2 text-sm font-medium">
+			<IconMdiCog class="h-4 w-4" />
+			{$_('preferences.edit_preferences')}
+		</div>
+		<div class="collapse-content">
+			<PreferencesForm
+				onClose={() => (showPreferences = false)}
+				groups={data.attributeGroups as AttributeGroup[]}
+			/>
+		</div>
+	</div>
 
 	<KnowledgePanelsComp panels={product.knowledge_panels} code={product.code} roots={['root']} />
 

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -117,17 +117,17 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		? getPricesCoords(pricesApi, params.barcode)
 		: Promise.resolve(null);
 
-	const defaultPreferences = (async () => {
-		const { data: attributeGroups } = await productsApi.getAttributeGroups();
+	const attributeGroups = (async () => {
+		const { data } = await productsApi.getAttributeGroups();
 		// FIXME: Remove cast when SDK fixes ids type being string | undefined
-		const attributeGroupsList = (attributeGroups ?? []) as AttributeGroup[];
-		return attributesToDefaultPreferences(attributeGroupsList);
+		return (data ?? []) as AttributeGroup[];
 	})();
 
 	return {
 		state,
 		lc,
-		defaultProductPreferences: await defaultPreferences,
+		attributeGroups: await attributeGroups,
+		defaultProductPreferences: attributesToDefaultPreferences(await attributeGroups),
 		tags: await folksonomyTags,
 		keys: await folksonomyKeys,
 		prices: await pricesResponse


### PR DESCRIPTION
### Description

Adds an "Edit Preferences" collapse under the Attributes section on the product page, so you can adjust your food preferences without going to Settings. Changing one re-filters the attribute cards straight away.

Same pattern the search page already uses, reusing `PreferencesForm`. `+page.ts` was already fetching the attribute groups for the default preferences, it just wasn't returning them, so no extra request.

### Screenshot

<img width="1400" height="1000" alt="image" src="https://github.com/user-attachments/assets/eae5d013-5d28-4132-b721-d49c68afe129" />
<img width="1400" height="1000" alt="image" src="https://github.com/user-attachments/assets/33213049-1353-47f3-8b46-593a2097b0fc" />


### Related issue(s) and discussion

- Fixes: #1734

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [x] I did **not** use an LLM or AI tool to write this PR.

---

## Notes not in the PR body

- **Why a collapse and not a link to Settings:** classic OFF puts an "Edit your preferences" toggle on the product page that expands the form inline (`#preferences_selection_form`), and `search/+page.svelte:319` already does the same thing here. A link out would also have needed `/settings` deep-linking, which does not exist — `activeTab` is local state and nothing reads the URL.
- **Why `PreferencesForm` took no changes:** it already had an unused `onClose` prop rendering a Close button, and `preferences.edit_preferences` / `preferences.close` were already in `en.json`. Nothing new was needed.
- **Deliberately not done:** `ProductAttributes.svelte` hardcodes its heading (`<h2>Attributes</h2>`) instead of using i18n. Real bug, unrelated to this, separate PR.

## Verification

- `pnpm lint` clean, `pnpm check` 1600 files 0 errors (the 2 warnings are pre-existing, `products/[barcode]/+page.svelte:224`, `<robotoff-contribution-message>`), `pnpm test` 23/23, `pnpm build` 48.6s exit 0.
- Functional check in the browser on `/products/3017620422003`: cards start as `Nutri-Score, NOVA group, Green-Score` (defaults). Opened the collapse, set *Salt in low quantity* to *Very important*, and the cards became `Salt` immediately with no reload. Persisted to `localStorage.preferences`.
- Checked at 1400px and in dark mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible product-preferences section to product pages.
  * Product preferences are now organized into attribute groups for easier viewing and editing.
  * Added a settings icon and controls to expand or collapse the preferences section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->