### PR TITLE
fix(dark-mode): keep external-source knowledge-panel text readable

### DIFF
--- a/src/lib/knowledgepanels/TextElement.svelte
+++ b/src/lib/knowledgepanels/TextElement.svelte
@@ -18,7 +18,7 @@
 	{/if}
 </div>
 
-<div class="prose w-full max-w-full dark:text-white">
+<div class="kp-html-content prose w-full max-w-full dark:text-white">
 	<HtmlPurify dirty={html} />
 </div>
 
@@ -29,6 +29,20 @@
 {/if}
 
 <style>
+	:global(.kp-html-content img) {
+		margin: 0;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		:global(.kp-html-content *:not(.allergen):not(.text_info)) {
+			color: inherit !important;
+		}
+
+		:global(.kp-html-content img) {
+			filter: brightness(0) invert(1);
+		}
+	}
+
 	:global(.allergen) {
 		background-color: #f8d7da;
 		border-color: #f5c6cb;

--- a/src/lib/knowledgepanels/TextElement.svelte
+++ b/src/lib/knowledgepanels/TextElement.svelte
@@ -39,7 +39,8 @@
 		}
 
 		:global(.kp-html-content img) {
-			filter: brightness(0) invert(1);
+			background-color: #fff;
+			border-radius: 0.25rem;
 		}
 	}
 


### PR DESCRIPTION
### Description

Knowledge-panel providers can send raw HTML with inline text colors and monochrome icons tuned for a light page. Since an inline style always beats this component's `dark:text-white` class, that content stayed unreadable in dark mode.

Fix scoped to `TextElement.svelte`, the shared renderer for `text`-type knowledge-panel elements (used by external sources like the "Empreinte Souffrance" panel, as well as OFF's own text panels):
- Force injected HTML to inherit the theme's text color in dark mode (needs `!important`, since inline styles win over ancestor classes), explicitly excluding OFF's own `.allergen`/`.text_info` highlight classes so ingredient highlighting is untouched.
- Invert monochrome provider icons/logos so they're visible against the dark background.
- Reset the unwanted margin `.prose` adds to injected `<img>` tags by default, which was misaligning icons against their adjacent text.

### Screenshot or video

**Before:**
<img width="500" height="413" alt="image" src="https://github.com/user-attachments/assets/88e826c8-4d88-43da-8610-f49c30f0d4dc" />

**After:**
<img width="500" height="413" alt="image" src="https://github.com/user-attachments/assets/4f8bcfe1-e861-4496-9df3-b56e63015ccb" />

### Related issue(s) and discussion

- Fixes: #1869

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [x] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] I did **not** use an LLM or AI tool to write this PR.
- [x] I used an LLM / AI agent — details below:
  - **Agent / tool name and version:** Claude Code 
  - **How it was used:** agentic — investigated the root cause (including fetching the real external provider's API response to confirm the actual HTML/CSS causing the bug), implemented the fix, and verified it by rendering the real provider data through the component before/after.
  - **I have reviewed and take full responsibility for all AI-generated code in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved knowledge-panel text formatting by removing extra spacing around images.
  * Enhanced dark-mode readability for embedded content, including adjusted text colors and image contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->