### PR TITLE
chore: update pnpm to 11.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,5 @@
 		"@webcomponents/webcomponentsjs": "^2.8.0",
 		"isomorphic-dompurify": "^3.21.0"
 	},
-	"packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72"
+	"packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621"
 }


### PR DESCRIPTION
### Description

Updates the `packageManager` pin in `package.json` from pnpm 11.17.0 to pnpm 11.22.0, including the new integrity hash.

### Screenshot or video

Not applicable; this is a tooling metadata update.

### Related issue(s) and discussion

Not applicable; this is a maintenance update with no issue.

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

Validation: `pnpm format`, `pnpm lint`, `pnpm check`, `pnpm test`, and `pnpm build` passed.

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** OpenAI Codex (GPT-5), agentic workflow
  - **How it was used:** Agentic implementation, validation, commit, branch publication, and PR creation.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**