### PR TITLE
fix(scan): show invalid GS1 payload

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -707,6 +707,8 @@
 		"add_new_product": "Add new product",
 		"scan_again": "Scan again",
 		"invalid_barcode": "Scanned code is not a valid barcode",
+		"invalid_barcode_payload": "Scanner payload",
+		"empty_barcode_payload": "(empty)",
 		"manual_barcode": "Enter the barcode manually",
 		"camera_access_required": "Camera access is required. Please enable it in your browser settings."
 	},

--- a/src/routes/qr/+page.svelte
+++ b/src/routes/qr/+page.svelte
@@ -10,6 +10,7 @@
 	let html5QrCode: Html5Qrcode | null = null;
 	let scannerTimedOut = $state(false);
 	let manualBarcode = $state('');
+	let invalidBarcodePayload = $state<string | null>(null);
 	let scannerTimeout: ReturnType<typeof setTimeout> | null = null;
 	let isSubmittingBarcode = $state(false);
 	let canRetryScan = $state(false);
@@ -52,6 +53,7 @@
 		if (isDestroyed || productCode == null || isSubmittingBarcode) {
 			if (productCode == null && !isDestroyed) {
 				canRetryScan = true;
+				invalidBarcodePayload = barcode;
 				error = $_('qr.invalid_barcode', {
 					default: 'Scanned code is not a valid barcode'
 				});
@@ -202,6 +204,7 @@
 			canRetryScan = false;
 			scannerTimedOut = false;
 			manualBarcode = '';
+			invalidBarcodePayload = null;
 
 			await tick();
 
@@ -219,7 +222,21 @@
 {#if error != null}
 	<div class="flex h-screen items-center justify-center">
 		<div class="flex flex-col items-center gap-4 text-center">
-			<p class="text-error">{error}</p>
+			<div class="max-w-full px-4" role="alert">
+				<p class="text-error">{error}</p>
+				{#if invalidBarcodePayload !== null}
+					<div class="mt-3 max-w-full text-left">
+						<p class="mb-1 text-sm font-semibold">
+							{$_('qr.invalid_barcode_payload', { default: 'Scanner payload' })}
+						</p>
+						<code
+							class="block max-w-full overflow-x-auto rounded-box bg-base-200 p-3 text-sm break-all whitespace-pre-wrap"
+						>
+							{invalidBarcodePayload || $_('qr.empty_barcode_payload', { default: '(empty)' })}
+						</code>
+					</div>
+				{/if}
+			</div>
 			{#if canRetryScan}
 				<button class="btn btn-outline" onclick={restartScanner}>
 					{$_('qr.scan_again', { default: 'Scan again' })}


### PR DESCRIPTION
### Description

When a GS1 scan cannot be parsed as a valid barcode, the scanner now displays the raw payload in a wrapped code block. This makes malformed GS1 payloads available for debugging while keeping the existing retry flow.

The payload display is escaped by Svelte and preserves whitespace/newlines where possible. New labels use the existing i18n conventions.

### Screenshot or video

Not applicable; this change affects the invalid barcode scanner error state and was validated through the running LAN dev server.

### Related issue(s) and discussion

Fixes: #1822

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** OpenAI Codex (GPT-5)
  - **How it was used:** Agentic implementation, validation, and PR preparation.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invalid QR code error messages by displaying the scanner payload.
  * Added a clear fallback when the scanned payload is empty.
  * Raw scan data is cleared when restarting the scanner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->