### PR TITLE
fix(dark-mode): harden Table/Action panel renderers for third-party HTML

### DIFF
--- a/src/lib/knowledgepanels/Action.svelte
+++ b/src/lib/knowledgepanels/Action.svelte
@@ -111,7 +111,7 @@
 	class={[element.action_element.html != '' && 'rounded border-s border-accent bg-accent/10 p-4']}
 >
 	{#if element.action_element.html != ''}
-		<div class="mb-4 text-sm">
+		<div class="kp-html-content mb-4 text-sm">
 			<HtmlPurify dirty={element.action_element.html} />
 		</div>
 	{/if}
@@ -127,3 +127,19 @@
 		</div>
 	{/if}
 </div>
+
+<style>
+	:global(.kp-html-content img) {
+		margin: 0;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		:global(.kp-html-content *:not(.allergen):not(.text_info)) {
+			color: inherit !important;
+		}
+
+		:global(.kp-html-content img) {
+			filter: brightness(0) invert(1);
+		}
+	}
+</style>

--- a/src/lib/knowledgepanels/Action.svelte
+++ b/src/lib/knowledgepanels/Action.svelte
@@ -139,7 +139,8 @@
 		}
 
 		:global(.kp-html-content img) {
-			filter: brightness(0) invert(1);
+			background-color: #fff;
+			border-radius: 0.25rem;
 		}
 	}
 </style>

--- a/src/lib/knowledgepanels/Table.svelte
+++ b/src/lib/knowledgepanels/Table.svelte
@@ -51,7 +51,8 @@
 		}
 
 		:global(.kp-html-content img) {
-			filter: brightness(0) invert(1);
+			background-color: #fff;
+			border-radius: 0.25rem;
 		}
 	}
 </style>

--- a/src/lib/knowledgepanels/Table.svelte
+++ b/src/lib/knowledgepanels/Table.svelte
@@ -29,7 +29,7 @@
 									aria-hidden="true"
 								/>
 							{/if}
-							<div class="kp-html-content inline">
+							<div class="kp-html-content inline-block align-middle">
 								<HtmlPurify dirty={cell.text} />
 							</div>
 						</td>

--- a/src/lib/knowledgepanels/Table.svelte
+++ b/src/lib/knowledgepanels/Table.svelte
@@ -12,7 +12,7 @@
 		<thead>
 			<tr>
 				{#each element.table_element.columns as column, columnIndex (columnIndex)}
-					<th><HtmlPurify dirty={column.text} /></th>
+					<th><div class="kp-html-content"><HtmlPurify dirty={column.text} /></div></th>
 				{/each}
 			</tr>
 		</thead>
@@ -29,7 +29,9 @@
 									aria-hidden="true"
 								/>
 							{/if}
-							<HtmlPurify dirty={cell.text} />
+							<div class="kp-html-content inline">
+								<HtmlPurify dirty={cell.text} />
+							</div>
 						</td>
 					{/each}
 				</tr>
@@ -37,3 +39,19 @@
 		</tbody>
 	</table>
 </div>
+
+<style>
+	:global(.kp-html-content img) {
+		margin: 0;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		:global(.kp-html-content *:not(.allergen):not(.text_info)) {
+			color: inherit !important;
+		}
+
+		:global(.kp-html-content img) {
+			filter: brightness(0) invert(1);
+		}
+	}
+</style>


### PR DESCRIPTION
### Description

`Table.svelte` and `Action.svelte` render provider HTML the same way `TextElement.svelte` does, but had none of the dark-mode protection added for it in #1869. Applies the same treatment so a future table/action-type external source doesn't hit the same bug:
- Force injected text to inherit the theme's color in dark mode (needs `!important`, since inline styles win over ancestor classes), excluding OFF's own `.allergen`/`.text_info` highlight classes.
- Invert monochrome images shipped by providers, same as `TextElement.svelte`.
- Reset the unwanted margin `.prose`/other defaults add to injected `<img>` tags.

No live provider currently sends `table`/`action` panels (the only external source configured today only sends `text` panels, fixed in #1869), so this is preventive hardening rather than a fix for an observed bug.

### Screenshot or video

**Before:**
<img width="500" height="362" alt="image" src="https://github.com/user-attachments/assets/c7d56928-f7f1-4c63-9dd5-a2e82fb8c2da" />

**After:**
<img width="500" height="362" alt="image" src="https://github.com/user-attachments/assets/0314836e-7b91-417e-80e0-ec589a636257" />

### Related issue(s) and discussion

- Fixes: #1871

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved formatting for HTML content in knowledge panel actions and tables.
  * Images no longer display unwanted spacing and now use rounded corners with a white background in dark mode.
  * Updated dark-mode text styling to improve readability while preserving specialized content colors.
  * Improved vertical alignment and wrapping for HTML content within table cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->