### PR TITLE
feat: show non-production environment notice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ RESTART_POLICY=no
 
 # app config  ###############################
 
+# Set to development or staging to show the non-production environment notice.
+PUBLIC_ENVIRONMENT=development
+
 PUBLIC_FOLKSONOMY_API_URL=https://api.folksonomy.openfoodfacts.net
 PUBLIC_OFF_BASE_URL=https://world.openfoodfacts.net
 PUBLIC_SEARCH_BASE_URL=https://search.openfoodfacts.net

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -52,6 +52,7 @@ jobs:
           echo "PUBLIC_ROBOTOFF_URL=https://robotoff.openfoodfacts.net" >> $GITHUB_ENV
           echo "PUBLIC_IMAGES_URL=https://images.openfoodfacts.net" >> $GITHUB_ENV
           echo "PUBLIC_NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.net" >> $GITHUB_ENV
+          echo "PUBLIC_ENVIRONMENT=staging" >> $GITHUB_ENV
       - name: Set various variable for production deployment
         if: matrix.env == 'off-explorer-org'
         run: |
@@ -132,6 +133,7 @@ jobs:
             echo "PUBLIC_ROBOTOFF_URL=${{ env.PUBLIC_ROBOTOFF_URL }}" >> .env
             echo "PUBLIC_IMAGES_URL=${{ env.PUBLIC_IMAGES_URL }}" >> .env
             echo "PUBLIC_NUTRIPATROL_URL=${{ env.PUBLIC_NUTRIPATROL_URL }}" >> .env
+            echo "PUBLIC_ENVIRONMENT=${{ env.PUBLIC_ENVIRONMENT }}" >> .env
 
       - name: Pull Docker image
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,4 +1,5 @@
 import { resolve } from '$app/paths';
+import { dev } from '$app/environment';
 import { env as publicEnv } from '$env/dynamic/public';
 import { toWebsiteFlavor, WEBSITE_FLAVOR_METADATA } from '$lib/flavor';
 
@@ -20,6 +21,8 @@ export {
 
 export const STATIC_HOST = 'https://static.openfoodfacts.org';
 export const API_HOST = publicEnv.PUBLIC_OFF_BASE_URL || 'https://world.openfoodfacts.org';
+export const IS_NON_PRODUCTION =
+	dev || ['development', 'staging'].includes(publicEnv.PUBLIC_ENVIRONMENT ?? '');
 export const SEARCH_URL = `${API_HOST}/api/v2/search`;
 export const PRODUCT_EDIT_URL = `${API_HOST}/product/`;
 

--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -82,6 +82,10 @@
 		"error_occurred": "error occurred:",
 		"errors_occurred": "errors occurred:"
 	},
+	"environment_notice": {
+		"title": "Non-production environment",
+		"message": "Data and features on this site may change or be reset without notice."
+	},
 	"footer": {
 		"stay_updated": "Stay Updated",
 		"contribute": "Contribute",

--- a/src/lib/i18n/messages/it.json
+++ b/src/lib/i18n/messages/it.json
@@ -82,6 +82,10 @@
 		"error_occurred": "si è verificato un errore:",
 		"errors_occurred": "si sono verificati degli errori:"
 	},
+	"environment_notice": {
+		"title": "Ambiente non di produzione",
+		"message": "I dati e le funzionalità di questo sito possono cambiare o essere ripristinati senza preavviso."
+	},
 	"footer": {
 		"stay_updated": "Rimani aggiornato",
 		"contribute": "Contribuire",

--- a/src/lib/ui/EnvironmentNotice.svelte
+++ b/src/lib/ui/EnvironmentNotice.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import IconMdiAlertCircleOutline from '@iconify-svelte/mdi/alert-circle-outline';
+	import { _ } from '$lib/i18n';
+	import { IS_NON_PRODUCTION } from '$lib/const';
+</script>
+
+{#if IS_NON_PRODUCTION}
+	<div class="my-2 w-full px-2 xl:px-4">
+		<div class="alert items-start alert-warning" role="alert" aria-live="polite">
+			<IconMdiAlertCircleOutline class="mt-0.5 h-6 w-6 shrink-0" aria-hidden="true" />
+			<div>
+				<p class="font-semibold">
+					{$_('environment_notice.title', { default: 'Non-production environment' })}
+				</p>
+				<p>
+					{$_('environment_notice.message', {
+						default: 'Data and features on this site may change or be reset without notice.'
+					})}
+				</p>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,6 +16,7 @@
 	import Footer from '$lib/ui/Footer.svelte';
 	import SearchBar from '$lib/ui/SearchBar.svelte';
 	import Toast from '$lib/ui/Toast.svelte';
+	import EnvironmentNotice from '$lib/ui/EnvironmentNotice.svelte';
 	import IconMdiCog from '@iconify-svelte/mdi/cog';
 	import IconMdiHelpCircleOutline from '@iconify-svelte/mdi/help-circle-outline';
 	import IconMdiMagnify from '@iconify-svelte/mdi/magnify';
@@ -276,6 +277,8 @@
 	<progress class="progress fixed top-0 left-0 z-50 h-1 w-full rounded-none progress-secondary"
 	></progress>
 {/if}
+
+<EnvironmentNotice />
 
 <!-- Desktop Header -->
 <div class="hidden xl:block">


### PR DESCRIPTION
### Description

Adds a global warning notice for development and staging environments. The staging deployment workflow sets `PUBLIC_ENVIRONMENT=staging`, while local development is detected automatically and can also be configured through `.env`. Production remains unaffected.

Validation completed with `pnpm format`, `pnpm lint`, `pnpm check`, `pnpm test`, and `pnpm build`.

### Screenshot or video

<img width="1676" height="978" alt="immagine" src="https://github.com/user-attachments/assets/5113cc97-d684-4121-9035-239e82b47545" />

### Related issue(s) and discussion

- Fixes: #1843

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Codex (GPT-5)
  - **How it was used:** Agentic implementation, validation, branch/commit preparation, and PR creation.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prominent notice for development and staging environments.
  * Notice explains that data and features may change or be reset without notice.
  * Supports English and Italian translations and accessible alert behavior.
* **Configuration**
  * Added environment configuration to identify development and staging deployments.
  * Staging deployments now display the non-production notice automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->