### PR TITLE
feat: add external knowledge panel sources

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,7 @@ export * from './api/product';
 export * from './api/nutriments';
 
 export * from './api/knowledgepanels';
+export * from './api/externalSources';
 
 export function createRobotoffApi(fetch: typeof window.fetch) {
 	// We hardcode this because it is not expected to change

--- a/src/lib/api/externalSources.test.ts
+++ b/src/lib/api/externalSources.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+	expandExternalSourceUrl,
+	isExternalSourceEligible,
+	type ExternalSource
+} from './externalSources';
+
+const source = (overrides: Partial<ExternalSource> = {}): ExternalSource => ({
+	id: 'source',
+	name: 'Source',
+	knowledge_panel_url: 'https://provider.example/$code?lang=$lc&country=$cc',
+	...overrides
+});
+
+describe('external knowledge panel sources', () => {
+	it('expands and encodes all documented URL variables', () => {
+		expect(
+			expandExternalSourceUrl('https://example.test/$code/$lc/$cc', {
+				code: '123/456',
+				lc: 'en-US',
+				cc: 'world wide'
+			})
+		).toBe('https://example.test/123%2F456/en-US/world%20wide');
+	});
+
+	it('matches category, country, language and product type filters', () => {
+		expect(
+			isExternalSourceEligible(
+				source({
+					filters: {
+						categories: ['en:snacks'],
+						countries: ['de'],
+						languages: ['de'],
+						product_types: ['food']
+					}
+				}),
+				{
+					cc: 'de',
+					lc: 'de',
+					productType: 'food',
+					categories: ['en:snacks', 'en:foods']
+				}
+			)
+		).toBe(true);
+
+		expect(
+			isExternalSourceEligible(source({ filters: { countries: ['fr'] } }), {
+				cc: 'de',
+				lc: 'de',
+				productType: 'food',
+				categories: []
+			})
+		).toBe(false);
+	});
+
+	it('does not expose private sources without an explicit scope grant', () => {
+		const context = { cc: 'world', lc: 'en', categories: [] };
+		expect(isExternalSourceEligible(source({ scope: 'moderators' }), context)).toBe(false);
+		expect(
+			isExternalSourceEligible(source({ scope: 'moderators', user_in_scope: true }), context)
+		).toBe(true);
+	});
+});

--- a/src/lib/api/externalSources.test.ts
+++ b/src/lib/api/externalSources.test.ts
@@ -9,6 +9,8 @@ const source = (overrides: Partial<ExternalSource> = {}): ExternalSource => ({
 	id: 'source',
 	name: 'Source',
 	knowledge_panel_url: 'https://provider.example/$code?lang=$lc&country=$cc',
+	section: 'external',
+	scope: 'public',
 	...overrides
 });
 

--- a/src/lib/api/externalSources.test.ts
+++ b/src/lib/api/externalSources.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
 	expandExternalSourceUrl,
+	getExternalKnowledgePanels,
 	isExternalSourceEligible,
 	type ExternalSource
 } from './externalSources';
@@ -61,5 +62,35 @@ describe('external knowledge panel sources', () => {
 		expect(
 			isExternalSourceEligible(source({ scope: 'moderators', user_in_scope: true }), context)
 		).toBe(true);
+	});
+
+	it('accepts the panels response returned by external providers', async () => {
+		const externalSource = source();
+		const fetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = input instanceof Request ? input.url : String(input);
+			if (url.includes('/api/v3/external_sources')) {
+				return Response.json({ external_sources: [externalSource] });
+			}
+
+			return Response.json({
+				panels: {
+					root: {
+						elements: [],
+						type: 'root'
+					}
+				}
+			});
+		});
+
+		const results = await getExternalKnowledgePanels(fetch, {
+			code: '5000326011242',
+			lc: 'en',
+			cc: 'world',
+			productType: 'food',
+			categories: ['en:eggs']
+		});
+
+		expect(results).toHaveLength(1);
+		expect(results[0].knowledgePanels).toHaveProperty('root');
 	});
 });

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -1,0 +1,298 @@
+import type { KnowledgePanels } from './knowledgepanels';
+import { createProductsApi } from './product';
+import { dev } from '$app/environment';
+
+export type ExternalSourceFilters = {
+	categories?: string[];
+	countries?: string[];
+	languages?: string[];
+	product_types?: string[];
+};
+
+export type ExternalSource = {
+	id: string;
+	name: string;
+	description?: string;
+	icon_url?: string;
+	knowledge_panel_url: string;
+	provider_name?: string;
+	provider_website?: string;
+	privacy_policy_url?: string;
+	section?: string;
+	scope?: 'public' | 'users' | 'moderators' | string;
+	user_in_scope?: boolean;
+	filters?: ExternalSourceFilters;
+};
+
+export type ExternalSourceMatchReason =
+	'category' | 'country' | 'language' | 'product_type' | 'public' | 'moderator' | 'account';
+
+export type ExternalKnowledgePanels = ExternalSource & {
+	knowledgePanels: KnowledgePanels;
+	matchReasons: ExternalSourceMatchReason[];
+	productName?: string;
+	productImageUrl?: string;
+};
+
+export type ExternalSourceProductContext = {
+	code: string;
+	lc: string;
+	cc: string;
+	productType?: string;
+	categories: string[];
+};
+
+type ExternalSourcesResponse = {
+	external_sources?: ExternalSource[];
+};
+
+type ExternalSourceProductResponse = {
+	name?: string;
+	product_image_url?: string;
+	knowledge_panels?: KnowledgePanels;
+	result?: {
+		knowledge_panels?: KnowledgePanels;
+	};
+	panels?: KnowledgePanels;
+};
+
+const EXTERNAL_SOURCE_TIMEOUT_MS = 10_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function matchesFilter(values: string[] | undefined, value: string | undefined, list: string[]) {
+	if (values == null || values.length === 0) return true;
+	if (value != null && values.includes(value)) return true;
+	return list.some((item) => values.includes(item));
+}
+
+/**
+ * Expand the template variables documented by the Product Opener API.
+ * Values are encoded individually so that a barcode or locale cannot alter
+ * the provider URL structure.
+ */
+export function expandExternalSourceUrl(
+	template: string,
+	context: Pick<ExternalSourceProductContext, 'code' | 'lc' | 'cc'>
+): string {
+	const values = {
+		code: context.code,
+		lc: context.lc,
+		cc: context.cc
+	};
+
+	return template.replace(/\$(code|lc|cc)/g, (_, key: keyof typeof values) => {
+		return encodeURIComponent(values[key]);
+	});
+}
+
+export function isExternalSourceEligible(
+	source: ExternalSource,
+	context: Omit<ExternalSourceProductContext, 'code'>
+): boolean {
+	return getExternalSourceEligibilityIssues(source, context).length === 0;
+}
+
+export function getExternalSourceEligibilityIssues(
+	source: ExternalSource,
+	context: Omit<ExternalSourceProductContext, 'code'>
+): string[] {
+	const issues: string[] = [];
+
+	// The API may return all configured sources. Non-public sources must only
+	// be displayed when the authenticated API response explicitly grants access.
+	if (source.scope != null && source.scope !== 'public' && source.user_in_scope !== true) {
+		issues.push(`scope:${source.scope}`);
+	}
+
+	const filters = source.filters;
+	if (filters == null) return issues;
+
+	if (!matchesFilter(filters.categories, undefined, context.categories)) {
+		issues.push('categories');
+	}
+	if (!matchesFilter(filters.countries, context.cc, [])) {
+		issues.push(`country:${context.cc}`);
+	}
+	if (!matchesFilter(filters.languages, context.lc, [])) {
+		issues.push(`language:${context.lc}`);
+	}
+	if (!matchesFilter(filters.product_types, context.productType, [])) {
+		issues.push(`product_type:${context.productType ?? 'unknown'}`);
+	}
+
+	return issues;
+}
+
+export function getExternalSourceMatchReasons(
+	source: ExternalSource,
+	context: Omit<ExternalSourceProductContext, 'code'>
+): ExternalSourceMatchReason[] {
+	const reasons: ExternalSourceMatchReason[] = [];
+	const filters = source.filters;
+
+	if (
+		filters?.categories?.length &&
+		matchesFilter(filters.categories, undefined, context.categories)
+	) {
+		reasons.push('category');
+	}
+	if (filters?.countries?.length && matchesFilter(filters.countries, context.cc, [])) {
+		reasons.push('country');
+	}
+	if (filters?.languages?.length && matchesFilter(filters.languages, context.lc, [])) {
+		reasons.push('language');
+	}
+	if (
+		filters?.product_types?.length &&
+		matchesFilter(filters.product_types, context.productType, [])
+	) {
+		reasons.push('product_type');
+	}
+
+	if (source.scope === 'moderators' && source.user_in_scope === true) {
+		reasons.push('moderator');
+	} else if (source.scope === 'users' && source.user_in_scope === true) {
+		reasons.push('account');
+	} else if (source.scope == null || source.scope === 'public') {
+		reasons.push('public');
+	}
+
+	return reasons;
+}
+
+function getKnowledgePanels(payload: unknown): KnowledgePanels | undefined {
+	if (!isRecord(payload)) return undefined;
+
+	const candidates = [payload, payload.result, payload.product];
+	for (const candidate of candidates) {
+		if (!isRecord(candidate)) continue;
+		const panels = candidate.knowledge_panels ?? candidate.panels;
+		if (isRecord(panels)) return panels as KnowledgePanels;
+	}
+
+	// Also accept a provider returning the knowledge-panels map directly.
+	const directPanelEntries = Object.entries(payload).filter(([, value]) => isRecord(value));
+	if (
+		directPanelEntries.length > 0 &&
+		directPanelEntries.every(([, value]) => {
+			return (
+				isRecord(value) && ('elements' in value || 'title_element' in value || 'type' in value)
+			);
+		})
+	) {
+		return Object.fromEntries(directPanelEntries) as KnowledgePanels;
+	}
+
+	return undefined;
+}
+
+async function fetchExternalSourcePanels(
+	fetch: typeof window.fetch,
+	source: ExternalSource,
+	context: ExternalSourceProductContext,
+	matchReasons: ExternalSourceMatchReason[]
+): Promise<ExternalKnowledgePanels | null> {
+	const url = expandExternalSourceUrl(source.knowledge_panel_url, context);
+	if (dev) console.debug('[external sources] Fetching provider panels', source.id, url);
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), EXTERNAL_SOURCE_TIMEOUT_MS);
+
+	try {
+		const response = await fetch(url, {
+			headers: { Accept: 'application/json' },
+			signal: controller.signal
+		});
+		if (!response.ok) {
+			throw new Error(`Provider returned ${response.status} ${response.statusText}`);
+		}
+
+		const payload = (await response.json()) as ExternalSourceProductResponse;
+		const knowledgePanels = getKnowledgePanels(payload);
+		if (knowledgePanels == null || Object.keys(knowledgePanels).length === 0) {
+			return null;
+		}
+
+		return {
+			...source,
+			knowledgePanels,
+			matchReasons,
+			productName: typeof payload.name === 'string' ? payload.name : undefined,
+			productImageUrl:
+				typeof payload.product_image_url === 'string' ? payload.product_image_url : undefined
+		};
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+export async function getExternalKnowledgePanels(
+	fetch: typeof window.fetch,
+	context: ExternalSourceProductContext
+): Promise<ExternalKnowledgePanels[]> {
+	const sources = await getExternalSources(fetch);
+	const sourceDiagnostics = sources.map((source) => ({
+		id: source.id,
+		issues: getExternalSourceEligibilityIssues(source, context)
+	}));
+	const eligibleSources = sources.filter((source) => isExternalSourceEligible(source, context));
+	if (dev) {
+		console.debug('[external sources] Sources loaded', {
+			count: sources.length,
+			context,
+			eligible: eligibleSources.map((source) => source.id),
+			rejected: sourceDiagnostics.filter(({ issues }) => issues.length > 0)
+		});
+	}
+	const results = await Promise.allSettled(
+		eligibleSources.map((source) =>
+			fetchExternalSourcePanels(
+				fetch,
+				source,
+				context,
+				getExternalSourceMatchReasons(source, context)
+			)
+		)
+	);
+
+	return results.flatMap((result, index) => {
+		if (result.status === 'fulfilled' && result.value != null) {
+			if (dev)
+				console.debug('[external sources] Provider panels loaded', eligibleSources[index].id);
+			return [result.value];
+		}
+		if (result.status === 'fulfilled' && dev) {
+			console.debug('[external sources] Provider returned no panels', eligibleSources[index].id);
+		}
+		if (result.status === 'rejected') {
+			console.warn(`Failed to fetch external source ${eligibleSources[index].id}`, result.reason);
+		}
+		return [];
+	});
+}
+
+/** Fetch the ordered external source metadata from Product Opener v3. */
+export async function getExternalSources(fetch: typeof window.fetch): Promise<ExternalSource[]> {
+	try {
+		const { data, error } = await createProductsApi(fetch).apiv3.client.GET(
+			'/api/v3/external_sources'
+		);
+		if (error != null || data == null) {
+			console.warn('Failed to fetch external knowledge panel sources', error);
+			return [];
+		}
+
+		const sources = ((data as ExternalSourcesResponse).external_sources ?? []).filter(
+			(source): source is ExternalSource =>
+				typeof source?.id === 'string' &&
+				typeof source?.name === 'string' &&
+				typeof source?.knowledge_panel_url === 'string'
+		);
+		return sources;
+	} catch (error) {
+		console.warn('Failed to fetch external knowledge panel sources', error);
+		return [];
+	}
+}

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -37,9 +37,8 @@ export type ExternalSourceProductContext = {
 
 type ExternalSourceProductResponse = {
 	knowledge_panels?: KnowledgePanels;
+	panels?: KnowledgePanels;
 };
-
-const EXTERNAL_SOURCE_TIMEOUT_MS = 10_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
@@ -150,9 +149,14 @@ export function getExternalSourceMatchReasons(
 function getKnowledgePanels(payload: unknown): KnowledgePanels | undefined {
 	if (!isRecord(payload)) return undefined;
 
-	return isRecord(payload.knowledge_panels)
-		? (payload.knowledge_panels as KnowledgePanels)
-		: undefined;
+	if (isRecord(payload.knowledge_panels)) {
+		return payload.knowledge_panels as KnowledgePanels;
+	}
+	if (isRecord(payload.panels)) {
+		return payload.panels as KnowledgePanels;
+	}
+
+	return undefined;
 }
 
 async function fetchExternalSourcePanels(
@@ -162,30 +166,22 @@ async function fetchExternalSourcePanels(
 ): Promise<ExternalKnowledgePanelResult | null> {
 	const url = expandExternalSourceUrl(source.knowledge_panel_url, context);
 	if (dev) console.debug('[external sources] Fetching provider panels', source.id, url);
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), EXTERNAL_SOURCE_TIMEOUT_MS);
-
-	try {
-		const response = await fetch(url, {
-			headers: { Accept: 'application/json' },
-			signal: controller.signal
-		});
-		if (!response.ok) {
-			throw new Error(`Provider returned ${response.status} ${response.statusText}`);
-		}
-
-		const payload = (await response.json()) as ExternalSourceProductResponse;
-		const knowledgePanels = getKnowledgePanels(payload);
-		if (knowledgePanels == null || Object.keys(knowledgePanels).length === 0) {
-			return null;
-		}
-
-		return {
-			knowledgePanels
-		};
-	} finally {
-		clearTimeout(timeout);
+	const response = await fetch(url, {
+		headers: { Accept: 'application/json' }
+	});
+	if (!response.ok) {
+		throw new Error(`Provider returned ${response.status} ${response.statusText}`);
 	}
+
+	const payload = (await response.json()) as ExternalSourceProductResponse;
+	const knowledgePanels = getKnowledgePanels(payload);
+	if (knowledgePanels == null || Object.keys(knowledgePanels).length === 0) {
+		return null;
+	}
+
+	return {
+		knowledgePanels
+	};
 }
 
 export async function getExternalKnowledgePanelRequests(

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -55,6 +55,8 @@ function matchesFilter(values: string[] | undefined, value: string | undefined, 
  * Expand the template variables documented by the Product Opener API.
  * Values are encoded individually so that a barcode or locale cannot alter
  * the provider URL structure.
+ *
+ * @see https://openfoodfacts.github.io/documentation/docs/Product-Opener/v3/knowledge-panels/get-api-v3-external-sources/
  */
 export function expandExternalSourceUrl(
 	template: string,

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -52,10 +52,6 @@ export type ExternalSourceProductContext = {
 	categories: string[];
 };
 
-type ExternalSourcesResponse = {
-	external_sources?: ExternalSource[];
-};
-
 type ExternalSourceProductResponse = {
 	name?: string;
 	product_image_url?: string;
@@ -67,6 +63,31 @@ type ExternalSourceProductResponse = {
 };
 
 const EXTERNAL_SOURCE_TIMEOUT_MS = 10_000;
+
+function getExternalSourcesResponse(fetch: typeof window.fetch) {
+	return createProductsApi(fetch).apiv3.client.GET('/api/v3/external_sources');
+}
+
+type ExternalSourceApiItem = NonNullable<
+	NonNullable<Awaited<ReturnType<typeof getExternalSourcesResponse>>['data']>['external_sources']
+>[number];
+
+function mapExternalSource(source: ExternalSourceApiItem): ExternalSource {
+	return {
+		id: source.id,
+		name: source.name,
+		description: source.description,
+		icon_url: source.icon_url,
+		knowledge_panel_url: source.knowledge_panel_url,
+		provider_name: source.provider_name,
+		provider_website: source.provider_website,
+		privacy_policy_url: source.privacy_policy_url,
+		section: source.section,
+		scope: source.scope,
+		user_in_scope: source.user_in_scope,
+		filters: source.filters
+	};
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
@@ -294,20 +315,20 @@ export async function getExternalKnowledgePanels(
 /** Fetch the ordered external source metadata from Product Opener v3. */
 export async function getExternalSources(fetch: typeof window.fetch): Promise<ExternalSource[]> {
 	try {
-		const { data, error } = await createProductsApi(fetch).apiv3.client.GET(
-			'/api/v3/external_sources'
-		);
+		const { data, error } = await getExternalSourcesResponse(fetch);
 		if (error != null || data == null) {
 			console.warn('Failed to fetch external knowledge panel sources', error);
 			return [];
 		}
 
-		const sources = ((data as ExternalSourcesResponse).external_sources ?? []).filter(
-			(source): source is ExternalSource =>
-				typeof source?.id === 'string' &&
-				typeof source?.name === 'string' &&
-				typeof source?.knowledge_panel_url === 'string'
-		);
+		const sources = (data?.external_sources ?? [])
+			.map(mapExternalSource)
+			.filter(
+				(source) =>
+					typeof source.id === 'string' &&
+					typeof source.name === 'string' &&
+					typeof source.knowledge_panel_url === 'string'
+			);
 		return sources;
 	} catch (error) {
 		console.warn('Failed to fetch external knowledge panel sources', error);

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -34,6 +34,16 @@ export type ExternalKnowledgePanels = ExternalSource & {
 	productImageUrl?: string;
 };
 
+export type ExternalKnowledgePanelRequest = {
+	source: ExternalSource;
+	matchReasons: ExternalSourceMatchReason[];
+	promise: Promise<ExternalKnowledgePanels | null>;
+};
+
+export type ExternalKnowledgePanelBatch = {
+	requests: ExternalKnowledgePanelRequest[];
+};
+
 export type ExternalSourceProductContext = {
 	code: string;
 	lc: string;
@@ -228,10 +238,10 @@ async function fetchExternalSourcePanels(
 	}
 }
 
-export async function getExternalKnowledgePanels(
+export async function getExternalKnowledgePanelRequests(
 	fetch: typeof window.fetch,
 	context: ExternalSourceProductContext
-): Promise<ExternalKnowledgePanels[]> {
+): Promise<ExternalKnowledgePanelBatch> {
 	const sources = await getExternalSources(fetch);
 	const sourceDiagnostics = sources.map((source) => ({
 		id: source.id,
@@ -246,28 +256,36 @@ export async function getExternalKnowledgePanels(
 			rejected: sourceDiagnostics.filter(({ issues }) => issues.length > 0)
 		});
 	}
-	const results = await Promise.allSettled(
-		eligibleSources.map((source) =>
-			fetchExternalSourcePanels(
-				fetch,
-				source,
-				context,
-				getExternalSourceMatchReasons(source, context)
-			)
-		)
-	);
+	const requests = eligibleSources.map((source) => {
+		const matchReasons = getExternalSourceMatchReasons(source, context);
+		return {
+			source,
+			matchReasons,
+			promise: fetchExternalSourcePanels(fetch, source, context, matchReasons)
+		};
+	});
+
+	return { requests };
+}
+
+export async function getExternalKnowledgePanels(
+	fetch: typeof window.fetch,
+	context: ExternalSourceProductContext
+): Promise<ExternalKnowledgePanels[]> {
+	const { requests } = await getExternalKnowledgePanelRequests(fetch, context);
+	const results = await Promise.allSettled(requests.map(({ promise }) => promise));
 
 	return results.flatMap((result, index) => {
 		if (result.status === 'fulfilled' && result.value != null) {
 			if (dev)
-				console.debug('[external sources] Provider panels loaded', eligibleSources[index].id);
+				console.debug('[external sources] Provider panels loaded', requests[index].source.id);
 			return [result.value];
 		}
 		if (result.status === 'fulfilled' && dev) {
-			console.debug('[external sources] Provider returned no panels', eligibleSources[index].id);
+			console.debug('[external sources] Provider returned no panels', requests[index].source.id);
 		}
 		if (result.status === 'rejected') {
-			console.warn(`Failed to fetch external source ${eligibleSources[index].id}`, result.reason);
+			console.warn(`Failed to fetch external source ${requests[index].source.id}`, result.reason);
 		}
 		return [];
 	});

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -27,17 +27,14 @@ export type ExternalSource = {
 export type ExternalSourceMatchReason =
 	'category' | 'country' | 'language' | 'product_type' | 'public' | 'moderator' | 'account';
 
-export type ExternalKnowledgePanels = ExternalSource & {
+export type ExternalKnowledgePanelResult = {
 	knowledgePanels: KnowledgePanels;
-	matchReasons: ExternalSourceMatchReason[];
-	productName?: string;
-	productImageUrl?: string;
 };
 
 export type ExternalKnowledgePanelRequest = {
 	source: ExternalSource;
 	matchReasons: ExternalSourceMatchReason[];
-	promise: Promise<ExternalKnowledgePanels | null>;
+	promise: Promise<ExternalKnowledgePanelResult | null>;
 };
 
 export type ExternalKnowledgePanelBatch = {
@@ -53,8 +50,6 @@ export type ExternalSourceProductContext = {
 };
 
 type ExternalSourceProductResponse = {
-	name?: string;
-	product_image_url?: string;
 	knowledge_panels?: KnowledgePanels;
 	result?: {
 		knowledge_panels?: KnowledgePanels;
@@ -218,9 +213,8 @@ function getKnowledgePanels(payload: unknown): KnowledgePanels | undefined {
 async function fetchExternalSourcePanels(
 	fetch: typeof window.fetch,
 	source: ExternalSource,
-	context: ExternalSourceProductContext,
-	matchReasons: ExternalSourceMatchReason[]
-): Promise<ExternalKnowledgePanels | null> {
+	context: ExternalSourceProductContext
+): Promise<ExternalKnowledgePanelResult | null> {
 	const url = expandExternalSourceUrl(source.knowledge_panel_url, context);
 	if (dev) console.debug('[external sources] Fetching provider panels', source.id, url);
 	const controller = new AbortController();
@@ -242,12 +236,7 @@ async function fetchExternalSourcePanels(
 		}
 
 		return {
-			...source,
-			knowledgePanels,
-			matchReasons,
-			productName: typeof payload.name === 'string' ? payload.name : undefined,
-			productImageUrl:
-				typeof payload.product_image_url === 'string' ? payload.product_image_url : undefined
+			knowledgePanels
 		};
 	} finally {
 		clearTimeout(timeout);
@@ -277,7 +266,7 @@ export async function getExternalKnowledgePanelRequests(
 		return {
 			source,
 			matchReasons,
-			promise: fetchExternalSourcePanels(fetch, source, context, matchReasons)
+			promise: fetchExternalSourcePanels(fetch, source, context)
 		};
 	});
 
@@ -287,7 +276,7 @@ export async function getExternalKnowledgePanelRequests(
 export async function getExternalKnowledgePanels(
 	fetch: typeof window.fetch,
 	context: ExternalSourceProductContext
-): Promise<ExternalKnowledgePanels[]> {
+): Promise<ExternalKnowledgePanelResult[]> {
 	const { requests } = await getExternalKnowledgePanelRequests(fetch, context);
 	const results = await Promise.allSettled(requests.map(({ promise }) => promise));
 

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -51,10 +51,6 @@ export type ExternalSourceProductContext = {
 
 type ExternalSourceProductResponse = {
 	knowledge_panels?: KnowledgePanels;
-	result?: {
-		knowledge_panels?: KnowledgePanels;
-	};
-	panels?: KnowledgePanels;
 };
 
 const EXTERNAL_SOURCE_TIMEOUT_MS = 10_000;
@@ -192,22 +188,9 @@ export function getExternalSourceMatchReasons(
 function getKnowledgePanels(payload: unknown): KnowledgePanels | undefined {
 	if (!isRecord(payload)) return undefined;
 
-	const candidates = [payload, payload.result, payload.product];
-	for (const candidate of candidates) {
-		if (!isRecord(candidate)) continue;
-		const panels = candidate.knowledge_panels ?? candidate.panels;
-		if (isRecord(panels)) return panels as KnowledgePanels;
-	}
-
-	// Also accept a provider returning the knowledge-panels map directly.
-	const directPanelEntries = Object.entries(payload).filter(([, value]) => {
-		return isRecord(value) && ('elements' in value || 'title_element' in value || 'type' in value);
-	});
-	if (directPanelEntries.length > 0) {
-		return Object.fromEntries(directPanelEntries) as KnowledgePanels;
-	}
-
-	return undefined;
+	return isRecord(payload.knowledge_panels)
+		? (payload.knowledge_panels as KnowledgePanels)
+		: undefined;
 }
 
 async function fetchExternalSourcePanels(

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -45,10 +45,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
 }
 
-function matchesFilter(values: string[] | undefined, value: string | undefined, list: string[]) {
-	if (values == null || values.length === 0) return true;
-	if (value != null && values.includes(value)) return true;
-	return list.some((item) => values.includes(item));
+function matchesFilter(
+	allowedValues: readonly string[] | undefined,
+	contextValue: string | readonly string[] | undefined
+) {
+	if (allowedValues == null || allowedValues.length === 0) return true;
+	if (contextValue == null) return false;
+
+	const contextValues = Array.isArray(contextValue) ? contextValue : [contextValue];
+	return contextValues.some((value) => allowedValues.includes(value));
 }
 
 /**
@@ -95,16 +100,16 @@ export function getExternalSourceEligibilityIssues(
 	const filters = source.filters;
 	if (filters == null) return issues;
 
-	if (!matchesFilter(filters.categories, undefined, context.categories)) {
+	if (!matchesFilter(filters.categories, context.categories)) {
 		issues.push('categories');
 	}
-	if (!matchesFilter(filters.countries, context.cc, [])) {
+	if (!matchesFilter(filters.countries, context.cc)) {
 		issues.push(`country:${context.cc}`);
 	}
-	if (!matchesFilter(filters.languages, context.lc, [])) {
+	if (!matchesFilter(filters.languages, context.lc)) {
 		issues.push(`language:${context.lc}`);
 	}
-	if (!matchesFilter(filters.product_types, context.productType, [])) {
+	if (!matchesFilter(filters.product_types, context.productType)) {
 		issues.push(`product_type:${context.productType ?? 'unknown'}`);
 	}
 
@@ -118,22 +123,16 @@ export function getExternalSourceMatchReasons(
 	const reasons: ExternalSourceMatchReason[] = [];
 	const filters = source.filters;
 
-	if (
-		filters?.categories?.length &&
-		matchesFilter(filters.categories, undefined, context.categories)
-	) {
+	if (filters?.categories?.length && matchesFilter(filters.categories, context.categories)) {
 		reasons.push('category');
 	}
-	if (filters?.countries?.length && matchesFilter(filters.countries, context.cc, [])) {
+	if (filters?.countries?.length && matchesFilter(filters.countries, context.cc)) {
 		reasons.push('country');
 	}
-	if (filters?.languages?.length && matchesFilter(filters.languages, context.lc, [])) {
+	if (filters?.languages?.length && matchesFilter(filters.languages, context.lc)) {
 		reasons.push('language');
 	}
-	if (
-		filters?.product_types?.length &&
-		matchesFilter(filters.product_types, context.productType, [])
-	) {
+	if (filters?.product_types?.length && matchesFilter(filters.product_types, context.productType)) {
 		reasons.push('product_type');
 	}
 

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -205,15 +205,10 @@ function getKnowledgePanels(payload: unknown): KnowledgePanels | undefined {
 	}
 
 	// Also accept a provider returning the knowledge-panels map directly.
-	const directPanelEntries = Object.entries(payload).filter(([, value]) => isRecord(value));
-	if (
-		directPanelEntries.length > 0 &&
-		directPanelEntries.every(([, value]) => {
-			return (
-				isRecord(value) && ('elements' in value || 'title_element' in value || 'type' in value)
-			);
-		})
-	) {
+	const directPanelEntries = Object.entries(payload).filter(([, value]) => {
+		return isRecord(value) && ('elements' in value || 'title_element' in value || 'type' in value);
+	});
+	if (directPanelEntries.length > 0) {
 		return Object.fromEntries(directPanelEntries) as KnowledgePanels;
 	}
 

--- a/src/lib/api/externalSources.ts
+++ b/src/lib/api/externalSources.ts
@@ -2,27 +2,13 @@ import type { KnowledgePanels } from './knowledgepanels';
 import { createProductsApi } from './product';
 import { dev } from '$app/environment';
 
-export type ExternalSourceFilters = {
-	categories?: string[];
-	countries?: string[];
-	languages?: string[];
-	product_types?: string[];
-};
+function getExternalSourcesResponse(fetch: typeof window.fetch) {
+	return createProductsApi(fetch).apiv3.client.GET('/api/v3/external_sources');
+}
 
-export type ExternalSource = {
-	id: string;
-	name: string;
-	description?: string;
-	icon_url?: string;
-	knowledge_panel_url: string;
-	provider_name?: string;
-	provider_website?: string;
-	privacy_policy_url?: string;
-	section?: string;
-	scope?: 'public' | 'users' | 'moderators' | string;
-	user_in_scope?: boolean;
-	filters?: ExternalSourceFilters;
-};
+export type ExternalSource = NonNullable<
+	NonNullable<Awaited<ReturnType<typeof getExternalSourcesResponse>>['data']>['external_sources']
+>[number];
 
 export type ExternalSourceMatchReason =
 	'category' | 'country' | 'language' | 'product_type' | 'public' | 'moderator' | 'account';
@@ -54,31 +40,6 @@ type ExternalSourceProductResponse = {
 };
 
 const EXTERNAL_SOURCE_TIMEOUT_MS = 10_000;
-
-function getExternalSourcesResponse(fetch: typeof window.fetch) {
-	return createProductsApi(fetch).apiv3.client.GET('/api/v3/external_sources');
-}
-
-type ExternalSourceApiItem = NonNullable<
-	NonNullable<Awaited<ReturnType<typeof getExternalSourcesResponse>>['data']>['external_sources']
->[number];
-
-function mapExternalSource(source: ExternalSourceApiItem): ExternalSource {
-	return {
-		id: source.id,
-		name: source.name,
-		description: source.description,
-		icon_url: source.icon_url,
-		knowledge_panel_url: source.knowledge_panel_url,
-		provider_name: source.provider_name,
-		provider_website: source.provider_website,
-		privacy_policy_url: source.privacy_policy_url,
-		section: source.section,
-		scope: source.scope,
-		user_in_scope: source.user_in_scope,
-		filters: source.filters
-	};
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
@@ -288,14 +249,7 @@ export async function getExternalSources(fetch: typeof window.fetch): Promise<Ex
 			return [];
 		}
 
-		const sources = (data?.external_sources ?? [])
-			.map(mapExternalSource)
-			.filter(
-				(source) =>
-					typeof source.id === 'string' &&
-					typeof source.name === 'string' &&
-					typeof source.knowledge_panel_url === 'string'
-			);
+		const sources = data?.external_sources ?? [];
 		return sources;
 	} catch (error) {
 		console.warn('Failed to fetch external knowledge panel sources', error);

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -520,7 +520,8 @@
 				"moderator_tools": "Moderator Tools",
 				"packaging": "Packaging",
 				"prices": "Prices",
-				"comment": "Comment"
+			"comment": "Comment",
+			"external_sources": "External sources"
 			},
 			"more_details": "More details",
 			"more_details_subsections": {
@@ -615,6 +616,20 @@
 				"add_ingredients_image": "Add a photo of the ingredients",
 				"add_nutrition_facts": "Add nutrition facts"
 			}
+		},
+		"external_sources": {
+			"title": "External sources",
+			"description": "Additional information provided by organizations outside Open Food Facts.",
+			"source_label": "External source",
+			"reason_category": "Category match",
+			"reason_country": "Country match",
+			"reason_language": "Language match",
+			"reason_product_type": "Product type match",
+			"reason_public": "Public source",
+			"reason_moderator": "Moderator access",
+			"reason_account": "Account access",
+			"provider_website": "Provider website",
+			"privacy_policy": "Privacy policy"
 		},
 		"moderator": {
 			"barcode_correction_title": "Correct Barcode",

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -307,7 +307,8 @@
 			"knowledge_panels": "Analysis & Insights",
 			"datasources": "Data Sources",
 			"prices": "Prices",
-			"folksonomy": "Tags & Community"
+			"folksonomy": "Tags & Community",
+			"external_sources": "External sources"
 		},
 		"gs1": {
 			"title": "GS1 barcode information",
@@ -520,8 +521,7 @@
 				"moderator_tools": "Moderator Tools",
 				"packaging": "Packaging",
 				"prices": "Prices",
-			"comment": "Comment",
-			"external_sources": "External sources"
+				"comment": "Comment"
 			},
 			"more_details": "More details",
 			"more_details_subsections": {

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -620,6 +620,8 @@
 		"external_sources": {
 			"title": "External sources",
 			"description": "Additional information provided by organizations outside Open Food Facts.",
+			"loading": "Loading external sources…",
+			"error": "External sources could not be loaded.",
 			"source_label": "External source",
 			"reason_category": "Category match",
 			"reason_country": "Country match",

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -603,6 +603,8 @@
 		"external_sources": {
 			"title": "External sources",
 			"description": "Additional information provided by organizations outside Open Food Facts.",
+			"loading": "Loading external sources…",
+			"error": "External sources could not be loaded.",
 			"source_label": "External source",
 			"reason_category": "Category match",
 			"reason_country": "Country match",

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -307,7 +307,8 @@
 			"knowledge_panels": "Analysis & Insights",
 			"datasources": "Data Sources",
 			"prices": "Prices",
-			"folksonomy": "Tags & Community"
+			"folksonomy": "Tags & Community",
+			"external_sources": "External sources"
 		},
 		"edit": {
 			"sidebar_navigation": "Product edit sections",
@@ -598,6 +599,20 @@
 				"add_ingredients_image": "Add a photo of the ingredients",
 				"add_nutrition_facts": "Add nutrition facts"
 			}
+		},
+		"external_sources": {
+			"title": "External sources",
+			"description": "Additional information provided by organizations outside Open Food Facts.",
+			"source_label": "External source",
+			"reason_category": "Category match",
+			"reason_country": "Country match",
+			"reason_language": "Language match",
+			"reason_product_type": "Product type match",
+			"reason_public": "Public source",
+			"reason_moderator": "Moderator access",
+			"reason_account": "Account access",
+			"provider_website": "Provider website",
+			"privacy_policy": "Privacy policy"
 		},
 		"moderator": {
 			"barcode_correction_title": "Correct Barcode",

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -9,6 +9,7 @@
 	import IconMdiAccountCheck from '@iconify-svelte/mdi/account-check';
 	import IconMdiChevronDown from '@iconify-svelte/mdi/chevron-down';
 	import IconMdiEarth from '@iconify-svelte/mdi/earth';
+	import IconMdiOpenInNew from '@iconify-svelte/mdi/open-in-new';
 	import IconMdiPackageVariantClosed from '@iconify-svelte/mdi/package-variant-closed';
 	import IconMdiShieldAccount from '@iconify-svelte/mdi/shield-account';
 	import IconMdiTagOutline from '@iconify-svelte/mdi/tag-outline';
@@ -159,33 +160,37 @@
 						</span>
 					</div>
 				{:else if panels != null}
-					<div class="mb-4 flex flex-wrap gap-x-4 gap-y-2 text-sm">
-						{#if source.provider_website}
-							<a
-								href={source.provider_website}
-								target="_blank"
-								rel="noopener"
-								class="link link-hover"
-							>
-								{$_('product.external_sources.provider_website', {
-									default: 'Provider website'
-								})}
-							</a>
-						{/if}
-						{#if source.privacy_policy_url}
-							<a
-								href={source.privacy_policy_url}
-								target="_blank"
-								rel="noopener"
-								class="link link-hover"
-							>
-								{$_('product.external_sources.privacy_policy', {
-									default: 'Privacy policy'
-								})}
-							</a>
-						{/if}
-					</div>
 					<Panels panels={panels.knowledgePanels} summary={false} />
+					{#if source.provider_website || source.privacy_policy_url}
+						<div class="mt-6 flex flex-wrap gap-2 border-t border-base-300 pt-4">
+							{#if source.provider_website}
+								<a
+									href={source.provider_website}
+									target="_blank"
+									rel="noopener"
+									class="badge gap-1 border-base-300 bg-base-100 text-base-content/70 hover:bg-base-200"
+								>
+									{$_('product.external_sources.provider_website', {
+										default: 'Provider website'
+									})}
+									<IconMdiOpenInNew class="h-3.5 w-3.5" aria-hidden="true" />
+								</a>
+							{/if}
+							{#if source.privacy_policy_url}
+								<a
+									href={source.privacy_policy_url}
+									target="_blank"
+									rel="noopener"
+									class="badge gap-1 border-base-300 bg-base-100 text-base-content/70 hover:bg-base-200"
+								>
+									{$_('product.external_sources.privacy_policy', {
+										default: 'Privacy policy'
+									})}
+									<IconMdiOpenInNew class="h-3.5 w-3.5" aria-hidden="true" />
+								</a>
+							{/if}
+						</div>
+					{/if}
 				{/if}
 			{/if}
 		</div>

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -83,7 +83,7 @@
 )}
 	{@const source = request.source}
 	{@const panelId = `external-source-panel-${encodeURIComponent(source.id)}`}
-	<article
+	<div
 		class="overflow-hidden rounded-box border border-base-300 bg-base-100 shadow-md dark:bg-base-200"
 	>
 		<header class="border-b border-base-300 bg-base-200">
@@ -194,7 +194,7 @@
 				{/if}
 			{/if}
 		</div>
-	</article>
+	</div>
 {/snippet}
 
 <section aria-labelledby="external-sources-title">

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -96,7 +96,7 @@
 			{@const panelId = `external-source-panel-${source.id}`}
 			{#if requestStatuses[source.id] !== 'empty'}
 				<article
-					class="overflow-hidden rounded-box border border-base-300 bg-white shadow-md dark:bg-base-200"
+					class="overflow-hidden rounded-box border border-base-300 bg-base-100 shadow-md dark:bg-base-200"
 				>
 					<header class="border-b border-base-300 bg-base-200">
 						<button

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+	import { _ } from '$lib/i18n';
+	import type {
+		ExternalKnowledgePanels,
+		ExternalSourceMatchReason
+	} from '$lib/api/externalSources';
+	import IconMdiAccountCheck from '@iconify-svelte/mdi/account-check';
+	import IconMdiChevronDown from '@iconify-svelte/mdi/chevron-down';
+	import IconMdiEarth from '@iconify-svelte/mdi/earth';
+	import IconMdiPackageVariantClosed from '@iconify-svelte/mdi/package-variant-closed';
+	import IconMdiShieldAccount from '@iconify-svelte/mdi/shield-account';
+	import IconMdiTagOutline from '@iconify-svelte/mdi/tag-outline';
+	import IconMdiTranslate from '@iconify-svelte/mdi/translate';
+	import Panels from './Panels.svelte';
+
+	type Props = {
+		panels: ExternalKnowledgePanels[];
+	};
+
+	let { panels }: Props = $props();
+	let expandedSources = $state<Record<string, boolean>>({});
+
+	function isExpanded(sourceId: string) {
+		return expandedSources[sourceId] === true;
+	}
+
+	function toggleSource(sourceId: string) {
+		expandedSources[sourceId] = !isExpanded(sourceId);
+	}
+
+	function reasonLabel(reason: ExternalSourceMatchReason): string {
+		const labels: Record<ExternalSourceMatchReason, string> = {
+			category: $_('product.external_sources.reason_category', { default: 'Category match' }),
+			country: $_('product.external_sources.reason_country', { default: 'Country match' }),
+			language: $_('product.external_sources.reason_language', { default: 'Language match' }),
+			product_type: $_('product.external_sources.reason_product_type', {
+				default: 'Product type match'
+			}),
+			public: $_('product.external_sources.reason_public', { default: 'Public source' }),
+			moderator: $_('product.external_sources.reason_moderator', {
+				default: 'Moderator access'
+			}),
+			account: $_('product.external_sources.reason_account', { default: 'Account access' })
+		};
+		return labels[reason];
+	}
+</script>
+
+<section aria-labelledby="external-sources-title">
+	<h2 id="external-sources-title" class="text-3xl font-bold">
+		{$_('product.external_sources.title', { default: 'External sources' })}
+	</h2>
+	<p class="mt-2 text-base-content/70">
+		{$_('product.external_sources.description', {
+			default: 'Additional information provided by organizations outside Open Food Facts.'
+		})}
+	</p>
+
+	<div class="mt-6 space-y-6">
+		{#each panels as source (source.id)}
+			{@const panelId = `external-source-panel-${source.id}`}
+			<article
+				class="overflow-hidden rounded-box border border-base-300 bg-white shadow-md dark:bg-base-200"
+			>
+				<header class="border-b border-base-300 bg-base-200">
+					<button
+						type="button"
+						class="flex w-full cursor-pointer items-start gap-4 p-4 text-left hover:bg-base-300/50 sm:p-6"
+						aria-expanded={isExpanded(source.id)}
+						aria-controls={panelId}
+						onclick={() => toggleSource(source.id)}
+					>
+						{#if source.icon_url}
+							<div
+								class="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-base-100 p-2"
+							>
+								<img class="h-full w-full object-contain" src={source.icon_url} alt="" />
+							</div>
+						{/if}
+						<div class="min-w-0 grow">
+							<p class="text-xs font-semibold tracking-widest text-secondary uppercase">
+								{$_('product.external_sources.source_label', { default: 'External source' })}
+							</p>
+							<h3 class="text-2xl font-bold">{source.name}</h3>
+							{#if source.provider_name && source.provider_name !== source.name}
+								<p class="text-sm text-base-content/70">{source.provider_name}</p>
+							{/if}
+							{#if source.description}
+								<p class="mt-2">{source.description}</p>
+							{/if}
+							{#if source.matchReasons?.length}
+								<div class="mt-3 flex flex-wrap gap-2">
+									{#each source.matchReasons as reason (reason)}
+										<span
+											class="badge gap-1 border-base-300 bg-base-100/70 badge-sm text-base-content/70"
+											title={reasonLabel(reason)}
+										>
+											{#if reason === 'category'}
+												<IconMdiTagOutline class="h-3.5 w-3.5" aria-hidden="true" />
+											{:else if reason === 'country'}
+												<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
+											{:else if reason === 'language'}
+												<IconMdiTranslate class="h-3.5 w-3.5" aria-hidden="true" />
+											{:else if reason === 'product_type'}
+												<IconMdiPackageVariantClosed class="h-3.5 w-3.5" aria-hidden="true" />
+											{:else if reason === 'moderator'}
+												<IconMdiShieldAccount class="h-3.5 w-3.5" aria-hidden="true" />
+											{:else if reason === 'account'}
+												<IconMdiAccountCheck class="h-3.5 w-3.5" aria-hidden="true" />
+											{:else}
+												<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
+											{/if}
+											<span>{reasonLabel(reason)}</span>
+										</span>
+									{/each}
+								</div>
+							{/if}
+						</div>
+						<IconMdiChevronDown
+							class={[
+								'mt-1 h-6 w-6 shrink-0 transition-transform',
+								isExpanded(source.id) && 'rotate-180'
+							]}
+							aria-hidden="true"
+						/>
+					</button>
+				</header>
+
+				{#if isExpanded(source.id)}
+					<div id={panelId} class="p-4 sm:p-6">
+						<div class="mb-4 flex flex-wrap gap-x-4 gap-y-2 text-sm">
+							{#if source.provider_website}
+								<a
+									href={source.provider_website}
+									target="_blank"
+									rel="noopener"
+									class="link link-hover"
+								>
+									{$_('product.external_sources.provider_website', {
+										default: 'Provider website'
+									})}
+								</a>
+							{/if}
+							{#if source.privacy_policy_url}
+								<a
+									href={source.privacy_policy_url}
+									target="_blank"
+									rel="noopener"
+									class="link link-hover"
+								>
+									{$_('product.external_sources.privacy_policy', {
+										default: 'Privacy policy'
+									})}
+								</a>
+							{/if}
+						</div>
+						<Panels panels={source.knowledgePanels} summary={false} />
+					</div>
+				{/if}
+			</article>
+		{/each}
+	</div>
+</section>

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -93,7 +93,7 @@
 	<div class="mt-6 space-y-6">
 		{#each requests as request (request.source.id)}
 			{@const source = request.source}
-			{@const panelId = `external-source-panel-${source.id}`}
+			{@const panelId = `external-source-panel-${encodeURIComponent(source.id)}`}
 			{#if requestStatuses[source.id] !== 'empty'}
 				<article
 					class="overflow-hidden rounded-box border border-base-300 bg-base-100 shadow-md dark:bg-base-200"
@@ -166,8 +166,8 @@
 						</button>
 					</header>
 
-					{#if isExpanded(source.id)}
-						<div id={panelId} class="p-4 sm:p-6">
+					<div id={panelId} class="p-4 sm:p-6" hidden={!isExpanded(source.id)}>
+						{#if isExpanded(source.id)}
 							{#await request.promise}
 								<div class="space-y-3 py-2" aria-busy="true">
 									<div class="h-4 w-1/3 skeleton"></div>
@@ -214,8 +214,8 @@
 									</span>
 								</div>
 							{/await}
-						</div>
-					{/if}
+						{/if}
+					</div>
 				</article>
 			{/if}
 		{/each}

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { _ } from '$lib/i18n';
 	import type {
+		ExternalKnowledgePanelResult,
 		ExternalKnowledgePanelRequest,
 		ExternalSourceMatchReason
 	} from '$lib/api/externalSources';
@@ -19,40 +20,6 @@
 
 	let { requests }: Props = $props();
 	let expandedSources = $state<Record<string, boolean>>({});
-	type RequestStatus = 'pending' | 'fulfilled' | 'empty' | 'rejected';
-	let requestStatuses = $state<Record<string, RequestStatus>>({});
-
-	$effect(() => {
-		let cancelled = false;
-		requestStatuses = Object.fromEntries(
-			requests.map((request) => [request.source.id, 'pending' as RequestStatus])
-		);
-
-		for (const request of requests) {
-			request.promise.then(
-				(panel) => {
-					if (!cancelled) {
-						requestStatuses = {
-							...requestStatuses,
-							[request.source.id]: panel == null ? 'empty' : 'fulfilled'
-						};
-					}
-				},
-				() => {
-					if (!cancelled) {
-						requestStatuses = {
-							...requestStatuses,
-							[request.source.id]: 'rejected'
-						};
-					}
-				}
-			);
-		}
-
-		return () => {
-			cancelled = true;
-		};
-	});
 
 	function isExpanded(sourceId: string) {
 		return expandedSources[sourceId] === true;
@@ -80,6 +47,135 @@
 	}
 </script>
 
+{#snippet sourceCard(
+	request: ExternalKnowledgePanelRequest,
+	state: 'loading' | 'ready' | 'error',
+	panels: ExternalKnowledgePanelResult | null
+)}
+	{@const source = request.source}
+	{@const panelId = `external-source-panel-${encodeURIComponent(source.id)}`}
+	<article
+		class="overflow-hidden rounded-box border border-base-300 bg-base-100 shadow-md dark:bg-base-200"
+	>
+		<header class="border-b border-base-300 bg-base-200">
+			<button
+				type="button"
+				class="flex w-full cursor-pointer items-start gap-4 p-4 text-left hover:bg-base-300/50 sm:p-6"
+				aria-expanded={isExpanded(source.id)}
+				aria-controls={panelId}
+				onclick={() => toggleSource(source.id)}
+			>
+				{#if source.icon_url}
+					<div
+						class="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-base-100 p-2"
+					>
+						<img class="h-full w-full object-contain" src={source.icon_url} alt="" />
+					</div>
+				{/if}
+				<div class="min-w-0 grow">
+					<p class="text-xs font-semibold tracking-widest text-secondary uppercase">
+						{$_('product.external_sources.source_label', { default: 'External source' })}
+					</p>
+					<h3 class="text-2xl font-bold">{source.name}</h3>
+					{#if source.provider_name && source.provider_name !== source.name}
+						<p class="text-sm text-base-content/70">{source.provider_name}</p>
+					{/if}
+					{#if source.description}
+						<p class="mt-2">{source.description}</p>
+					{/if}
+					{#if request.matchReasons?.length}
+						<div class="mt-3 flex flex-wrap gap-2">
+							{#each request.matchReasons as reason (reason)}
+								<span
+									class="badge gap-1 border-base-300 bg-base-100/70 badge-sm text-base-content/70"
+									title={reasonLabel(reason)}
+								>
+									{#if reason === 'category'}
+										<IconMdiTagOutline class="h-3.5 w-3.5" aria-hidden="true" />
+									{:else if reason === 'country'}
+										<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
+									{:else if reason === 'language'}
+										<IconMdiTranslate class="h-3.5 w-3.5" aria-hidden="true" />
+									{:else if reason === 'product_type'}
+										<IconMdiPackageVariantClosed class="h-3.5 w-3.5" aria-hidden="true" />
+									{:else if reason === 'moderator'}
+										<IconMdiShieldAccount class="h-3.5 w-3.5" aria-hidden="true" />
+									{:else if reason === 'account'}
+										<IconMdiAccountCheck class="h-3.5 w-3.5" aria-hidden="true" />
+									{:else}
+										<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
+									{/if}
+									<span>{reasonLabel(reason)}</span>
+								</span>
+							{/each}
+						</div>
+					{/if}
+				</div>
+				{#if state === 'loading'}
+					<span class="loading mt-1 loading-sm shrink-0 loading-spinner"></span>
+				{:else}
+					<IconMdiChevronDown
+						class={[
+							'mt-1 h-6 w-6 shrink-0 transition-transform',
+							isExpanded(source.id) && 'rotate-180'
+						]}
+						aria-hidden="true"
+					/>
+				{/if}
+			</button>
+		</header>
+
+		<div id={panelId} class="p-4 sm:p-6" hidden={!isExpanded(source.id)}>
+			{#if isExpanded(source.id)}
+				{#if state === 'loading'}
+					<div class="space-y-3 py-2" aria-busy="true">
+						<div class="h-4 w-1/3 skeleton"></div>
+						<div class="h-4 w-full skeleton"></div>
+						<div class="h-4 w-5/6 skeleton"></div>
+					</div>
+				{:else if state === 'error'}
+					<div class="alert alert-warning">
+						<IconMdiEarth class="h-6 w-6 shrink-0" />
+						<span>
+							{$_('product.external_sources.error', {
+								default: 'External sources could not be loaded.'
+							})}
+						</span>
+					</div>
+				{:else if panels != null}
+					<div class="mb-4 flex flex-wrap gap-x-4 gap-y-2 text-sm">
+						{#if source.provider_website}
+							<a
+								href={source.provider_website}
+								target="_blank"
+								rel="noopener"
+								class="link link-hover"
+							>
+								{$_('product.external_sources.provider_website', {
+									default: 'Provider website'
+								})}
+							</a>
+						{/if}
+						{#if source.privacy_policy_url}
+							<a
+								href={source.privacy_policy_url}
+								target="_blank"
+								rel="noopener"
+								class="link link-hover"
+							>
+								{$_('product.external_sources.privacy_policy', {
+									default: 'Privacy policy'
+								})}
+							</a>
+						{/if}
+					</div>
+					<Panels panels={panels.knowledgePanels} summary={false} />
+				{/if}
+			{/if}
+		</div>
+	</article>
+{/snippet}
+
 <section aria-labelledby="external-sources-title">
 	<h2 id="external-sources-title" class="text-3xl font-bold">
 		{$_('product.external_sources.title', { default: 'External sources' })}
@@ -92,132 +188,15 @@
 
 	<div class="mt-6 space-y-6">
 		{#each requests as request (request.source.id)}
-			{@const source = request.source}
-			{@const panelId = `external-source-panel-${encodeURIComponent(source.id)}`}
-			{#if requestStatuses[source.id] !== 'empty'}
-				<article
-					class="overflow-hidden rounded-box border border-base-300 bg-base-100 shadow-md dark:bg-base-200"
-				>
-					<header class="border-b border-base-300 bg-base-200">
-						<button
-							type="button"
-							class="flex w-full cursor-pointer items-start gap-4 p-4 text-left hover:bg-base-300/50 sm:p-6"
-							aria-expanded={isExpanded(source.id)}
-							aria-controls={panelId}
-							onclick={() => toggleSource(source.id)}
-						>
-							{#if source.icon_url}
-								<div
-									class="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-base-100 p-2"
-								>
-									<img class="h-full w-full object-contain" src={source.icon_url} alt="" />
-								</div>
-							{/if}
-							<div class="min-w-0 grow">
-								<p class="text-xs font-semibold tracking-widest text-secondary uppercase">
-									{$_('product.external_sources.source_label', { default: 'External source' })}
-								</p>
-								<h3 class="text-2xl font-bold">{source.name}</h3>
-								{#if source.provider_name && source.provider_name !== source.name}
-									<p class="text-sm text-base-content/70">{source.provider_name}</p>
-								{/if}
-								{#if source.description}
-									<p class="mt-2">{source.description}</p>
-								{/if}
-								{#if request.matchReasons?.length}
-									<div class="mt-3 flex flex-wrap gap-2">
-										{#each request.matchReasons as reason (reason)}
-											<span
-												class="badge gap-1 border-base-300 bg-base-100/70 badge-sm text-base-content/70"
-												title={reasonLabel(reason)}
-											>
-												{#if reason === 'category'}
-													<IconMdiTagOutline class="h-3.5 w-3.5" aria-hidden="true" />
-												{:else if reason === 'country'}
-													<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
-												{:else if reason === 'language'}
-													<IconMdiTranslate class="h-3.5 w-3.5" aria-hidden="true" />
-												{:else if reason === 'product_type'}
-													<IconMdiPackageVariantClosed class="h-3.5 w-3.5" aria-hidden="true" />
-												{:else if reason === 'moderator'}
-													<IconMdiShieldAccount class="h-3.5 w-3.5" aria-hidden="true" />
-												{:else if reason === 'account'}
-													<IconMdiAccountCheck class="h-3.5 w-3.5" aria-hidden="true" />
-												{:else}
-													<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
-												{/if}
-												<span>{reasonLabel(reason)}</span>
-											</span>
-										{/each}
-									</div>
-								{/if}
-							</div>
-							{#if requestStatuses[source.id] === 'pending'}
-								<span class="loading mt-1 loading-sm shrink-0 loading-spinner"></span>
-							{:else}
-								<IconMdiChevronDown
-									class={[
-										'mt-1 h-6 w-6 shrink-0 transition-transform',
-										isExpanded(source.id) && 'rotate-180'
-									]}
-									aria-hidden="true"
-								/>
-							{/if}
-						</button>
-					</header>
-
-					<div id={panelId} class="p-4 sm:p-6" hidden={!isExpanded(source.id)}>
-						{#if isExpanded(source.id)}
-							{#await request.promise}
-								<div class="space-y-3 py-2" aria-busy="true">
-									<div class="h-4 w-1/3 skeleton"></div>
-									<div class="h-4 w-full skeleton"></div>
-									<div class="h-4 w-5/6 skeleton"></div>
-								</div>
-							{:then panels}
-								{#if panels != null}
-									<div class="mb-4 flex flex-wrap gap-x-4 gap-y-2 text-sm">
-										{#if source.provider_website}
-											<a
-												href={source.provider_website}
-												target="_blank"
-												rel="noopener"
-												class="link link-hover"
-											>
-												{$_('product.external_sources.provider_website', {
-													default: 'Provider website'
-												})}
-											</a>
-										{/if}
-										{#if source.privacy_policy_url}
-											<a
-												href={source.privacy_policy_url}
-												target="_blank"
-												rel="noopener"
-												class="link link-hover"
-											>
-												{$_('product.external_sources.privacy_policy', {
-													default: 'Privacy policy'
-												})}
-											</a>
-										{/if}
-									</div>
-									<Panels panels={panels.knowledgePanels} summary={false} />
-								{/if}
-							{:catch}
-								<div class="alert alert-warning">
-									<IconMdiEarth class="h-6 w-6 shrink-0" />
-									<span>
-										{$_('product.external_sources.error', {
-											default: 'External sources could not be loaded.'
-										})}
-									</span>
-								</div>
-							{/await}
-						{/if}
-					</div>
-				</article>
-			{/if}
+			{#await request.promise}
+				{@render sourceCard(request, 'loading', null)}
+			{:then panels}
+				{#if panels != null}
+					{@render sourceCard(request, 'ready', panels)}
+				{/if}
+			{:catch}
+				{@render sourceCard(request, 'error', null)}
+			{/await}
 		{/each}
 	</div>
 </section>

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { _ } from '$lib/i18n';
 	import type {
-		ExternalKnowledgePanels,
+		ExternalKnowledgePanelRequest,
 		ExternalSourceMatchReason
 	} from '$lib/api/externalSources';
 	import IconMdiAccountCheck from '@iconify-svelte/mdi/account-check';
@@ -14,11 +14,45 @@
 	import Panels from './Panels.svelte';
 
 	type Props = {
-		panels: ExternalKnowledgePanels[];
+		requests: ExternalKnowledgePanelRequest[];
 	};
 
-	let { panels }: Props = $props();
+	let { requests }: Props = $props();
 	let expandedSources = $state<Record<string, boolean>>({});
+	type RequestStatus = 'pending' | 'fulfilled' | 'empty' | 'rejected';
+	let requestStatuses = $state<Record<string, RequestStatus>>({});
+
+	$effect(() => {
+		let cancelled = false;
+		requestStatuses = Object.fromEntries(
+			requests.map((request) => [request.source.id, 'pending' as RequestStatus])
+		);
+
+		for (const request of requests) {
+			request.promise.then(
+				(panel) => {
+					if (!cancelled) {
+						requestStatuses = {
+							...requestStatuses,
+							[request.source.id]: panel == null ? 'empty' : 'fulfilled'
+						};
+					}
+				},
+				() => {
+					if (!cancelled) {
+						requestStatuses = {
+							...requestStatuses,
+							[request.source.id]: 'rejected'
+						};
+					}
+				}
+			);
+		}
+
+		return () => {
+			cancelled = true;
+		};
+	});
 
 	function isExpanded(sourceId: string) {
 		return expandedSources[sourceId] === true;
@@ -57,107 +91,133 @@
 	</p>
 
 	<div class="mt-6 space-y-6">
-		{#each panels as source (source.id)}
+		{#each requests as request (request.source.id)}
+			{@const source = request.source}
 			{@const panelId = `external-source-panel-${source.id}`}
-			<article
-				class="overflow-hidden rounded-box border border-base-300 bg-white shadow-md dark:bg-base-200"
-			>
-				<header class="border-b border-base-300 bg-base-200">
-					<button
-						type="button"
-						class="flex w-full cursor-pointer items-start gap-4 p-4 text-left hover:bg-base-300/50 sm:p-6"
-						aria-expanded={isExpanded(source.id)}
-						aria-controls={panelId}
-						onclick={() => toggleSource(source.id)}
-					>
-						{#if source.icon_url}
-							<div
-								class="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-base-100 p-2"
-							>
-								<img class="h-full w-full object-contain" src={source.icon_url} alt="" />
-							</div>
-						{/if}
-						<div class="min-w-0 grow">
-							<p class="text-xs font-semibold tracking-widest text-secondary uppercase">
-								{$_('product.external_sources.source_label', { default: 'External source' })}
-							</p>
-							<h3 class="text-2xl font-bold">{source.name}</h3>
-							{#if source.provider_name && source.provider_name !== source.name}
-								<p class="text-sm text-base-content/70">{source.provider_name}</p>
-							{/if}
-							{#if source.description}
-								<p class="mt-2">{source.description}</p>
-							{/if}
-							{#if source.matchReasons?.length}
-								<div class="mt-3 flex flex-wrap gap-2">
-									{#each source.matchReasons as reason (reason)}
-										<span
-											class="badge gap-1 border-base-300 bg-base-100/70 badge-sm text-base-content/70"
-											title={reasonLabel(reason)}
-										>
-											{#if reason === 'category'}
-												<IconMdiTagOutline class="h-3.5 w-3.5" aria-hidden="true" />
-											{:else if reason === 'country'}
-												<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
-											{:else if reason === 'language'}
-												<IconMdiTranslate class="h-3.5 w-3.5" aria-hidden="true" />
-											{:else if reason === 'product_type'}
-												<IconMdiPackageVariantClosed class="h-3.5 w-3.5" aria-hidden="true" />
-											{:else if reason === 'moderator'}
-												<IconMdiShieldAccount class="h-3.5 w-3.5" aria-hidden="true" />
-											{:else if reason === 'account'}
-												<IconMdiAccountCheck class="h-3.5 w-3.5" aria-hidden="true" />
-											{:else}
-												<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
-											{/if}
-											<span>{reasonLabel(reason)}</span>
-										</span>
-									{/each}
+			{#if requestStatuses[source.id] !== 'empty'}
+				<article
+					class="overflow-hidden rounded-box border border-base-300 bg-white shadow-md dark:bg-base-200"
+				>
+					<header class="border-b border-base-300 bg-base-200">
+						<button
+							type="button"
+							class="flex w-full cursor-pointer items-start gap-4 p-4 text-left hover:bg-base-300/50 sm:p-6"
+							aria-expanded={isExpanded(source.id)}
+							aria-controls={panelId}
+							onclick={() => toggleSource(source.id)}
+						>
+							{#if source.icon_url}
+								<div
+									class="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-base-100 p-2"
+								>
+									<img class="h-full w-full object-contain" src={source.icon_url} alt="" />
 								</div>
 							{/if}
-						</div>
-						<IconMdiChevronDown
-							class={[
-								'mt-1 h-6 w-6 shrink-0 transition-transform',
-								isExpanded(source.id) && 'rotate-180'
-							]}
-							aria-hidden="true"
-						/>
-					</button>
-				</header>
+							<div class="min-w-0 grow">
+								<p class="text-xs font-semibold tracking-widest text-secondary uppercase">
+									{$_('product.external_sources.source_label', { default: 'External source' })}
+								</p>
+								<h3 class="text-2xl font-bold">{source.name}</h3>
+								{#if source.provider_name && source.provider_name !== source.name}
+									<p class="text-sm text-base-content/70">{source.provider_name}</p>
+								{/if}
+								{#if source.description}
+									<p class="mt-2">{source.description}</p>
+								{/if}
+								{#if request.matchReasons?.length}
+									<div class="mt-3 flex flex-wrap gap-2">
+										{#each request.matchReasons as reason (reason)}
+											<span
+												class="badge gap-1 border-base-300 bg-base-100/70 badge-sm text-base-content/70"
+												title={reasonLabel(reason)}
+											>
+												{#if reason === 'category'}
+													<IconMdiTagOutline class="h-3.5 w-3.5" aria-hidden="true" />
+												{:else if reason === 'country'}
+													<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
+												{:else if reason === 'language'}
+													<IconMdiTranslate class="h-3.5 w-3.5" aria-hidden="true" />
+												{:else if reason === 'product_type'}
+													<IconMdiPackageVariantClosed class="h-3.5 w-3.5" aria-hidden="true" />
+												{:else if reason === 'moderator'}
+													<IconMdiShieldAccount class="h-3.5 w-3.5" aria-hidden="true" />
+												{:else if reason === 'account'}
+													<IconMdiAccountCheck class="h-3.5 w-3.5" aria-hidden="true" />
+												{:else}
+													<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
+												{/if}
+												<span>{reasonLabel(reason)}</span>
+											</span>
+										{/each}
+									</div>
+								{/if}
+							</div>
+							{#if requestStatuses[source.id] === 'pending'}
+								<span class="loading mt-1 loading-sm shrink-0 loading-spinner"></span>
+							{:else}
+								<IconMdiChevronDown
+									class={[
+										'mt-1 h-6 w-6 shrink-0 transition-transform',
+										isExpanded(source.id) && 'rotate-180'
+									]}
+									aria-hidden="true"
+								/>
+							{/if}
+						</button>
+					</header>
 
-				{#if isExpanded(source.id)}
-					<div id={panelId} class="p-4 sm:p-6">
-						<div class="mb-4 flex flex-wrap gap-x-4 gap-y-2 text-sm">
-							{#if source.provider_website}
-								<a
-									href={source.provider_website}
-									target="_blank"
-									rel="noopener"
-									class="link link-hover"
-								>
-									{$_('product.external_sources.provider_website', {
-										default: 'Provider website'
-									})}
-								</a>
-							{/if}
-							{#if source.privacy_policy_url}
-								<a
-									href={source.privacy_policy_url}
-									target="_blank"
-									rel="noopener"
-									class="link link-hover"
-								>
-									{$_('product.external_sources.privacy_policy', {
-										default: 'Privacy policy'
-									})}
-								</a>
-							{/if}
+					{#if isExpanded(source.id)}
+						<div id={panelId} class="p-4 sm:p-6">
+							{#await request.promise}
+								<div class="space-y-3 py-2" aria-busy="true">
+									<div class="h-4 w-1/3 skeleton"></div>
+									<div class="h-4 w-full skeleton"></div>
+									<div class="h-4 w-5/6 skeleton"></div>
+								</div>
+							{:then panels}
+								{#if panels != null}
+									<div class="mb-4 flex flex-wrap gap-x-4 gap-y-2 text-sm">
+										{#if panels.provider_website}
+											<a
+												href={panels.provider_website}
+												target="_blank"
+												rel="noopener"
+												class="link link-hover"
+											>
+												{$_('product.external_sources.provider_website', {
+													default: 'Provider website'
+												})}
+											</a>
+										{/if}
+										{#if panels.privacy_policy_url}
+											<a
+												href={panels.privacy_policy_url}
+												target="_blank"
+												rel="noopener"
+												class="link link-hover"
+											>
+												{$_('product.external_sources.privacy_policy', {
+													default: 'Privacy policy'
+												})}
+											</a>
+										{/if}
+									</div>
+									<Panels panels={panels.knowledgePanels} summary={false} />
+								{/if}
+							{:catch}
+								<div class="alert alert-warning">
+									<IconMdiEarth class="h-6 w-6 shrink-0" />
+									<span>
+										{$_('product.external_sources.error', {
+											default: 'External sources could not be loaded.'
+										})}
+									</span>
+								</div>
+							{/await}
 						</div>
-						<Panels panels={source.knowledgePanels} summary={false} />
-					</div>
-				{/if}
-			</article>
+					{/if}
+				</article>
+			{/if}
 		{/each}
 	</div>
 </section>

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { _ } from '$lib/i18n';
+	import type { ComponentType } from 'svelte';
 	import type {
 		ExternalKnowledgePanelResult,
 		ExternalKnowledgePanelRequest,
@@ -21,29 +22,56 @@
 	let { requests }: Props = $props();
 	let expandedSources = $state<Record<string, boolean>>({});
 
+	type MatchReasonMetadata = {
+		key: string;
+		fallback: string;
+		icon: ComponentType;
+	};
+
+	const matchReasonMetadata: Record<ExternalSourceMatchReason, MatchReasonMetadata> = {
+		category: {
+			key: 'product.external_sources.reason_category',
+			fallback: 'Category match',
+			icon: IconMdiTagOutline
+		},
+		country: {
+			key: 'product.external_sources.reason_country',
+			fallback: 'Country match',
+			icon: IconMdiEarth
+		},
+		language: {
+			key: 'product.external_sources.reason_language',
+			fallback: 'Language match',
+			icon: IconMdiTranslate
+		},
+		product_type: {
+			key: 'product.external_sources.reason_product_type',
+			fallback: 'Product type match',
+			icon: IconMdiPackageVariantClosed
+		},
+		public: {
+			key: 'product.external_sources.reason_public',
+			fallback: 'Public source',
+			icon: IconMdiEarth
+		},
+		moderator: {
+			key: 'product.external_sources.reason_moderator',
+			fallback: 'Moderator access',
+			icon: IconMdiShieldAccount
+		},
+		account: {
+			key: 'product.external_sources.reason_account',
+			fallback: 'Account access',
+			icon: IconMdiAccountCheck
+		}
+	};
+
 	function isExpanded(sourceId: string) {
 		return expandedSources[sourceId] === true;
 	}
 
 	function toggleSource(sourceId: string) {
 		expandedSources[sourceId] = !isExpanded(sourceId);
-	}
-
-	function reasonLabel(reason: ExternalSourceMatchReason): string {
-		const labels: Record<ExternalSourceMatchReason, string> = {
-			category: $_('product.external_sources.reason_category', { default: 'Category match' }),
-			country: $_('product.external_sources.reason_country', { default: 'Country match' }),
-			language: $_('product.external_sources.reason_language', { default: 'Language match' }),
-			product_type: $_('product.external_sources.reason_product_type', {
-				default: 'Product type match'
-			}),
-			public: $_('product.external_sources.reason_public', { default: 'Public source' }),
-			moderator: $_('product.external_sources.reason_moderator', {
-				default: 'Moderator access'
-			}),
-			account: $_('product.external_sources.reason_account', { default: 'Account access' })
-		};
-		return labels[reason];
 	}
 </script>
 
@@ -86,26 +114,14 @@
 					{#if request.matchReasons?.length}
 						<div class="mt-3 flex flex-wrap gap-2">
 							{#each request.matchReasons as reason (reason)}
+								{@const metadata = matchReasonMetadata[reason]}
+								{@const reasonLabel = $_(metadata.key, { default: metadata.fallback })}
 								<span
 									class="badge gap-1 border-base-300 bg-base-100/70 badge-sm text-base-content/70"
-									title={reasonLabel(reason)}
+									title={reasonLabel}
 								>
-									{#if reason === 'category'}
-										<IconMdiTagOutline class="h-3.5 w-3.5" aria-hidden="true" />
-									{:else if reason === 'country'}
-										<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
-									{:else if reason === 'language'}
-										<IconMdiTranslate class="h-3.5 w-3.5" aria-hidden="true" />
-									{:else if reason === 'product_type'}
-										<IconMdiPackageVariantClosed class="h-3.5 w-3.5" aria-hidden="true" />
-									{:else if reason === 'moderator'}
-										<IconMdiShieldAccount class="h-3.5 w-3.5" aria-hidden="true" />
-									{:else if reason === 'account'}
-										<IconMdiAccountCheck class="h-3.5 w-3.5" aria-hidden="true" />
-									{:else}
-										<IconMdiEarth class="h-3.5 w-3.5" aria-hidden="true" />
-									{/if}
-									<span>{reasonLabel(reason)}</span>
+									<metadata.icon class="h-3.5 w-3.5" aria-hidden="true" />
+									<span>{reasonLabel}</span>
 								</span>
 							{/each}
 						</div>

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -177,9 +177,9 @@
 							{:then panels}
 								{#if panels != null}
 									<div class="mb-4 flex flex-wrap gap-x-4 gap-y-2 text-sm">
-										{#if panels.provider_website}
+										{#if source.provider_website}
 											<a
-												href={panels.provider_website}
+												href={source.provider_website}
 												target="_blank"
 												rel="noopener"
 												class="link link-hover"
@@ -189,9 +189,9 @@
 												})}
 											</a>
 										{/if}
-										{#if panels.privacy_policy_url}
+										{#if source.privacy_policy_url}
 											<a
-												href={panels.privacy_policy_url}
+												href={source.privacy_policy_url}
 												target="_blank"
 												rel="noopener"
 												class="link link-hover"

--- a/src/lib/knowledgepanels/ExternalPanels.svelte
+++ b/src/lib/knowledgepanels/ExternalPanels.svelte
@@ -160,7 +160,7 @@
 						</span>
 					</div>
 				{:else if panels != null}
-					<Panels panels={panels.knowledgePanels} summary={false} />
+					<Panels panels={panels.knowledgePanels} roots={['root']} summary={false} />
 					{#if source.provider_website || source.privacy_policy_url}
 						<div class="mt-6 flex flex-wrap gap-2 border-t border-base-300 pt-4">
 							{#if source.provider_website}

--- a/src/lib/knowledgepanels/Panels.svelte
+++ b/src/lib/knowledgepanels/Panels.svelte
@@ -29,7 +29,10 @@ Props:
 		roots == null
 			? panels
 			: Object.fromEntries(
-					Object.entries(panels).filter(([_, panel]) => panel.type && roots.includes(panel.type))
+					Object.entries(panels).filter(
+						([id, panel]) =>
+							roots.includes(id) || (panel.type != null && roots.includes(panel.type))
+					)
 				)
 	);
 
@@ -70,7 +73,7 @@ Props:
 {/if}
 
 {#each Object.entries(panels) as [id, panel] (id)}
-	{#if roots == null || (panel.type != null && roots.includes(panel.type))}
+	{#if roots == null || roots.includes(id) || (panel.type != null && roots.includes(panel.type))}
 		<Panel {panel} {panels} {id} link={'#' + SUMMARY_ID} productCode={code} inline />
 	{/if}
 {/each}

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -77,8 +77,17 @@
 	);
 
 	let externalKnowledgePanels = $state<ExternalKnowledgePanels[]>([]);
+	let externalKnowledgePanelsPromise = $state<Promise<ExternalKnowledgePanels[]> | null>(null);
+	let externalKnowledgePanelsLoading = $state(false);
+	let externalKnowledgePanelsError = $state<unknown>(null);
 	$effect(() => {
-		if (!browser || !product.code) return;
+		if (!browser || !product.code) {
+			externalKnowledgePanelsPromise = null;
+			externalKnowledgePanels = [];
+			externalKnowledgePanelsLoading = false;
+			externalKnowledgePanelsError = null;
+			return;
+		}
 
 		const requestContext = {
 			code: product.code,
@@ -89,15 +98,36 @@
 		};
 		let cancelled = false;
 		externalKnowledgePanels = [];
+		externalKnowledgePanelsLoading = true;
+		externalKnowledgePanelsError = null;
 
-		getExternalKnowledgePanels(window.fetch.bind(window), requestContext).then((panels) => {
-			if (!cancelled) externalKnowledgePanels = panels;
-		});
+		const request = getExternalKnowledgePanels(window.fetch.bind(window), requestContext);
+		externalKnowledgePanelsPromise = request;
+		request.then(
+			(panels) => {
+				if (!cancelled) {
+					externalKnowledgePanels = panels;
+					externalKnowledgePanelsLoading = false;
+				}
+			},
+			(error) => {
+				if (!cancelled) {
+					externalKnowledgePanelsLoading = false;
+					externalKnowledgePanelsError = error;
+				}
+			}
+		);
 
 		return () => {
 			cancelled = true;
 		};
 	});
+
+	let hasExternalKnowledgePanelsSection = $derived(
+		externalKnowledgePanelsLoading ||
+			externalKnowledgePanels.length > 0 ||
+			externalKnowledgePanelsError != null
+	);
 
 	let websiteCtx = getWebsiteCtx();
 	$effect(() => {
@@ -159,7 +189,7 @@
 				label: $_('product.sections.product_information', { default: 'Product information' }),
 				icon: IconMdiFormatListBulleted
 			},
-			externalKnowledgePanels.length > 0 && {
+			hasExternalKnowledgePanelsSection && {
 				id: 'external-sources',
 				label: $_('product.sections.external_sources', { default: 'External sources' }),
 				icon: IconMdiDatabase
@@ -387,9 +417,31 @@
 				/>
 			</div>
 
-			{#if externalKnowledgePanels.length > 0}
+			{#if externalKnowledgePanelsPromise != null && hasExternalKnowledgePanelsSection}
 				<div id="external-sources">
-					<ExternalPanels panels={externalKnowledgePanels} />
+					{#await externalKnowledgePanelsPromise}
+						<div class="flex items-center justify-center py-8">
+							<span class="loading loading-lg loading-spinner"></span>
+							<span class="ml-2">
+								{$_('product.external_sources.loading', {
+									default: 'Loading external sources…'
+								})}
+							</span>
+						</div>
+					{:then panels}
+						{#if panels.length > 0}
+							<ExternalPanels {panels} />
+						{/if}
+					{:catch}
+						<div class="alert alert-warning">
+							<IconMdiWarning class="h-6 w-6 shrink-0" />
+							<span>
+								{$_('product.external_sources.error', {
+									default: 'External sources could not be loaded.'
+								})}
+							</span>
+						</div>
+					{/await}
 				</div>
 			{/if}
 

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -51,8 +51,8 @@
 	import { trackOffEvent } from '$lib/analytics';
 	import { browser } from '$app/environment';
 	import {
-		getExternalKnowledgePanels,
-		type ExternalKnowledgePanels
+		getExternalKnowledgePanelRequests,
+		type ExternalKnowledgePanelBatch
 	} from '$lib/api/externalSources';
 
 	let { data }: PageProps = $props();
@@ -76,16 +76,12 @@
 		productState.status === 'success' ? (productState.product as UiProduct) : ({} as UiProduct)
 	);
 
-	let externalKnowledgePanels = $state<ExternalKnowledgePanels[]>([]);
-	let externalKnowledgePanelsPromise = $state<Promise<ExternalKnowledgePanels[]> | null>(null);
-	let externalKnowledgePanelsLoading = $state(false);
-	let externalKnowledgePanelsError = $state<unknown>(null);
+	let externalKnowledgePanelBatchPromise = $state<Promise<ExternalKnowledgePanelBatch> | null>(
+		null
+	);
 	$effect(() => {
 		if (!browser || !product.code) {
-			externalKnowledgePanelsPromise = null;
-			externalKnowledgePanels = [];
-			externalKnowledgePanelsLoading = false;
-			externalKnowledgePanelsError = null;
+			externalKnowledgePanelBatchPromise = null;
 			return;
 		}
 
@@ -97,25 +93,15 @@
 			categories: product.categories_tags ?? []
 		};
 		let cancelled = false;
-		externalKnowledgePanels = [];
-		externalKnowledgePanelsLoading = true;
-		externalKnowledgePanelsError = null;
+		const request = getExternalKnowledgePanelRequests(window.fetch.bind(window), requestContext);
+		externalKnowledgePanelBatchPromise = request;
 
-		const request = getExternalKnowledgePanels(window.fetch.bind(window), requestContext);
-		externalKnowledgePanelsPromise = request;
 		request.then(
-			(panels) => {
-				if (!cancelled) {
-					externalKnowledgePanels = panels;
-					externalKnowledgePanelsLoading = false;
-				}
+			({ requests }) => {
+				if (cancelled) return;
+				if (requests.length === 0) externalKnowledgePanelBatchPromise = null;
 			},
-			(error) => {
-				if (!cancelled) {
-					externalKnowledgePanelsLoading = false;
-					externalKnowledgePanelsError = error;
-				}
-			}
+			() => {}
 		);
 
 		return () => {
@@ -124,9 +110,7 @@
 	});
 
 	let hasExternalKnowledgePanelsSection = $derived(
-		externalKnowledgePanelsLoading ||
-			externalKnowledgePanels.length > 0 ||
-			externalKnowledgePanelsError != null
+		browser && product.code != null && externalKnowledgePanelBatchPromise != null
 	);
 
 	let websiteCtx = getWebsiteCtx();
@@ -417,9 +401,9 @@
 				/>
 			</div>
 
-			{#if externalKnowledgePanelsPromise != null && hasExternalKnowledgePanelsSection}
+			{#if hasExternalKnowledgePanelsSection}
 				<div id="external-sources">
-					{#await externalKnowledgePanelsPromise}
+					{#await externalKnowledgePanelBatchPromise}
 						<div class="flex items-center justify-center py-8">
 							<span class="loading loading-lg loading-spinner"></span>
 							<span class="ml-2">
@@ -428,9 +412,9 @@
 								})}
 							</span>
 						</div>
-					{:then panels}
-						{#if panels.length > 0}
-							<ExternalPanels {panels} />
+					{:then batch}
+						{#if batch != null && batch.requests.length > 0}
+							<ExternalPanels requests={batch.requests} />
 						{/if}
 					{:catch}
 						<div class="alert alert-warning">

--- a/src/routes/products/[barcode]/+page.svelte
+++ b/src/routes/products/[barcode]/+page.svelte
@@ -5,6 +5,7 @@
 	import { preferences } from '$lib/settings';
 
 	import KnowledgePanelsComp from '$lib/knowledgepanels/Panels.svelte';
+	import ExternalPanels from '$lib/knowledgepanels/ExternalPanels.svelte';
 	import Card from '$lib/ui/Card.svelte';
 	import Metadata from '$lib/Metadata.svelte';
 
@@ -49,6 +50,10 @@
 	import { goto } from '$app/navigation';
 	import { trackOffEvent } from '$lib/analytics';
 	import { browser } from '$app/environment';
+	import {
+		getExternalKnowledgePanels,
+		type ExternalKnowledgePanels
+	} from '$lib/api/externalSources';
 
 	let { data }: PageProps = $props();
 	let { state: productState } = $derived(data);
@@ -70,6 +75,29 @@
 	let product = $derived(
 		productState.status === 'success' ? (productState.product as UiProduct) : ({} as UiProduct)
 	);
+
+	let externalKnowledgePanels = $state<ExternalKnowledgePanels[]>([]);
+	$effect(() => {
+		if (!browser || !product.code) return;
+
+		const requestContext = {
+			code: product.code,
+			lc: data.lc || $preferences.lang || 'en',
+			cc: $preferences.country || 'world',
+			productType: product.product_type,
+			categories: product.categories_tags ?? []
+		};
+		let cancelled = false;
+		externalKnowledgePanels = [];
+
+		getExternalKnowledgePanels(window.fetch.bind(window), requestContext).then((panels) => {
+			if (!cancelled) externalKnowledgePanels = panels;
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	});
 
 	let websiteCtx = getWebsiteCtx();
 	$effect(() => {
@@ -130,6 +158,11 @@
 				id: 'product_card',
 				label: $_('product.sections.product_information', { default: 'Product information' }),
 				icon: IconMdiFormatListBulleted
+			},
+			externalKnowledgePanels.length > 0 && {
+				id: 'external-sources',
+				label: $_('product.sections.external_sources', { default: 'External sources' }),
+				icon: IconMdiDatabase
 			},
 			isPriceConfigured() &&
 				data.prices != null && {
@@ -353,6 +386,12 @@
 					summary={sidebarHidden}
 				/>
 			</div>
+
+			{#if externalKnowledgePanels.length > 0}
+				<div id="external-sources">
+					<ExternalPanels panels={externalKnowledgePanels} />
+				</div>
+			{/if}
 
 			{#if isPriceConfigured() && data?.prices != null}
 				<div id="prices">

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -43,7 +43,8 @@ const config = {
 					'https://tile.openstreetmap.org',
 					'https://play.google.com',
 					'https://fdroid.gitlab.io',
-					'https://upload.wikimedia.org'
+					'https://upload.wikimedia.org',
+					'https://lheuredescomptes.org'
 				],
 				'style-src': ['self', 'unsafe-inline'],
 				'frame-ancestors': ['none']


### PR DESCRIPTION
### Description

Adds support for fetching eligible external knowledge-panel sources from the Product Opener v3 API, querying each provider endpoint, and displaying returned panels in distinct collapsible cards.

The UI also shows compact eligibility-reason icons, defaults cards to collapsed, adds pointer affordances, displays a loading state while external sources are fetched, and allows provider images from lheuredescomptes.org via CSP.

### Screenshot or video

<img width="1063" height="411" alt="immagine" src="https://github.com/user-attachments/assets/f1281fbb-a860-481a-a613-68df6efe2bea" />
---
<img width="971" height="2127" alt="immagine" src="https://github.com/user-attachments/assets/e76103ba-5289-42ce-bce8-972955a968cb" />


### Related issue(s) and discussion

No issue number was provided.

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** OpenAI Codex (GPT-5)
  - **How it was used:** agentic implementation and validation
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “External sources” section to product pages.
  * Displays knowledge panels with source details, matching criteria, provider links, and privacy policies.
  * Filters sources by product, language, country, and access eligibility.
  * Supports localized loading, empty, and error states.
* **Bug Fixes**
  * Prevents outdated or canceled requests from replacing current external-source results.
* **Configuration**
  * Allows images from an additional approved provider domain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->