### PR TITLE
fix: remove colon from categories label

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -431,7 +431,7 @@
 				"multiple_uploads_guidance": "With Chrome, Firefox and Safari, you can select multiple pictures (product, ingredients, nutrition facts etc.) by clicking them while holding the Ctrl key pressed to add them all in one shot."
 			},
 			"manufacturing_places": "Manufacturing places",
-			"categories": "Categories:",
+			"categories": "Categories",
 			"labels": "Labels",
 			"brands": "Brands",
 			"stores": "Stores",

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -414,7 +414,7 @@
 				"multiple_uploads_guidance": "With Chrome, Firefox and Safari, you can select multiple pictures (product, ingredients, nutrition facts etc.) by clicking them while holding the Ctrl key pressed to add them all in one shot."
 			},
 			"manufacturing_places": "Manufacturing places",
-			"categories": "Categories:",
+			"categories": "Categories",
 			"labels": "Labels",
 			"brands": "Brands",
 			"stores": "Stores",

--- a/src/lib/i18n/messages/en_AU.json
+++ b/src/lib/i18n/messages/en_AU.json
@@ -414,7 +414,7 @@
 				"multiple_uploads_guidance": "With Chrome, Firefox and Safari, you can select multiple pictures (product, ingredients, nutrition facts etc.) by clicking them while holding the Ctrl key pressed to add them all in one shot."
 			},
 			"manufacturing_places": "Manufacturing places",
-			"categories": "Categories:",
+			"categories": "Categories",
 			"labels": "Labels",
 			"brands": "Brands",
 			"stores": "Stores",

--- a/src/lib/i18n/messages/en_GB.json
+++ b/src/lib/i18n/messages/en_GB.json
@@ -414,7 +414,7 @@
 				"multiple_uploads_guidance": "With Chrome, Firefox and Safari, you can select multiple pictures (product, ingredients, nutrition facts etc.) by clicking them while holding the Ctrl key pressed to add them all in one shot."
 			},
 			"manufacturing_places": "Manufacturing places",
-			"categories": "Categories:",
+			"categories": "Categories",
 			"labels": "Labels",
 			"brands": "Brands",
 			"stores": "Stores",


### PR DESCRIPTION
<!--
Thank you for contributing to Open Food Facts Explorer!
Please provide a description of your changes below.
-->

### Description
Remove the trailing colon from the Categories label in the product edit form to make it consistent with other fields such as Labels, Brands, and Stores.

The colon was coming from the `product.edit.categories` English translation strings.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

### Screenshot or video
Before 
<img width="921" height="107" alt="image" src="https://github.com/user-attachments/assets/17e4de09-041f-49dc-bf0d-9cbcd43589c2" />

After
<img width="1100" height="463" alt="image" src="https://github.com/user-attachments/assets/48ab0cdb-c0b7-41f5-b7b1-f390340f809d" />

<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

### Related issue(s) and discussion

<!-- Please use a linking keyword like `Fixes:` or `Closes:` followed by the issue number - doc: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

- Closes: <!-- #1 --> #1796

---

### Checklist: Author Self-Review

<!-- replace [ ] by [x] for each item you have completed -->

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** <!-- e.g. GitHub Copilot (GPT-4o), Claude Sonnet 4.5, Cursor --> Antigravity CLI 1.1.16
  - **How it was used:** <!-- e.g. agentic (fully automated), autocomplete (suggestions accepted), review (checked my code) --> Review/investigation — used to locate and analyze the source of the trailing colon
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the product edit form’s “Categories” label to remove the trailing colon across English translations.
  - Applied the same wording refinement to Australian and British English locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->