### PR TITLE
fix: tint knowledge panel icons from their evaluation

### DIFF
--- a/src/lib/knowledgepanels/Panel.svelte
+++ b/src/lib/knowledgepanels/Panel.svelte
@@ -51,16 +51,31 @@
 			]}
 		>
 			{#if title.icon_url != null}
-				<img
-					class={[
-						'kp-icon mr-4 ml-2 h-12 w-12 object-contain',
-						title.icon_size && `kp-icon-${title.icon_size}`,
-						title.icon_color_from_evaluation && 'kp-icon-from-eval',
-						title.icon_url.includes(MONOCHROME_ICON_PATH) && 'kp-icon-monochrome'
-					]}
-					src={title.icon_url}
-					alt={title.title}
-				/>
+				{#if title.icon_color_from_evaluation}
+					<!-- CSS `color` has no effect on an <img>'s pixels, so icons that must be
+					     tinted from the panel's evaluation are painted with currentColor
+					     through a mask instead -->
+					<span
+						class={[
+							'kp-icon kp-icon-from-eval mr-4 ml-2 h-12 w-12',
+							title.icon_size && `kp-icon-${title.icon_size}`
+						]}
+						style:mask-image="url('{title.icon_url}')"
+						style:-webkit-mask-image="url('{title.icon_url}')"
+						role="img"
+						aria-label={title.title}
+					></span>
+				{:else}
+					<img
+						class={[
+							'kp-icon mr-4 ml-2 h-12 w-12 object-contain',
+							title.icon_size && `kp-icon-${title.icon_size}`,
+							title.icon_url.includes(MONOCHROME_ICON_PATH) && 'kp-icon-monochrome'
+						]}
+						src={title.icon_url}
+						alt={title.title}
+					/>
+				{/if}
 			{/if}
 			<div class="grow">
 				<div class="kp-title">{title.title}</div>
@@ -110,11 +125,25 @@
 
 	@media (prefers-color-scheme: dark) {
 		/* Flip black knowledge panel icons to white so they stay readable on a dark
-		   background. Only monochrome icons are inverted: see MONOCHROME_ICON_PATH. */
-		.kp-icon-monochrome,
-		.kp-icon-from-eval {
+		   background. Only monochrome icons are inverted: see MONOCHROME_ICON_PATH.
+		   kp-icon-from-eval icons are not inverted: they are painted with
+		   currentColor, which is already theme-aware. */
+		.kp-icon-monochrome {
 			@apply invert;
 		}
+	}
+
+	/* Icons with icon_color_from_evaluation are rendered as a mask painted with
+	   currentColor, so the kp-panel-eval-* color below actually tints them
+	   (and they stay readable in dark mode when the panel has no evaluation). */
+	.kp-icon-from-eval {
+		@apply bg-current;
+		mask-size: contain;
+		mask-repeat: no-repeat;
+		mask-position: center;
+		-webkit-mask-size: contain;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: center;
 	}
 
 	/*.kp-icon-small {


### PR DESCRIPTION
### Description

The knowledge panel API marks some title icons with `icon_color_from_evaluation: true`, meaning the client should color the (colorless) icon from the panel's evaluation ([upstream discussion](https://github.com/openfoodfacts/openfoodfacts-server/issues/14078)). `Panel.svelte` has `kp-panel-eval-*` rules applying `text-green-500` / `text-yellow-500` / `text-gray-500` / `text-red-500` to `.kp-icon-from-eval` — but they never had any visible effect, because the icon is an `<img>` and CSS `color` cannot recolor an image's pixels. So e.g. the carbon footprint panel (evaluation `good`) showed a green border with a plain **black** icon in light mode, and a plain **white** icon in dark mode (flipped by the #1788 invert).

This PR renders `icon_color_from_evaluation` icons as a `mask-image` painted with `currentColor`, so the existing evaluation color rules actually tint them, in both light and dark mode:

- `good` → green, `average` → yellow, `unknown` → gray, `bad` → red (unchanged rules, now effective);
- panels without an evaluation (or with `neutral`, which has no color rule) fall back to the inherited text color, which is already theme-aware — so these icons no longer need the dark-mode `invert` and are removed from that rule;
- the `<span>` keeps the icon accessible via `role="img"` + `aria-label` (same text the `<img>` had as `alt`).

The black-on-black *info buttons* originally reported in #1694 were fixed by #1788; this addresses the remaining part of that issue (badly tinted icons — evaluation tinting silently not working).

### Screenshot or video

Carbon footprint panel of [product 4056489613695](http://localhost:5173/products/4056489613695), evaluation `good`:

| | before | after |
|---|---|---|
| light | ![before light](https://raw.githubusercontent.com/AchrafReyani/openfoodfacts-explorer/assets/kp-icon-eval-tint/before-light.png) | ![after light](https://raw.githubusercontent.com/AchrafReyani/openfoodfacts-explorer/assets/kp-icon-eval-tint/after-light.png) |
| dark | ![before dark](https://raw.githubusercontent.com/AchrafReyani/openfoodfacts-explorer/assets/kp-icon-eval-tint/before-dark.png) | ![after dark](https://raw.githubusercontent.com/AchrafReyani/openfoodfacts-explorer/assets/kp-icon-eval-tint/after-dark.png) |

### Related issue(s) and discussion

- Fixes: #1694

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

<!-- Open-Source is a community and human process. Let's keep it that way, so that it is enjoyable for contributors AND reviewers :-) -->

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Claude Code (Claude Fable 5.1)
  - **How it was used:** agentic — the agent investigated the issue, wrote the change and the PR description, and verified it by running the dev server locally and checking the panel in Chrome (the before/after screenshots above)
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Evaluation-colored icons now use theme-aware colors and render correctly in light and dark modes.
  * Monochrome image icons retain dark-mode inversion behavior.
  * Other icon types continue displaying as images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
