### PR TITLE
feat: optimize product image loading

### DIFF
--- a/src/lib/i18n/messages/en-US.json
+++ b/src/lib/i18n/messages/en-US.json
@@ -257,6 +257,7 @@
 	"product": {
 		"title": "{productName} - Open Food Facts Explorer",
 		"description": "Product page for {productName} on Open Food Facts Explorer",
+		"image_alt": "Image",
 		"card": {
 			"aria_label": "Go to product {productName} with code {productCode}",
 			"aria_label_no_name": "Go to product with code {productCode}"

--- a/src/lib/knowledgepanels/PanelGroup.svelte
+++ b/src/lib/knowledgepanels/PanelGroup.svelte
@@ -15,6 +15,12 @@
 	} = $props();
 
 	let groupEl = $derived(element.panel_group_element);
+	let previewImageUrl = $derived(
+		groupEl.image?.sizes['400']?.url ??
+			groupEl.image?.sizes['200']?.url ??
+			groupEl.image?.sizes['100']?.url ??
+			groupEl.image?.sizes['full']?.url
+	);
 </script>
 
 <h3 class="my-3 text-lg font-bold sm:text-xl">{groupEl.title}</h3>
@@ -26,11 +32,11 @@
 		{/each}
 	</div>
 
-	{#if groupEl.image != null}
+	{#if groupEl.image != null && previewImageUrl != null}
 		{@const parsedImageId = Number(groupEl.image.id)}
 		<div class="md:max-w-64">
 			<ImageButton
-				src={groupEl.image.sizes['full'].url}
+				src={previewImageUrl}
 				alt={groupEl.image.alt}
 				rawImageId={Number.isFinite(parsedImageId) ? parsedImageId : undefined}
 				productCode={code}

--- a/src/lib/ui/ImageButton.svelte
+++ b/src/lib/ui/ImageButton.svelte
@@ -24,7 +24,7 @@
 		if (src == null) {
 			return undefined;
 		}
-		return () => modal.displayImage(getFullSizeImageUrl(src), alt, imageId, productCode);
+		return () => modal.displayImage(getFullSizeImageUrl(src), alt, imageId, productCode, src);
 	});
 </script>
 

--- a/src/lib/ui/ImageManagerCard.svelte
+++ b/src/lib/ui/ImageManagerCard.svelte
@@ -45,7 +45,7 @@
 			default: 'Uploaded on {date}',
 			values: { date: formatDate(img.uploaded_t) }
 		});
-		modal.displayImage(fullUrl, `${uploaderText} ${dateText}`, img.imgid, product.code);
+		modal.displayImage(fullUrl, `${uploaderText} ${dateText}`, img.imgid, product.code, img.url);
 	}
 
 	// Extract numeric raw images from product.images

--- a/src/lib/ui/ImageModal.svelte
+++ b/src/lib/ui/ImageModal.svelte
@@ -108,7 +108,7 @@
 					>
 						<ResizableImage
 							src={image.url}
-							alt={image.alt ?? 'Image'}
+							alt={image.alt ?? $_('product.image_alt', { default: 'Image' })}
 							bind:zoom={zoomLevel}
 							bind:rotation
 							bind:translation

--- a/src/lib/ui/ImageModal.svelte
+++ b/src/lib/ui/ImageModal.svelte
@@ -13,8 +13,15 @@
 	import IconMdiFlagOutline from '@iconify-svelte/mdi/flag-outline';
 	import IconMdiPencilOutline from '@iconify-svelte/mdi/pencil-outline';
 
-	type ImageState = { url: string; alt?: string; imageid?: number; productCode?: string };
+	type ImageState = {
+		url: string;
+		previewUrl?: string;
+		alt?: string;
+		imageid?: number;
+		productCode?: string;
+	};
 	let image: ImageState | undefined = $state();
+	let isImageLoading = $state(false);
 
 	let dialog: HTMLDialogElement | undefined = $state();
 	let zoomLevel = $state(1);
@@ -23,8 +30,15 @@
 
 	let rotation = $state(0);
 
-	export function displayImage(url: string, alt?: string, imageid?: number, productCode?: string) {
-		image = { url, alt, imageid, productCode };
+	export function displayImage(
+		url: string,
+		alt?: string,
+		imageid?: number,
+		productCode?: string,
+		previewUrl?: string
+	) {
+		image = { url, previewUrl, alt, imageid, productCode };
+		isImageLoading = true;
 
 		zoomLevel = 1;
 		dialog?.showModal();
@@ -76,14 +90,34 @@
 	<div class="relative flex h-full w-full flex-col">
 		<div class="h-full w-full p-5">
 			{#if image}
-				<ResizableImage
-					src={image.url}
-					alt={image.alt ?? 'Image'}
-					bind:zoom={zoomLevel}
-					bind:rotation
-					bind:translation
-					maxzoom={10}
-				/>
+				<div class="relative h-full w-full overflow-hidden">
+					{#if isImageLoading}
+						<img
+							src={image.previewUrl ?? image.url}
+							alt=""
+							class="absolute inset-0 h-full w-full scale-105 object-contain opacity-60 blur-lg"
+							aria-hidden="true"
+						/>
+						<div class="absolute inset-0 z-10 flex items-center justify-center" aria-hidden="true">
+							<span class="loading loading-lg loading-spinner text-primary"></span>
+						</div>
+					{/if}
+					<div
+						class="h-full w-full transition-opacity duration-200"
+						class:opacity-0={isImageLoading}
+					>
+						<ResizableImage
+							src={image.url}
+							alt={image.alt ?? 'Image'}
+							bind:zoom={zoomLevel}
+							bind:rotation
+							bind:translation
+							maxzoom={10}
+							onload={() => (isImageLoading = false)}
+							onerror={() => (isImageLoading = false)}
+						/>
+					</div>
+				</div>
 			{/if}
 		</div>
 		<div class="absolute right-2 z-10 flex h-full flex-col items-center justify-center gap-2">

--- a/src/lib/ui/ResizableImage.svelte
+++ b/src/lib/ui/ResizableImage.svelte
@@ -9,6 +9,8 @@
 		rotation?: number;
 		minzoom?: number;
 		maxzoom?: number;
+		onload?: (event: Event) => void;
+		onerror?: (event: Event) => void;
 	};
 	let {
 		src,
@@ -17,7 +19,9 @@
 		rotation = $bindable(0),
 		translation = $bindable({ x: 0, y: 0 }),
 		minzoom = 1,
-		maxzoom = 3
+		maxzoom = 3,
+		onload,
+		onerror
 	}: Props = $props();
 
 	let containerEl: HTMLElement | undefined;
@@ -104,5 +108,12 @@
 	class:cursor-grabbing={isDragging}
 	bind:this={containerEl}
 >
-	<img class="pointer-events-none block h-full w-full object-contain" {src} {alt} {style} />
+	<img
+		class="pointer-events-none block h-full w-full object-contain"
+		{src}
+		{alt}
+		{style}
+		{onload}
+		{onerror}
+	/>
 </div>

--- a/src/routes/products/[barcode]/ProductHeader.svelte
+++ b/src/routes/products/[barcode]/ProductHeader.svelte
@@ -80,7 +80,8 @@
 	}
 
 	let frontImage = $derived(
-		'image_front_url' in product ? (product.image_front_url as string) : undefined
+		product.image_front_small_url ??
+			('image_front_url' in product ? (product.image_front_url as string) : undefined)
 	);
 
 	let productWebsiteUrl = $derived(PRODUCT_WEBSITE_URL(product.code!, product.product_type));


### PR DESCRIPTION
### Description

Loads smaller product image renditions on the product page to reduce initial image bandwidth. The main product image prefers the small variant, while knowledge-panel product photos prefer the 400px rendition with progressively smaller and full-size fallbacks.

The image modal continues to load the full-resolution image when opened. While it loads, the already-available preview is displayed blurred beneath a centered spinner, then the full image fades in. Loading state is also cleared on errors.

### Screenshot or video

Not included. The visual change is limited to the transient loading state, which depends on network speed.

### Related issue(s) and discussion

- No related issue.

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable). No documentation changes are required.

Validation completed:
- pnpm format
- pnpm lint
- pnpm check
- pnpm test (76 tests passed)
- pnpm build

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** OpenAI Codex (GPT-5)
  - **How it was used:** Agentic implementation, code review, validation, Git operations, and PR preparation.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blurred image previews and a loading indicator while full-size images load.
  * Image previews now use the best available smaller image before loading the original.
* **Bug Fixes**
  * Improved product and panel image selection by prioritizing available preview sizes.
  * Prevented image sections from appearing when no usable preview image is available.
  * Added image load and error handling for more reliable preview behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->