### PR TITLE
fix: restore products on Explore page

### DIFF
--- a/src/routes/explore/+page.ts
+++ b/src/routes/explore/+page.ts
@@ -6,7 +6,7 @@ import type { Product } from '@openfoodfacts/openfoodfacts-nodejs';
 export const load: PageLoad = async ({ fetch }) => {
 	const api = createSearchApi(fetch);
 
-	// Example: fetch some popular categories (replace with real API call as needed)
+	// Fetch some popular categories for the Explore landing page.
 	const categories = [
 		'Snacks',
 		'Beverages',
@@ -20,11 +20,11 @@ export const load: PageLoad = async ({ fetch }) => {
 		'Sauces'
 	];
 
-	// For each category, fetch a few products (limit to 4 per category for demo)
+	// For each category, fetch a few popular products.
 	const sections = await Promise.all(
 		categories.map(async (cat) => {
 			const { data: searchRes, error: searchError } = (await api.search({
-				q: `categories:(${cat.toLowerCase()})`,
+				q: `categories:"en:${cat.toLowerCase()}"`,
 				page_size: 6,
 				langs: ['en'],
 				page: 1,


### PR DESCRIPTION
### Description

The /explore page was sending category filters as categories:(snacks). The search backend now expects quoted, language-qualified category tags, so requests now use categories:"en:snacks" and equivalent values for the other Explore sections.

This restores product results after the search backend update.

### Screenshot or video

Not applicable: this is a data-loading fix with no visual changes.

### Related issue(s) and discussion

No issue: bug fix discovered from the backend query contract change.

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (not applicable).

Validation:
- pnpm test — 164 tests passed
- pnpm check — 0 errors and 0 warnings
- Targeted Prettier and ESLint checks passed
- pnpm build — passed

## Large Language Models usage disclosure

- [ ] I did not use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - Agent / tool name and version: Codex, GPT-5
  - How it was used: Agentic implementation, testing, and review.
  - I have reviewed and take full responsibility for all AI-generated code in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Explore category searches by targeting English category tags.
  * Preserved category result limits and error handling for reliable loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->