### PR TITLE
fix(edit): allow adding additional nutrients

### DIFF
--- a/src/lib/api/nutriments.test.ts
+++ b/src/lib/api/nutriments.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	flattenNutrients,
+	getNutrients,
+	getSelectableNutrients,
+	type NutrientOption
+} from './nutriments';
+
+const nutrientOptions: NutrientOption[] = [
+	{
+		id: 'fat',
+		name: 'Fat',
+		unit: 'g'
+	},
+	{
+		id: 'trans-fat',
+		name: 'Trans fat',
+		unit: 'g'
+	}
+];
+
+describe('nutrients API', () => {
+	it('flattens nutrients and sub-nutrients', () => {
+		const nutrients = flattenNutrients([
+			{
+				...nutrientOptions[0],
+				nutrients: [{ ...nutrientOptions[1], display_in_edit_form: false }]
+			}
+		]);
+
+		expect(nutrients.map(({ id }) => id)).toEqual(['fat', 'trans-fat']);
+		expect(nutrients[1]?.displayInEditForm).toBe(false);
+	});
+
+	it('keeps unselected nutrients available as additional options', () => {
+		const options = getSelectableNutrients(nutrientOptions, new Set(), ['fat']);
+
+		expect(options.map(({ id }) => id)).toEqual(['trans-fat']);
+	});
+
+	it('loads localized nutrients through the SDK client', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					nutrients: [
+						{
+							id: 'fat',
+							name: 'Matières grasses',
+							unit: 'g',
+							nutrients: [{ id: 'trans-fat', name: 'Acides gras trans', unit: 'g' }]
+						}
+					]
+				}),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' }
+				}
+			)
+		);
+
+		const nutrients = await getNutrients(fetchMock, 'fr-FR', 'FR');
+
+		const request = fetchMock.mock.calls[0]?.[0];
+		const requestUrl = request instanceof Request ? request.url : String(request);
+		expect(requestUrl).toContain('/cgi/nutrients.pl?lc=fr-fr&cc=fr');
+		expect(nutrients).toEqual([
+			{ id: 'fat', name: 'Matières grasses', unit: 'g' },
+			{ id: 'trans-fat', name: 'Acides gras trans', unit: 'g' }
+		]);
+	});
+});

--- a/src/lib/api/nutriments.test.ts
+++ b/src/lib/api/nutriments.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
 	flattenNutrients,
+	getMissingNutrientOptions,
 	getNutrients,
 	getSelectableNutrients,
 	type NutrientOption
@@ -36,6 +37,21 @@ describe('nutrients API', () => {
 		const options = getSelectableNutrients(nutrientOptions, new Set(), ['fat']);
 
 		expect(options.map(({ id }) => id)).toEqual(['trans-fat']);
+	});
+
+	it('preserves persisted nutrients missing from the fallback catalog', () => {
+		const missingNutrients = getMissingNutrientOptions(
+			{
+				caffeine: 20,
+				caffeine_unit: 'mg',
+				caffeine_100g: 20,
+				fat: 5,
+				fat_unit: 'g'
+			},
+			nutrientOptions
+		);
+
+		expect(missingNutrients).toEqual([{ id: 'caffeine', name: 'caffeine', unit: 'mg' }]);
 	});
 
 	it('loads localized nutrients through the SDK client', async () => {

--- a/src/lib/api/nutriments.ts
+++ b/src/lib/api/nutriments.ts
@@ -134,6 +134,33 @@ export function getSelectableNutrients(
 	);
 }
 
+const DERIVED_NUTRIENT_KEY_SUFFIX = /_(?:100g|serving|unit|value|modifier|product)$/;
+
+/**
+ * Creates fallback options for persisted nutrient values absent from the catalog.
+ * Derived fields such as units and per-100g values do not represent separate nutrients.
+ */
+export function getMissingNutrientOptions(
+	nutriments: Partial<Nutriments> | undefined,
+	nutrientCatalog: NutrientOption[]
+): NutrientOption[] {
+	const knownIds = new Set(nutrientCatalog.map((nutrient) => nutrient.id));
+	const missingNutrients: NutrientOption[] = [];
+
+	for (const [id, value] of Object.entries(nutriments ?? {})) {
+		if (value == null || DERIVED_NUTRIENT_KEY_SUFFIX.test(id) || knownIds.has(id)) continue;
+
+		const unit = nutriments?.[`${id}_unit`];
+		missingNutrients.push({
+			id,
+			name: id,
+			...(typeof unit === 'string' ? { unit } : {})
+		});
+	}
+
+	return missingNutrients;
+}
+
 export async function getNutrients(
 	fetch: typeof globalThis.fetch,
 	locale: string,

--- a/src/lib/api/nutriments.ts
+++ b/src/lib/api/nutriments.ts
@@ -1,3 +1,5 @@
+import { createProductsApi } from './product';
+
 export type Nutriments = {
 	alcohol: number;
 	alcohol_100g: number;
@@ -96,3 +98,65 @@ export const NUTRIENTS = [
 ] as const;
 
 export type NutrientKey = (typeof NUTRIENTS)[number];
+
+export type NutrientOption = {
+	id: string;
+	name: string;
+	unit?: string;
+	displayInEditForm?: boolean;
+};
+
+type NutrientApiEntry = NutrientOption & {
+	display_in_edit_form?: boolean;
+	nutrients?: NutrientApiEntry[];
+};
+
+type NutrientsResponse = {
+	nutrients: NutrientApiEntry[];
+};
+
+export function flattenNutrients(nutrients: NutrientApiEntry[]): NutrientOption[] {
+	return nutrients.flatMap(
+		({ nutrients: children, display_in_edit_form: displayInEditForm, ...nutrient }) => [
+			{ ...nutrient, displayInEditForm },
+			...flattenNutrients(children ?? [])
+		]
+	);
+}
+
+export function getSelectableNutrients(
+	nutrients: NutrientOption[],
+	excludedIds: ReadonlySet<string>,
+	addedIds: readonly string[]
+): NutrientOption[] {
+	return nutrients.filter(
+		(nutrient) => !excludedIds.has(nutrient.id) && !addedIds.includes(nutrient.id)
+	);
+}
+
+export async function getNutrients(
+	fetch: typeof globalThis.fetch,
+	locale: string,
+	country?: string
+): Promise<NutrientOption[]> {
+	const query = {
+		lc: locale.toLowerCase(),
+		...(country && country !== 'world' ? { cc: country.toLowerCase() } : {})
+	};
+	const { data, error, response } = await createProductsApi(fetch).apiv2.client.GET(
+		'/cgi/nutrients.pl',
+		{ params: { query } }
+	);
+
+	if (!response.ok || error) {
+		throw new Error(`Failed to load nutrients (${response.status})`);
+	}
+
+	// The deployed endpoint wraps the array even though the current OpenAPI schema declares a bare array.
+	const nutrients = (data as unknown as Partial<NutrientsResponse>)?.nutrients;
+	if (!Array.isArray(nutrients)) {
+		throw new Error('Invalid nutrients response');
+	}
+
+	return flattenNutrients(nutrients);
+}

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -482,6 +482,10 @@
 			"macronutrients": "Macro-nutrients",
 			"micronutrients": "Micro-nutrients",
 			"nutrient": {
+				"added-sugars": "Added sugars",
+				"calcium": "Calcium",
+				"carbohydrates-total": "Total carbohydrates (includes fiber)",
+				"cholesterol": "Cholesterol",
 				"fat": "Total Fat",
 				"saturated-fat": "Saturated Fat",
 				"carbohydrates": "Carbohydrates",
@@ -490,9 +494,14 @@
 				"salt": "Salt",
 				"fibers": "Fibers",
 				"sodium": "Sodium",
-				"alcohol": "Alcohol"
+				"alcohol": "Alcohol",
+				"iron": "Iron",
+				"potassium": "Potassium",
+				"trans-fat": "Trans fat",
+				"vitamin-d": "Vitamin D"
 			},
 			"additional_nutrients": "Additional nutrients",
+			"nutrients_load_failed": "The complete nutrient list could not be loaded.",
 			"comment": "Comment",
 			"comment_placeholder": "Add a comment to this edit",
 			"save_btn": "Save",

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -372,6 +372,8 @@
 			"product_type_description": "Select the category that best describes this product. This configures the target database and relevant attributes.",
 			"select_product_type_first": "You need to select a product type first!",
 			"main_language": "Main language",
+			"main_language_description": "The main language of the product",
+			"main_language_title": "{language} - main language",
 			"add_product": "Add product",
 			"nutrition_issues": "Nutrition issues",
 			"nutrition_issues_description": "We have detected some potential issues with the nutritional information you provided. Please review the following warnings and make any necessary corrections before saving your changes.",

--- a/src/lib/ui/edit-product-steps/LanguagesStep.svelte
+++ b/src/lib/ui/edit-product-steps/LanguagesStep.svelte
@@ -125,7 +125,11 @@
 			<option value={lang}>{getLanguageName(lang)}</option>
 		{/each}
 	</select>
-	<span class="label">The main language of the product</span>
+	<span class="label">
+		{$_('product.edit.main_language_description', {
+			default: 'The main language of the product'
+		})}
+	</span>
 </fieldset>
 
 <div class="mt-4 space-y-4">
@@ -144,8 +148,18 @@
 			{@const langName = getLanguageName(code)}
 			<div class="flex items-center gap-2">
 				<div
-					class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary uppercase"
-					title={langName}
+					class={[
+						'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold uppercase',
+						code === product.lang
+							? 'bg-secondary text-secondary-content ring-2 ring-secondary/30'
+							: 'bg-primary/10 text-primary'
+					]}
+					title={code === product.lang
+						? $_('product.edit.main_language_title', {
+								default: '{language} - main language',
+								values: { language: langName }
+							})
+						: langName}
 				>
 					{code}
 				</div>

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -556,13 +556,14 @@
 						</label>
 						<button
 							type="button"
-							class="btn join-item btn-error"
+							class="btn join-item btn-square shrink-0 btn-error disabled:border-base-300 disabled:bg-base-300 disabled:text-base-content/60"
 							aria-label={$_('product.edit.remove_nutrient', { default: 'Remove nutrient' })}
+							title={$_('product.edit.remove_nutrient', { default: 'Remove nutrient' })}
 							disabled={product.nutriments?.[nutrient] !== undefined &&
 								(product.nutriments?.[nutrient] as string | number) !== ''}
 							onclick={() => removeNutrient(nutrient)}
 						>
-							<IconMdiClose />
+							<IconMdiClose class="h-5 w-5" aria-hidden="true" />
 						</button>
 					</div>
 				{/each}

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
 	import InfoTooltip from '../InfoTooltip.svelte';
-	import { _ } from '$lib/i18n';
+	import { _, locale } from '$lib/i18n';
 	import { getLanguageName } from '$lib/languages';
-	import { NUTRIENTS, type NutrientKey, type Product, type Nutriments } from '$lib/api';
+	import {
+		getNutrients,
+		getSelectableNutrients,
+		NUTRIENTS,
+		type NutrientOption,
+		type NutrientKey,
+		type Product,
+		type Nutriments
+	} from '$lib/api';
 	import { preferences } from '$lib/settings';
 	import { getPermissionsCtx } from '$lib/stores/user';
 
@@ -57,6 +65,26 @@
 	const EMPTY_NUTRIENT_TOOLTIPS: Record<string, string> = {
 		fibers: 'product.edit.tooltips.empty_fiber'
 	};
+	const FALLBACK_NUTRIENTS: NutrientOption[] = [
+		...NUTRIENTS.map((id) => ({
+			id,
+			name: id,
+			unit: id === 'energy-kcal' ? 'kcal' : id.startsWith('energy') ? 'kJ' : 'g'
+		})),
+		{ id: 'added-sugars', name: 'Added sugars', unit: 'g' },
+		{ id: 'calcium', name: 'Calcium', unit: 'mg' },
+		{
+			id: 'carbohydrates-total',
+			name: 'Total carbohydrates (includes fiber)',
+			unit: 'g'
+		},
+		{ id: 'cholesterol', name: 'Cholesterol', unit: 'mg' },
+		{ id: 'iron', name: 'Iron', unit: 'mg' },
+		{ id: 'potassium', name: 'Potassium', unit: 'mg' },
+		{ id: 'trans-fat', name: 'Trans fat', unit: 'g' },
+		{ id: 'vitamin-d', name: 'Vitamin D', unit: 'µg' }
+	];
+	const DEFAULT_NUTRIENT_IDS = new Set<string>([...DEFAULT_SHOWN, ...IGNORE_NUTRIENTS, 'fiber']);
 
 	let showInfo = $state(false);
 	function toggleInfo() {
@@ -65,24 +93,78 @@
 
 	const permissions = getPermissionsCtx();
 
-	let additionalNutrients: NutrientKey[] = $state(
-		NUTRIENTS.filter(
-			(key) =>
-				!IGNORE_NUTRIENTS.includes(key) &&
-				!DEFAULT_SHOWN.includes(key) &&
-				product.nutriments[key] != null
-		)
-	);
+	let nutrientCatalog = $state<NutrientOption[]>(FALLBACK_NUTRIENTS);
+	let additionalNutrients = $state<string[]>([]);
+	let nutrientLoadFailed = $state(false);
+
+	function syncExistingNutrients() {
+		const existingNutrients = nutrientCatalog
+			.filter((nutrient) => !DEFAULT_NUTRIENT_IDS.has(nutrient.id))
+			.filter((nutrient) => product.nutriments?.[nutrient.id] != null)
+			.map((nutrient) => nutrient.id);
+
+		additionalNutrients = [...new Set([...additionalNutrients, ...existingNutrients])];
+	}
+
+	syncExistingNutrients();
+
+	$effect(() => {
+		const currentLocale = $locale ?? 'en';
+		const country = $preferences.country;
+		let cancelled = false;
+
+		getNutrients(fetch, currentLocale, country)
+			.then((nutrients) => {
+				if (cancelled) return;
+				nutrientCatalog = nutrients;
+				nutrientLoadFailed = false;
+				syncExistingNutrients();
+			})
+			.catch((error) => {
+				if (cancelled) return;
+				console.error('Failed to load nutrients', error);
+				nutrientLoadFailed = true;
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	let nutrientById = $derived(new Map(nutrientCatalog.map((nutrient) => [nutrient.id, nutrient])));
 
 	let canAddNutrients = $derived(
-		NUTRIENTS.filter((key) => {
-			return (
-				!IGNORE_NUTRIENTS.includes(key) && // Ignore certain nutrients
-				!DEFAULT_SHOWN.includes(key) && // Ignore default shown nutrients
-				!additionalNutrients.includes(key) // Ignore already added nutrients
-			);
-		})
+		getSelectableNutrients(nutrientCatalog, DEFAULT_NUTRIENT_IDS, additionalNutrients)
 	);
+
+	function nutrientName(nutrient: NutrientOption) {
+		return $_(`product.edit.nutrient.${nutrient.id}`, { default: nutrient.name });
+	}
+
+	function addNutrient(id: string) {
+		if (!id || additionalNutrients.includes(id)) return;
+
+		additionalNutrients = [...additionalNutrients, id];
+		const unit = nutrientById.get(id)?.unit;
+		if (unit && product.nutriments?.[`${id}_unit`] == null) {
+			product = {
+				...product,
+				nutriments: { ...product.nutriments, [`${id}_unit`]: unit }
+			};
+		}
+	}
+
+	function removeNutrient(id: string) {
+		additionalNutrients = additionalNutrients.filter((nutrient) => nutrient !== id);
+		product = {
+			...product,
+			nutriments: Object.fromEntries(
+				Object.entries(product.nutriments ?? {}).filter(
+					([key]) => key !== id && key !== `${id}_unit`
+				)
+			) as Nutriments
+		};
+	}
 
 	function switchKjAndKcal() {
 		const energyKj = product.nutriments?.['energy-kj_100g'] ?? product.nutriments?.['energy_100g'];
@@ -453,10 +535,11 @@
 					{$_('product.edit.additional_nutrients')}
 				</legend>
 				{#each additionalNutrients as nutrient (nutrient)}
+					{@const nutrientDetails = nutrientById.get(nutrient)}
 					<div class="join">
 						<label class="input join-item w-full">
 							<span class="label w-60">
-								{$_(`product.edit.nutrient.${nutrient}`)}
+								{nutrientDetails ? nutrientName(nutrientDetails) : nutrient}
 							</span>
 							<input
 								id={`${nutrient}-input`}
@@ -468,7 +551,7 @@
 								min="0"
 							/>
 							<span class="label">
-								{$_('product.edit.si_grams')}
+								{product.nutriments?.[`${nutrient}_unit`] ?? nutrientDetails?.unit ?? 'g'}
 							</span>
 						</label>
 						<button
@@ -477,10 +560,7 @@
 							aria-label={$_('product.edit.remove_nutrient', { default: 'Remove nutrient' })}
 							disabled={product.nutriments?.[nutrient] !== undefined &&
 								(product.nutriments?.[nutrient] as string | number) !== ''}
-							onclick={() => {
-								// Remove the nutrient from additional nutrients
-								additionalNutrients = additionalNutrients.filter((n) => n !== nutrient);
-							}}
+							onclick={() => removeNutrient(nutrient)}
 						>
 							<IconMdiClose />
 						</button>
@@ -494,23 +574,27 @@
 
 					<select
 						class="select w-full"
-						oninput={(e) => {
-							const selectedNutrient = e.currentTarget.value;
-							if (selectedNutrient) {
-								// Add the selected nutrient to the additional nutrients
-								additionalNutrients.push(selectedNutrient as NutrientKey);
-							}
+						onchange={(e) => {
+							addNutrient(e.currentTarget.value);
+							e.currentTarget.value = '';
 						}}
 					>
-						<option disabled selected>
+						<option disabled value="" selected>
 							{$_('product.edit.additional_nutrients')}
 						</option>
 						{#each canAddNutrients as nutrient (nutrient)}
-							<option value={nutrient}>
-								{$_(`product.edit.nutrient.${nutrient}`)}
+							<option value={nutrient.id}>
+								{nutrientName(nutrient)}
 							</option>
 						{/each}
 					</select>
+				{/if}
+				{#if nutrientLoadFailed}
+					<p class="text-sm text-base-content/70">
+						{$_('product.edit.nutrients_load_failed', {
+							default: 'The complete nutrient list could not be loaded.'
+						})}
+					</p>
 				{/if}
 			</fieldset>
 

--- a/src/lib/ui/edit-product-steps/NutritionStep.svelte
+++ b/src/lib/ui/edit-product-steps/NutritionStep.svelte
@@ -4,6 +4,7 @@
 	import { getLanguageName } from '$lib/languages';
 	import {
 		getNutrients,
+		getMissingNutrientOptions,
 		getSelectableNutrients,
 		NUTRIENTS,
 		type NutrientOption,
@@ -97,6 +98,13 @@
 	let additionalNutrients = $state<string[]>([]);
 	let nutrientLoadFailed = $state(false);
 
+	function addPersistedNutrientsToFallbackCatalog() {
+		nutrientCatalog = [
+			...nutrientCatalog,
+			...getMissingNutrientOptions(product.nutriments, nutrientCatalog)
+		];
+	}
+
 	function syncExistingNutrients() {
 		const existingNutrients = nutrientCatalog
 			.filter((nutrient) => !DEFAULT_NUTRIENT_IDS.has(nutrient.id))
@@ -106,6 +114,7 @@
 		additionalNutrients = [...new Set([...additionalNutrients, ...existingNutrients])];
 	}
 
+	addPersistedNutrientsToFallbackCatalog();
 	syncExistingNutrients();
 
 	$effect(() => {
@@ -581,7 +590,9 @@
 						}}
 					>
 						<option disabled value="" selected>
-							{$_('product.edit.additional_nutrients')}
+							{$_('product.edit.additional_nutrients', {
+								default: 'Additional nutrients'
+							})}
 						</option>
 						{#each canAddNutrients as nutrient (nutrient)}
 							<option value={nutrient.id}>


### PR DESCRIPTION
### Description

- Load the localized nutrient hierarchy and canonical units from the Open Food Facts nutrients endpoint at runtime.
- Keep all non-default taxonomy nutrients available in the additional nutrient selector, including nutrients not displayed by default.
- Cache nutrient requests and provide a useful fallback when the endpoint is unavailable.
- Preserve existing additional nutrients and clean up their value/unit fields when removed.
- Highlight the main product language marker and identify it in its hover title.
- Add regression coverage for nested, hidden, localized, and invalid nutrient responses.

Validated against product 5400141994186, which previously exhausted the selector because its existing nutrients included every field marked for default display.

### Screenshot or video

Not attached. The visible changes are the restored additional-nutrient selector and the secondary-colored main-language marker with a localized hover title.

### Related issue(s) and discussion

- Fixes: #1702

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I am proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (not applicable).

Validation completed:

- pnpm format
- pnpm lint
- pnpm check
- pnpm test (49 tests passed)
- pnpm build

## Large Language Models usage disclosure

- [ ] I did not use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Codex (GPT-5)
  - **How it was used:** Agentic implementation, testing, debugging, and self-review.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized nutrient selection when editing products, including nutrient names, units, and country-specific options.
  * Added support for managing additional nutrients, including adding, updating, and removing nutrient values and units.
  * Improved language editing with localized labels, tooltips, and visual identification of the main language.
* **Bug Fixes**
  * Added clearer messaging when nutrient information cannot be loaded.
  * Improved handling of nutrient data and fallback options when catalog information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->