### PR TITLE
fix: rename NOVA Group to Ultra-processing level in compare mode

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -768,7 +768,7 @@
 		"code_barcode": "Code (Barcode)",
 		"brand": "Brand",
 		"quantity": "Quantity",
-		"nova_group": "Nova Group",
+		"nova_group": "Ultra-processed level",
 		"num_additives": "N. of additives",
 		"nutritional_values_per_100g": "Nutritional Values (per 100g)",
 		"fruits_vegetables_nuts": "Fruits/Vegetables/Nuts",

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -768,7 +768,7 @@
 		"code_barcode": "Code (Barcode)",
 		"brand": "Brand",
 		"quantity": "Quantity",
-		"nova_group": "Ultra-processed level",
+		"nova_group": "Ultra-processing level",
 		"num_additives": "N. of additives",
 		"nutritional_values_per_100g": "Nutritional Values (per 100g)",
 		"fruits_vegetables_nuts": "Fruits/Vegetables/Nuts",

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -768,7 +768,7 @@
 		"code_barcode": "Code (Barcode)",
 		"brand": "Brand",
 		"quantity": "Quantity",
-		"nova_group": "Nova Group",
+		"nova_group": "Ultra-processed level",
 		"num_additives": "N. of additives",
 		"nutritional_values_per_100g": "Nutritional Values (per 100g)",
 		"fruits_vegetables_nuts": "Fruits/Vegetables/Nuts",

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -768,7 +768,7 @@
 		"code_barcode": "Code (Barcode)",
 		"brand": "Brand",
 		"quantity": "Quantity",
-		"nova_group": "Ultra-processed level",
+		"nova_group": "Ultra-processing level",
 		"num_additives": "N. of additives",
 		"nutritional_values_per_100g": "Nutritional Values (per 100g)",
 		"fruits_vegetables_nuts": "Fruits/Vegetables/Nuts",

--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -458,7 +458,7 @@
 								{@const comparison = getNovaComparison(product.nova_group, products)}
 								{@render scoreImage(
 									getNovaImage(product.nova_group),
-									`${$_('compare.nova_group')} ${product.nova_group}`,
+									`${$_('compare.nova_group', { default: 'Ultra-processed level' })} ${product.nova_group}`,
 									comparison.isBest
 								)}
 							{/if}
@@ -617,14 +617,16 @@
 				{/each}
 			</tr>
 			<tr>
-				<td class="sticky left-0 w-40 bg-base-100 font-semibold">{$_('compare.nova_group')}</td>
+				<td class="sticky left-0 w-40 bg-base-100 font-semibold"
+					>{$_('compare.nova_group', { default: 'Ultra-processed level' })}</td
+				>
 				{#each products as product (product.code)}
 					{@const comparison = getNovaComparison(product.nova_group, products)}
 					<td animate:flip={{ duration: 300 }}>
 						{#if product.nova_group}
 							{@render scoreImage(
 								getNovaImage(product.nova_group),
-								`${$_('compare.nova_group')} ${product.nova_group}`,
+								`${$_('compare.nova_group', { default: 'Ultra-processed level' })} ${product.nova_group}`,
 								comparison.isBest
 							)}
 						{:else}

--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -458,7 +458,7 @@
 								{@const comparison = getNovaComparison(product.nova_group, products)}
 								{@render scoreImage(
 									getNovaImage(product.nova_group),
-									`${$_('compare.nova_group', { default: 'Ultra-processed level' })} ${product.nova_group}`,
+									`${$_('compare.nova_group', { default: 'Ultra-processing level' })} ${product.nova_group}`,
 									comparison.isBest
 								)}
 							{/if}
@@ -618,7 +618,7 @@
 			</tr>
 			<tr>
 				<td class="sticky left-0 w-40 bg-base-100 font-semibold"
-					>{$_('compare.nova_group', { default: 'Ultra-processed level' })}</td
+					>{$_('compare.nova_group', { default: 'Ultra-processing level' })}</td
 				>
 				{#each products as product (product.code)}
 					{@const comparison = getNovaComparison(product.nova_group, products)}
@@ -626,7 +626,7 @@
 						{#if product.nova_group}
 							{@render scoreImage(
 								getNovaImage(product.nova_group),
-								`${$_('compare.nova_group', { default: 'Ultra-processed level' })} ${product.nova_group}`,
+								`${$_('compare.nova_group', { default: 'Ultra-processing level' })} ${product.nova_group}`,
 								comparison.isBest
 							)}
 						{:else}

--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -458,7 +458,7 @@
 								{@const comparison = getNovaComparison(product.nova_group, products)}
 								{@render scoreImage(
 									getNovaImage(product.nova_group),
-									`Ultra-processing level ${product.nova_group}`,
+									`${$_('compare.nova_group')} ${product.nova_group}`,
 									comparison.isBest
 								)}
 							{/if}
@@ -624,7 +624,7 @@
 						{#if product.nova_group}
 							{@render scoreImage(
 								getNovaImage(product.nova_group),
-								`Nova Group ${product.nova_group}`,
+								`${$_('compare.nova_group')} ${product.nova_group}`,
 								comparison.isBest
 							)}
 						{:else}


### PR DESCRIPTION
### Description

Renames "NOVA Group" to "Ultra-processing level" in Compare mode, as requested in #1657. Wording confirmed by @VaiTon in review (the issue text said "Ultra-processed level"; "Ultra-processing level" also matches the existing `nova` and `product.edit.score_calculation_description` strings):

- `compare.nova_group` is updated in the Crowdin source (`en-US.json`) and the English runtime locale (`en.json`).
- The mobile card and the desktop table NOVA image descriptions now reuse the translated `compare.nova_group` label. They previously used two inconsistent hard-coded strings ("Ultra-processing level" and "Nova Group"), so assistive technology now announces the same label the table displays.

The diff is deliberately minimal (3 files, +7/−5). No dedicated test was added: the change is a locale value plus label reuse, following the review feedback on the previous attempt (#1695).

Validation run locally: `pnpm format`, `pnpm lint`, `pnpm check`, `pnpm test` (23 passed), `pnpm build`, plus a manual render of `/compare/shared` with two live products: the new label appears consistently and neither replaced phrase remains.

### Screenshot or video

![Compare table showing the Ultra-processed level row](https://raw.githubusercontent.com/MatheusMartinho/openfoodfacts-explorer/assets/compare-1657-after.png)

Dev server with real products (barcodes `3017620422003` and `3068320363188`).

### Related issue(s) and discussion

- Fixes: #1657

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Claude Code — Claude Fable 5 (`claude-fable-5`) for the original implementation, Claude Opus 5 (`claude-opus-5`) for the follow-up wording change
  - **How it was used:** agentic (investigation, implementation, validation, and PR preparation), directed and reviewed by @MatheusMartinho. Disclosed on issue #1657 before opening this PR.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Updated comparison image descriptions in mobile and desktop views to use the localized “Ultra-processing level” label.

- **Localization**
  - Revised the English comparison label from “Ultra-processed level” to “Ultra-processing level.”
  - Added a localized fallback for the Nova Group label when a translation is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
