### PR TITLE
fix: disable Vercel Speed Insights on self-hosted builds

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -176,8 +176,10 @@
 	let { children }: LayoutProps = $props();
 
 	onMount(() => {
-		// only inject the script on the client side
-		injectSpeedInsights();
+		if (import.meta.env.VERCEL) {
+			// if we're on vercel and on the client, inject the speed insights script
+			injectSpeedInsights();
+		}
 	});
 
 	function updateSearchQuery(url: URL) {

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,1 +1,5 @@
 declare const APP_VERSION: string;
+
+interface ImportMetaEnv {
+	readonly VERCEL: boolean;
+}

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,5 +1,4 @@
-declare const APP_VERSION: string;
-
 interface ImportMetaEnv {
+	readonly PACKAGE_VERSION: string;
 	readonly VERCEL: boolean;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,9 @@ export default defineConfig({
 		})
 	],
 	define: {
-		'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageVersion)
+		'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+		// Vercel provides this variable during the build. Keep the value in the
+		// client bundle so self-hosted Node builds do not load Vercel-only scripts.
+		'import.meta.env.VERCEL': JSON.stringify('VERCEL' in process.env)
 	}
 });


### PR DESCRIPTION
### Description

Vercel Speed Insights was injected unconditionally, causing self-hosted Node deployments to request the Vercel-only endpoint `/_vercel/speed-insights/script.js` and receive a 404.

The client now injects Speed Insights only when the build is running on Vercel, using the existing `VERCEL` build environment variable.

Validation completed: svelte-check, ESLint, 66 Vitest tests, and production build.

### Screenshot or video

Not applicable; this is a deployment/configuration bug fix with no UI changes.

### Related issue(s) and discussion

- Fixes: #1803

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (not applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Codex (GPT-5)
  - **How it was used:** Agentic implementation, validation, commit, and PR preparation.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**