### PR TITLE
feat: support sidebar anchor navigation

### DIFF
--- a/src/lib/ui/EditProductForm.svelte
+++ b/src/lib/ui/EditProductForm.svelte
@@ -174,6 +174,7 @@
 			id: sec.id,
 			label: $_(sec.labelKey, { default: sec.defaultLabel }),
 			icon: sec.icon,
+			href: `#${sec.id}`,
 			isCollapsed: () => !openSections[sec.id],
 			onToggle: (open?: boolean) => {
 				openSections[sec.id] = open !== undefined ? open : !openSections[sec.id];
@@ -186,6 +187,7 @@
 				label: $_('product.edit.sections.moderator_tools', { default: 'Moderator Tools' }),
 				icon: IconMdiShieldAccount,
 				style: 'warning',
+				href: '#moderator-tools',
 				isCollapsed: () => !openSections['moderator-tools'],
 				onToggle: (open?: boolean) => {
 					openSections['moderator-tools'] =
@@ -223,18 +225,6 @@
 		});
 		handleCollapseToggle(editSections[0]?.id || '');
 	}
-
-	function handleSidebarSectionClick(id: string) {
-		const section = editSections.find((s) => s.id === id);
-		sidebar?.scrollToSection(id, () => {
-			if (activeSection === id) {
-				section?.onToggle?.();
-			} else {
-				section?.onToggle?.(true);
-			}
-			handleCollapseToggle(id);
-		});
-	}
 </script>
 
 <div class="relative w-full lg:grid lg:grid-cols-[auto_1fr] lg:gap-8">
@@ -248,7 +238,6 @@
 			? $_('product.edit.sidebar.collapse_all', { default: 'Collapse All' })
 			: $_('product.edit.sidebar.expand_all', { default: 'Expand All' })}
 		onHeaderAction={toggleExpandAll}
-		onSectionClick={handleSidebarSectionClick}
 	/>
 
 	<div class="w-full min-w-0 space-y-4">

--- a/src/lib/ui/Sidebar.svelte
+++ b/src/lib/ui/Sidebar.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
 	import type { Component, ComponentType } from 'svelte';
 	import { _ } from '$lib/i18n';
 	import IconMdiChevronRight from '@iconify-svelte/mdi/chevron-right';
 
-	export interface SidebarSection {
+	export interface SidebarSectionBase {
 		id: string;
 		label: string;
 		icon?: Component | ComponentType;
@@ -13,6 +14,18 @@
 		onToggle?: (open?: boolean) => void;
 	}
 
+	type SidebarSectionAction =
+		| {
+				href: string;
+				onClick?: never;
+		  }
+		| {
+				href?: never;
+				onClick: () => void;
+		  };
+
+	export type SidebarSection = SidebarSectionBase & SidebarSectionAction;
+
 	type Props = {
 		sections: SidebarSection[];
 		activeSection?: string;
@@ -20,7 +33,6 @@
 		hidden?: boolean;
 		headerActionLabel?: string;
 		onHeaderAction?: () => void;
-		onSectionClick?: (id: string) => void;
 		type?: 'product' | 'edit';
 	};
 
@@ -31,7 +43,6 @@
 		hidden = $bindable(false),
 		headerActionLabel,
 		onHeaderAction,
-		onSectionClick,
 		type = 'product'
 	}: Props = $props();
 
@@ -112,12 +123,47 @@
 		}
 	}
 
-	function handleSectionClick(id: string) {
-		if (onSectionClick) {
-			onSectionClick(id);
+	function handleSectionClick(section: SidebarSection) {
+		if (section.onClick) {
+			section.onClick();
 		} else {
-			scrollToSection(id);
+			scrollToSection(section.id);
 		}
+	}
+
+	function getSectionClass(section: SidebarSection) {
+		return [
+			'group relative flex cursor-pointer items-center py-2 text-left transition-all duration-200 outline-none select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
+			activeSection === section.id
+				? section.style === 'warning'
+					? 'font-semibold text-warning'
+					: 'font-semibold text-primary'
+				: section.style === 'warning'
+					? 'text-warning/70 hover:text-warning'
+					: 'text-base-content/60 hover:text-primary'
+		];
+	}
+
+	async function handleAnchorClick(
+		event: MouseEvent,
+		section: Extract<SidebarSection, { href: string }>
+	) {
+		if (
+			event.button !== 0 ||
+			event.metaKey ||
+			event.ctrlKey ||
+			event.shiftKey ||
+			event.altKey ||
+			!section.href.startsWith('#')
+		) {
+			return;
+		}
+
+		const targetId = decodeURIComponent(section.href.slice(1));
+		if (!document.getElementById(targetId)) return;
+
+		event.preventDefault();
+		await goto(section.href, { noScroll: true });
 	}
 
 	function updateActiveSection() {
@@ -233,32 +279,43 @@
 			{/if}
 
 			{#each sections as section (section.id)}
-				<button
-					type="button"
-					data-section={section.id}
-					aria-controls={section.id}
-					aria-current={activeSection === section.id ? 'location' : undefined}
-					onclick={() => handleSectionClick(section.id)}
-					class={[
-						'group relative flex cursor-pointer items-center py-2 text-left transition-all duration-200 outline-none select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
-						activeSection === section.id
-							? section.style === 'warning'
-								? 'font-semibold text-warning'
-								: 'font-semibold text-primary'
-							: section.style === 'warning'
-								? 'text-warning/70 hover:text-warning'
-								: 'text-base-content/60 hover:text-primary'
-					]}
-				>
-					{#if section.icon}
-						{@const Icon = section.icon}
-						<Icon
-							aria-hidden="true"
-							class="mr-2 h-4 w-4 transition-transform duration-200 group-hover:scale-110"
-						/>
-					{/if}
-					<span>{section.label}</span>
-				</button>
+				{#if section.href}
+					<a
+						href={section.href}
+						onclick={(event) => handleAnchorClick(event, section)}
+						data-section={section.id}
+						aria-controls={section.id}
+						aria-current={activeSection === section.id ? 'location' : undefined}
+						class={getSectionClass(section)}
+					>
+						{#if section.icon}
+							{@const Icon = section.icon}
+							<Icon
+								aria-hidden="true"
+								class="mr-2 h-4 w-4 transition-transform duration-200 group-hover:scale-110"
+							/>
+						{/if}
+						<span>{section.label}</span>
+					</a>
+				{:else}
+					<button
+						type="button"
+						data-section={section.id}
+						aria-controls={section.id}
+						aria-current={activeSection === section.id ? 'location' : undefined}
+						onclick={() => handleSectionClick(section)}
+						class={getSectionClass(section)}
+					>
+						{#if section.icon}
+							{@const Icon = section.icon}
+							<Icon
+								aria-hidden="true"
+								class="mr-2 h-4 w-4 transition-transform duration-200 group-hover:scale-110"
+							/>
+						{/if}
+						<span>{section.label}</span>
+					</button>
+				{/if}
 			{/each}
 		</nav>
 	</aside>

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -24,7 +24,7 @@
 	import { userAuthTokens } from '$lib/stores/auth';
 	import { getWebsiteCtx } from '$lib/stores/website';
 
-	import Sidebar, { type SidebarSection } from '$lib/ui/Sidebar.svelte';
+	import Sidebar, { type SidebarSectionBase } from '$lib/ui/Sidebar.svelte';
 	import IconMdiInformation from '@iconify-svelte/mdi/information';
 	import IconMdiNutrition from '@iconify-svelte/mdi/nutrition';
 	import IconMdiLeaf from '@iconify-svelte/mdi/leaf';
@@ -111,9 +111,10 @@
 
 	let showBarcode = $state(false);
 	let sidebarHidden = $state(!($preferences.productSidebarVisible ?? true));
+	let sidebar = $state<ReturnType<typeof Sidebar>>();
 
 	const activeSections = $derived.by(() => {
-		const rawList: (SidebarSection | false | undefined | null)[] = [
+		const rawList: (SidebarSectionBase | false | undefined | null)[] = [
 			{
 				id: 'overview',
 				label: $_('product.sections.product', { default: 'Product' }),
@@ -177,7 +178,12 @@
 				icon: IconMdiLabel
 			}
 		];
-		return rawList.filter((item): item is SidebarSection => !!item);
+		return rawList
+			.filter((item): item is SidebarSectionBase => !!item)
+			.map((section) => ({
+				...section,
+				onClick: () => sidebar?.scrollToSection(section.id)
+			}));
 	});
 
 	const shortcutCtx = getShortcutCtx();
@@ -312,6 +318,7 @@
 		]}
 	>
 		<Sidebar
+			bind:this={sidebar}
 			type="product"
 			sections={activeSections}
 			bind:hidden={sidebarHidden}


### PR DESCRIPTION
### Description

The editing sidebar now uses real fragment links for section navigation. Clicking a section updates the URL, for example `#basic-info`, and keeps the existing accordion expansion and smooth-scroll behavior. This also makes edit sections directly bookmarkable and shareable.

The shared sidebar API now requires each item to define exactly one navigation mode:

- `href` renders an anchor.
- `onClick` renders a button.

The product sidebar keeps its existing button-based smooth scrolling through explicit `onClick` handlers.

### Screenshot or video

Not applicable: the change is to navigation semantics and URL fragments, with no visual layout change.

### Related issue(s) and discussion

No issue number was provided with the request.

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** OpenAI Codex, GPT-5
  - **How it was used:** Agentic implementation, code review, and validation.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**
