### PR TITLE
feat: clarify GS1 barcode information

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -309,6 +309,19 @@
 			"prices": "Prices",
 			"folksonomy": "Tags & Community"
 		},
+		"gs1": {
+			"title": "GS1 barcode information",
+			"intro": "GS1 provides standards for product barcodes. The prefix at the beginning of a barcode is associated with the company or organisation that registered it.",
+			"important": "This does not indicate where the product was manufactured or its country of origin.",
+			"prefix_title": "GS1 prefix",
+			"prefix_label": "Registered through:",
+			"prefix_note": "The location shown here refers to the GS1 registration, not the product’s origin.",
+			"verified_title": "More information",
+			"verified_description": "Verified by GS1 may provide more information about the company and product linked to this barcode.",
+			"verified_link": "View this barcode on GS1",
+			"source_label": "Source:",
+			"source_link": "GS1"
+		},
 		"edit": {
 			"sidebar_navigation": "Product edit sections",
 			"sidebar": {

--- a/src/routes/products/[barcode]/+page.ts
+++ b/src/routes/products/[barcode]/+page.ts
@@ -112,9 +112,8 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		? folkApi.getKeys().then((it) => it.data)
 		: Promise.resolve([]);
 
-	const pricesApi = createPricesApi(fetch);
 	const pricesResponse = isPriceConfigured()
-		? getPricesCoords(pricesApi, params.barcode)
+		? getPricesCoords(createPricesApi(fetch), params.barcode)
 		: Promise.resolve(null);
 
 	const defaultPreferences = (async () => {

--- a/src/routes/products/[barcode]/GS1Country.svelte
+++ b/src/routes/products/[barcode]/GS1Country.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from '$lib/i18n';
 	import Card from '$lib/ui/Card.svelte';
 
 	interface Props {
@@ -7,7 +8,7 @@
 
 	let { barcode }: Props = $props();
 
-	const gs1Country: Array<{ name: string; prefixes: number[]; code: string }> = [
+	const gs1Allocations: Array<{ name: string; prefixes: number[]; code: string }> = [
 		{ name: 'USA and Canada', prefixes: [0], code: 'US-CA' },
 		{ name: 'USA', prefixes: [1], code: 'US' },
 		{ name: 'France and Monaco', prefixes: [30, 31, 32, 33, 34, 35, 36, 37], code: 'FR-MC' },
@@ -130,28 +131,28 @@
 		{ name: 'Refund receipts', prefixes: [980], code: '' }
 	];
 
-	function getCountry(barcode: string) {
+	function getAllocation(barcode: string) {
 		// Try with the first 3 digits
 		let prefix = parseInt(barcode.slice(0, 3));
-		for (const country of gs1Country) {
-			if (country.prefixes.includes(prefix)) {
-				return country;
+		for (const allocation of gs1Allocations) {
+			if (allocation.prefixes.includes(prefix)) {
+				return allocation;
 			}
 		}
 
 		// Try with the first 2 digits
 		prefix = parseInt(barcode.slice(0, 2));
-		for (const country of gs1Country) {
-			if (country.prefixes.includes(prefix)) {
-				return country;
+		for (const allocation of gs1Allocations) {
+			if (allocation.prefixes.includes(prefix)) {
+				return allocation;
 			}
 		}
 
 		// Try with the first digit
 		prefix = parseInt(barcode.slice(0, 1));
-		for (const country of gs1Country) {
-			if (country.prefixes.includes(prefix)) {
-				return country;
+		for (const allocation of gs1Allocations) {
+			if (allocation.prefixes.includes(prefix)) {
+				return allocation;
 			}
 		}
 
@@ -172,37 +173,79 @@
 			.join('');
 	}
 
-	let country = $derived(getCountry(barcode));
+	let allocation = $derived(getAllocation(barcode));
 </script>
 
 <Card>
-	<h1 class="my-4 text-2xl font-bold sm:text-4xl">Barcode information</h1>
+	<h1 class="my-4 text-2xl font-bold sm:text-4xl">
+		{$_('product.gs1.title', { default: 'GS1 barcode information' })}
+	</h1>
 
-	<div>
-		<div class="flex items-center gap-2">
-			<div class="text-xl sm:text-3xl">{getFlagEmoji(country.code)}</div>
-			<p class="sm:text-md text-xs">
-				<strong>GS1 Country:</strong>
-				{country.name}
+	<div class="space-y-4 text-sm sm:text-base">
+		<p>
+			{$_('product.gs1.intro', {
+				default:
+					'GS1 provides standards for product barcodes. The prefix at the beginning of a barcode is associated with the company or organisation that registered it.'
+			})}
+			<em class="ml-1 text-base-content/70">
+				{$_('product.gs1.important', {
+					default:
+						'This does not indicate where the product was manufactured or its country of origin.'
+				})}
+			</em>
+		</p>
+
+		<div class="rounded-lg border border-base-300 bg-base-200 p-4">
+			<h2 class="mb-2 font-semibold">
+				{$_('product.gs1.prefix_title', { default: 'Prefix allocation' })}
+			</h2>
+			<div class="flex items-center gap-2">
+				{#if allocation.code}
+					<div class="text-xl sm:text-3xl" aria-hidden="true">{getFlagEmoji(allocation.code)}</div>
+				{/if}
+				<p>
+					<strong>{$_('product.gs1.prefix_label', { default: 'Registered through:' })}</strong>
+					{allocation.name}
+				</p>
+			</div>
+			<p class="mt-2 text-sm text-base-content/70">
+				{$_('product.gs1.prefix_note', {
+					default:
+						'The location shown here refers to the GS1 registration, not the product’s origin.'
+				})}
 			</p>
 		</div>
 
-		<div class="my-4">
+		<div>
+			<h2 class="mb-2 font-semibold">
+				{$_('product.gs1.verified_title', { default: 'More information' })}
+			</h2>
+			<p>
+				{$_('product.gs1.verified_description', {
+					default:
+						'Verified by GS1 may provide more information about the company and product linked to this barcode.'
+				})}
+			</p>
+		</div>
+
+		<div>
 			<a
 				class="btn btn-secondary"
 				href="https://www.gs1.org/services/verified-by-gs1/results?gtin={barcode}"
 				target="_blank"
 				rel="noopener noreferrer"
 			>
-				Get more information from GS1
+				{$_('product.gs1.verified_link', { default: 'View this barcode on GS1' })}
 			</a>
 		</div>
-		<p class="mt-4 text-end text-sm text-secondary italic">
-			Source: <a
+		<p class="text-end text-sm text-secondary italic">
+			{$_('product.gs1.source_label', { default: 'Source:' })}
+			<a
 				class="link"
 				href="https://www.gs1.org/standards/id-keys/company-prefix"
 				target="_blank"
-				rel="noopener noreferrer">GS1</a
+				rel="noopener noreferrer"
+				>{$_('product.gs1.source_link', { default: 'GS1 prefix standards' })}</a
 			>
 		</p>
 	</div>


### PR DESCRIPTION
### Description

Improves the GS1 barcode information section.

- Explains GS1 and barcode prefixes in simpler language.
- Clarifies that the prefix is associated with the registering company or organisation, not the manufacturing place or country of origin.
- Prevents the optional Prices API from crashing product pages when it is not configured.

### Related issue(s) and discussion

- Fixes: #1691

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code and run the project validation commands.
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (not applicable for this UI copy change).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** OpenAI Codex, GPT-5
  - **How it was used:** agentic implementation, review, and validation
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GS1 barcode information section with prefix allocation details, verification guidance, explanatory content, and source links.
  * Clarified that GS1 registration allocation does not necessarily indicate where a product was manufactured or sold.
  * Added conditional country flags and clearer allocation descriptions.
* **Localization**
  * Added English translations for the new GS1 information and source labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->