### PR TITLE
feat: add accordion collapse for nutritional values in compare mode

### DIFF
--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -326,6 +326,7 @@
 	}
 
 	let dragSrcIndex: { code: string; idx: number } | null = null;
+	let expandedNutrients = $state<Record<string, boolean>>({});
 </script>
 
 {#snippet scoreImage(imageSrc: string, altText: string, isBest: boolean)}
@@ -480,18 +481,37 @@
 
 				{#if product.nutriments}
 					<div class="mt-4 border-t pt-4">
-						<p class="mb-2 text-sm font-semibold">{$_('compare.nutrients_per_100g')}</p>
-						<div class="space-y-1 text-sm">
-							{#each availableNutrients as nutrient (nutrient.key)}
-								{@const comparison = getNutrientComparison(product, nutrient.key, products, index)}
-								{#if comparison.value != null}
-									<div class="flex items-center justify-between">
-										<span class="font-medium">{nutrient.label}:</span>
-										{@render nutrientValue(comparison, nutrient.unit, nutrient.key)}
-									</div>
-								{/if}
-							{/each}
-						</div>
+						<button
+							type="button"
+							class="flex w-full items-center justify-between text-left text-sm font-semibold"
+							onclick={() => {
+								expandedNutrients[product.code] = !expandedNutrients[product.code];
+							}}
+							aria-expanded={expandedNutrients[product.code] ?? false}
+						>
+							<span>{$_('compare.nutrients_per_100g')}</span>
+							<span>{expandedNutrients[product.code] ? '▲' : '▼'}</span>
+						</button>
+
+						{#if expandedNutrients[product.code]}
+							<div class="mt-2 space-y-1 text-sm">
+								{#each availableNutrients as nutrient (nutrient.key)}
+									{@const comparison = getNutrientComparison(
+										product,
+										nutrient.key,
+										products,
+										index
+									)}
+
+									{#if comparison.value != null}
+										<div class="flex items-center justify-between">
+											<span class="font-medium">{nutrient.label}:</span>
+											{@render nutrientValue(comparison, nutrient.unit, nutrient.key)}
+										</div>
+									{/if}
+								{/each}
+							</div>
+						{/if}
 					</div>
 				{/if}
 			</div>

--- a/src/lib/ui/ComparisonDisplay.svelte
+++ b/src/lib/ui/ComparisonDisplay.svelte
@@ -489,7 +489,11 @@
 							}}
 							aria-expanded={expandedNutrients[product.code] ?? false}
 						>
-							<span>{$_('compare.nutrients_per_100g')}</span>
+							<span
+								>{$_('compare.nutrients_per_100g', {
+									default: 'Nutrients /100g:'
+								})}</span
+							>
 							<span>{expandedNutrients[product.code] ? '▲' : '▼'}</span>
 						</button>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description
Makes nutritional values collapsible per product in Compare mode so users can expand or collapse to focus on relevant data.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

### Screenshot or video
<img width="232" height="560" alt="Screenshot 2026-08-21 011142" src="https://github.com/user-attachments/assets/39d597c7-cae4-412a-a997-58f1716a7066" />
<img width="232" height="571" alt="Screenshot 2026-08-21 011131" src="https://github.com/user-attachments/assets/c6e6d769-5b73-404c-bba0-b89ea1b361d9" />

<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- Fixes: #1654 

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** GitHub Copilot <!-- e.g. GitHub Copilot (GPT-4o), Claude Sonnet 4.5, Cursor -->
  - **How it was used:** autocomplete and review <!-- e.g. agentic (fully automated), autocomplete (suggestions accepted), review (checked my code) -->
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expandable nutrient details for each product on mobile devices.
  * Nutrient information is collapsed by default and can be opened with an accessible toggle button.
  * Desktop comparison behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->