### PR TITLE
fix(static-pages): show full content when the embedded page never posts its height

### DIFF
--- a/src/lib/ui/StaticPageIframe.svelte
+++ b/src/lib/ui/StaticPageIframe.svelte
@@ -5,22 +5,58 @@
 	type Props = { src: string };
 	let { src }: Props = $props();
 
+	// How long to wait for the iframe's `load` event before giving up.
 	const LOAD_TIMEOUT_MS = 8000;
+	// How long after `load` to wait for a `frameHeight` message before falling
+	// back to a viewport-sized, internally scrollable frame.
+	const HEIGHT_GRACE_MS = 1500;
+	const INITIAL_HEIGHT = '24rem';
+	// Roughly the viewport minus the navbar and some breathing room, so the
+	// fallback frame fills the screen without overshooting it.
+	const FALLBACK_HEIGHT = 'calc(100vh - 12rem)';
 
+	// The iframe is only rendered client-side: a server-rendered iframe starts
+	// loading before hydration attaches the `load` listener, so the event
+	// would be missed.
+	let mounted = $state(false);
 	let frameHeight = $state<number | null>(null);
+	let hasLoaded = $state(false);
+	let useFallback = $state(false);
 	let hasError = $state(false);
 	let iframeEl = $state<HTMLIFrameElement | null>(null);
 
 	// URL constructor throws on malformed strings; guard against SSR/runtime crashes.
 	const expectedOrigin = $derived(new URL(src).origin);
 
+	// When the embedded page tells us its exact height we size the frame to it
+	// and let the main window scroll. Otherwise (the page doesn't post a
+	// `frameHeight` — see #1842 review) we fall back to a viewport-sized frame
+	// that scrolls internally, so the content is never cut off.
+	const height = $derived(
+		frameHeight !== null ? `${frameHeight}px` : useFallback ? FALLBACK_HEIGHT : INITIAL_HEIGHT
+	);
+	const scrolling = $derived(frameHeight !== null ? 'no' : 'auto');
+
+	let graceTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	function handleLoad() {
+		hasLoaded = true;
+		hasError = false;
+		if (frameHeight !== null) return;
+		clearTimeout(graceTimeoutId);
+		graceTimeoutId = setTimeout(() => {
+			if (frameHeight === null) useFallback = true;
+		}, HEIGHT_GRACE_MS);
+	}
+
 	onMount(() => {
+		mounted = true;
 		const ac = new AbortController();
 
-		// External page never posts frameHeight on network/server failure;
-		// surface a graceful error instead of an infinite spinner.
-		const timeoutId = setTimeout(() => {
-			if (frameHeight === null) hasError = true;
+		// A frame that never fires `load` (network drop, blocked request) would
+		// otherwise sit on the initial placeholder forever.
+		const loadTimeoutId = setTimeout(() => {
+			if (!hasLoaded && frameHeight === null) hasError = true;
 		}, LOAD_TIMEOUT_MS);
 
 		const handler = (e: MessageEvent) => {
@@ -42,15 +78,18 @@
 			}
 
 			frameHeight = h;
+			useFallback = false;
 			hasError = false;
-			clearTimeout(timeoutId);
+			clearTimeout(loadTimeoutId);
+			clearTimeout(graceTimeoutId);
 		};
 
 		window.addEventListener('message', handler, { signal: ac.signal });
 
 		return () => {
 			ac.abort();
-			clearTimeout(timeoutId);
+			clearTimeout(loadTimeoutId);
+			clearTimeout(graceTimeoutId);
 		};
 	});
 </script>
@@ -63,14 +102,17 @@
 	>
 		<span class="font-medium text-red-500">{$_('static_iframe.load_failed')}</span>
 	</div>
-{:else}
-	<!-- scrolling="no" prevents the iframe's internal scrollbar -->
+{:else if mounted}
+	<!-- scrolling="no" once we know the exact height, so only the main window scrolls -->
 	<iframe
 		bind:this={iframeEl}
 		{src}
 		title="External Content"
-		scrolling="no"
+		{scrolling}
 		class="w-full border-0"
-		style:height={frameHeight !== null ? `${frameHeight}px` : '24rem'}
+		style:height
+		onload={handleLoad}
 	></iframe>
+{:else}
+	<div class="w-full" style:height={INITIAL_HEIGHT}></div>
 {/if}


### PR DESCRIPTION
### Description

Every `/static/[id]` page is currently cut off, then replaced by "Failed to load content." after 8 seconds (the "cut in the middle" issue @teolemon mentioned in #1842).

**Root cause.** `StaticPageIframe` sizes the frame from a `frameHeight` `postMessage` sent by the embedded page. `world.openfoodfacts.org/<page>?content_only=1` never sends one — I fetched the page and every script it loads (`display.js`, `foundation.js`, the webcomponents bundle, …) and none of them reference `frameHeight`/`postMessage`; `site_layout.tt.html` only uses `content_only` to hide chrome. So the frame stays at the 24rem placeholder (content cut) until the 8s timeout flips it into the error state.

**Fix.**
- Track the iframe's own `load` event. Only a frame that never loads within 8s is treated as an error.
- If no `frameHeight` arrives within 1.5s of `load`, fall back to a viewport-sized frame (`calc(100vh - 12rem)`) that scrolls internally, so the entire page stays reachable. If the embedded page ever does post a height, it still wins and the frame goes back to `scrolling="no"` at the exact height (the `postMessage` validation is unchanged).
- Render the iframe client-side only: a server-rendered iframe starts loading before hydration attaches the `load` listener, so the event was being missed (this bit me while verifying).

The proper long-term fix is for the server's `content_only` layout to post its height (and re-post on resize); this PR makes the explorer robust either way.

### Screenshot or video

Before (`main`, e.g. the Vercel preview of any static page): content cut at 24rem, then "Failed to load content." after 8s.

After (this branch, `/static/nova` on a local dev server, 15s after load — no error, frame fills the viewport with its own scrollbar, whole page reachable):

![static page rendered with the fallback height](https://raw.githubusercontent.com/AchrafReyani/openfoodfacts-explorer/pr-1842-assets/static-nova-fallback.png)

### Related issue(s) and discussion

- Related: #1842 (review comment), #1268 (previous iframe rework)

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

Verification: `pnpm lint` (prettier + eslint) clean, `svelte-check` 0 errors / 0 warnings, `vitest` 53/53, `vite build` OK. In Chrome on the dev server: `/static/nova` inspected via DevTools 15s after load → no error element, iframe present with `scrolling="auto"` and `height: calc(100vh - 12rem)`; scrolled inside the frame to the last paragraph.

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Claude Code (Claude Fable 5)
  - **How it was used:** agentic — root-cause investigation, implementation and browser verification were done by the agent in a session I supervised; I reviewed the change.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**