### PR TITLE
fix(pwa): add start_url and scope to manifest

### DIFF
--- a/src/routes/site.webmanifest/+server.ts
+++ b/src/routes/site.webmanifest/+server.ts
@@ -25,6 +25,8 @@ export const GET: RequestHandler = async () => {
 	const manifest: WebManifest = {
 		name: 'Open Food Facts Explorer',
 		short_name: 'OFF Explorer',
+		start_url: '/',
+		scope: '/',
 		icons: [
 			{
 				src: android192PNG,


### PR DESCRIPTION
The manifest declared `start_url` and `scope` as optional but never set
  them, so Chrome did not consider the site installable. Adding both
  satisfies Chrome's installability checklist and enables the
  `beforeinstallprompt` event.

  Closes #1726